### PR TITLE
Mods for compiling with latest GENE on draco and cobra

### DIFF
--- a/SHARE/make_cobra.inc
+++ b/SHARE/make_cobra.inc
@@ -15,8 +15,9 @@
 #            Define Compiler Flags
 #######################################################################
   FLAGS_R = -I$(MKL_HOME)/include -O2 -fp-model strict -ip \
-            -assume noold_unit_star 
-  FLAGS_D = -g -I$(MKL_HOME)/include
+            -assume noold_unit_star
+  FLAGS_D = -I$(MKL_HOME)/include -O2 -fp-model strict -ip \
+            -assume noold_unit_star -g -traceback
   LIBS    = -Wl,-rpath,$(MKL_HOME)/lib/intel64 \
             -L$(MKL_HOME)/lib/intel64 -lmkl_scalapack_lp64 \
             -lmkl_intel_lp64 -lmkl_core -lmkl_sequential \
@@ -31,10 +32,10 @@
   MPI_COMPILE_C = mpiifort
   MPI_LINK = mpiifort
   MPI_RUN  = srun
-  MPI_RUN_OPTS = --nodes=1 --ntasks-per-node=40 --time=0:30:00
-  MPI_RUN_SM   = --nodes=1 --ntasks-per-node=40 --time=0:30:00
-  MPI_RUN_MD   = --nodes=1 --ntasks-per-node=40 --time=0:30:00
-  MPI_RUN_LG   = --nodes=8 --ntasks-per-node=40 --time=2:00:00
+  MPI_RUN_OPTS = --nodes=1 --ntasks-per-node=40 --time=0:30:00 -p express
+  MPI_RUN_OPTS_SM   = --nodes=1 --ntasks-per-node=40 --time=0:30:00 -p express
+  MPI_RUN_OPTS_MD   = --nodes=8 --ntasks-per-node=40 --time=0:30:00 -p express
+  MPI_RUN_OPTS_LG   = --nodes=32 --ntasks-per-node=40 --time=0:30:00 -p express
 
 #######################################################################
 #            NAG Options
@@ -90,18 +91,18 @@
 #######################################################################
 #            GENE Options
 #######################################################################
-  LGENE = F
-  GENE_INC = -I$(GENE_PATH)
-  GENE_DIR = $(GENE_PATH)
+  LGENE = T
+  GENE_DIR = $(GENE_PATH)/bin/obj_cobra
+  FUTILS_DIR = $(GENE_PATH)/external/cobra/futils-gene-mod/src
   LIB_GENE = libgene.a
+  LIB_FUTILS = libfutils.a
+  GENE_INC = -I$(GENE_DIR) \
+             -I$(FUTILS_DIR)
   GENE_LIB = -L$(FFTW_HOME)/lib -lfftw3 -lfftw3f -Xlinker \
-             -rpath=$(FFTW_HOME)/lib \
-             -Wl,-rpath,$(SLEPC_HOME)/intel14.0-mpi.ibm1308-double-cplx/lib \
-             -L$(SLEPC_HOME)/intel14.0-mpi.ibm1308-double-cplx/lib -lslepc \
-             -Wl,-rpath,$(PETSC_HOME)/lib -L$(PETSC_HOME)/lib -lpetsc \
-             -Wl,-rpath,$(MKL_HOME)/lib/intel64 -L$(MKL_HOME)/lib/intel64 \
-             -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_core \
-             -lmkl_sequential -lmkl_blacs_intelmpi_lp64 -lpthread -lm 
+             -L$(SLEPC_HOME)/lib -lslepc \
+             -L$(PETSC_HOME)/lib -lpetsc \
+             $(GENE_DIR)/$(LIB_GENE) \
+             $(FUTILS_DIR)/$(LIB_FUTILS)
 
 #######################################################################
 #            COILOPT++ Options
@@ -289,7 +290,7 @@ endif
 ifeq ($(LGENE),T)
   MOD1_PATH += $(GENE_INC)
   PRECOMP += -DGENE
-  MOD_PATH += -I$(GENE_DIR)
+  MOD_PATH += -I$(GENE_DIR) -I$(FUTILS_DIR)
 else
   GENE_LIB = 
   GENE_DIR = 

--- a/SHARE/make_draco.inc
+++ b/SHARE/make_draco.inc
@@ -90,18 +90,17 @@
 #            GENE Options
 #######################################################################
   LGENE = F
-  GENE_INC = -I$(GENE_PATH)
-  GENE_DIR = $(GENE_PATH)
+  GENE_DIR = $(GENE_PATH)/bin/obj_draco
+  FUTILS_DIR = $(GENE_PATH)/external/draco/futils-gene-mod/src
   LIB_GENE = libgene.a
+  LIB_FUTILS = libfutils.a
+  GENE_INC = -I$(GENE_DIR) \
+             -I$(FUTILS_DIR)
   GENE_LIB = -L$(FFTW_HOME)/lib -lfftw3 -lfftw3f -Xlinker \
-             -rpath=$(FFTW_HOME)/lib \
-             -Wl,-rpath,$(SLEPC_HOME)/intel14.0-mpi.ibm1308-double-cplx/lib \
-             -L$(SLEPC_HOME)/intel14.0-mpi.ibm1308-double-cplx/lib -lslepc \
-             -Wl,-rpath,$(PETSC_HOME)/lib -L$(PETSC_HOME)/lib -lpetsc \
-             -Wl,-rpath,$(MKL_HOME)/lib/intel64 -L$(MKL_HOME)/lib/intel64 \
-             -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_core \
-             -lmkl_sequential -lmkl_blacs_intelmpi_lp64 -lpthread -lm 
-
+             -L$(SLEPC_HOME)/lib -lslepc \
+             -L$(PETSC_HOME)/lib -lpetsc \
+             $(GENE_DIR)/$(LIB_GENE) \
+             $(FUTILS_DIR)/$(LIB_FUTILS)
 #######################################################################
 #            COILOPT++ Options
 #######################################################################
@@ -288,7 +287,7 @@ endif
 ifeq ($(LGENE),T)
   MOD1_PATH += $(GENE_INC)
   PRECOMP += -DGENE
-  MOD_PATH += -I$(GENE_DIR)
+  MOD_PATH += -I$(GENE_DIR) -I$(FUTILS_DIR)
 else
   GENE_LIB = 
   GENE_DIR = 

--- a/STELLOPTV2/Sources/General/stellopt_paraexe.f90
+++ b/STELLOPTV2/Sources/General/stellopt_paraexe.f90
@@ -42,7 +42,8 @@
       USE par_in, ONLY: diagdir,file_extension, beta_gene => beta
       USE par_other, ONLY: print_ini_msg
       USE parameters_IO, ONLY: read_parameters, write_parameters, PAR_OUT_FILE, &
-                               PARFILE, bcast_parameters
+                               PARFILE
+      USE stellopt_interface, ONLY: bcast_parameters
       USE geometry, ONLY: geomdir, magn_geometry, geomfile
       USE file_io, ONLY: erase_stop_file
       USE discretization, ONLY: mype_gl, n_procs_sim, n_procs_s, n_procs_w, &


### PR DESCRIPTION
This is a quick patch to allow the latest version of GENE (pulled from git) to link to STELLOPT on the Draco and Cobra clusters.  There was one change to which module a subroutine was located in and also some minor mods to the makefiles for compiling with FUTILS (included in GENE).