### PR TITLE
Updates for SFINCS

### DIFF
--- a/STELLOPTV2/Debug/STELLOPTV2.dep
+++ b/STELLOPTV2/Debug/STELLOPTV2.dep
@@ -464,6 +464,7 @@ stellopt_sfincs.o : \
       $(BOOTSJ_DIR)/Debug/parambs.o \
       $(BOOTSJ_DIR)/Debug/vmec0.o \
       $(BOOTSJ_DIR)/Debug/trig.o \
+      $(LIB_DIR)/Debug/mpi_params.o
       $(LIB_DIR)/Debug/read_boozer_mod.o
       
 

--- a/STELLOPTV2/Release/STELLOPTV2.dep
+++ b/STELLOPTV2/Release/STELLOPTV2.dep
@@ -488,6 +488,7 @@ stellopt_sfincs.o : \
       $(BOOTSJ_DIR)/Release/parambs.o \
       $(BOOTSJ_DIR)/Release/vmec0.o \
       $(BOOTSJ_DIR)/Release/trig.o \
+      $(LIB_DIR)/Release/mpi_params.o \
       $(LIB_DIR)/Release/read_boozer_mod.o
       
 

--- a/STELLOPTV2/Sources/General/stellopt_sfincs.f90
+++ b/STELLOPTV2/Sources/General/stellopt_sfincs.f90
@@ -15,6 +15,8 @@
       USE stellopt_input_mod
       USE stellopt_vars
       USE equil_utils
+      USE mpi_params
+      USE mpi_inc
 
       USE sfincs_main, only: sfincs_init, sfincs_prepare, sfincs_run
       USE globalVariables, only: sfincs_inputFilename => inputFilename, sfincs_outputFilename => outputFilename, equilibriumFile, FSABjHat, FSABHat2
@@ -57,7 +59,7 @@
       character(len=buffer_length) :: proc_assignments_string, base_directory_string, directory_string, file_line, file_line_lower, file_line_lower2
       character(len=buffer_length) :: working_directory
       integer :: tag, file_status, unit_in, unit_out
-      integer :: mpi_status(MPI_STATUS_SIZE)
+      integer :: my_mpi_status(MPI_STATUS_SIZE)
       LOGICAL :: lfile_check
       LOGICAL :: added_scanType
       REAL(rprec) :: sfincs_ne, sfincs_ni, sfincs_Te, sfincs_Ti, sfincs_d_ne_d_s, sfincs_d_ni_d_s, sfincs_d_Te_d_s, sfincs_d_Ti_d_s, delta_s
@@ -130,7 +132,7 @@
                IF (lscreen) WRITE(*,"(a)") TRIM(proc_assignments_string)
                DO i = 1,numProcs_myWorld - 1
                   tag = i
-                  CALL MPI_RECV(proc_assignments_string,buffer_length,MPI_CHAR,i,tag,MPI_COMM_MYWORLD,mpi_status,ierr_mpi)
+                  CALL MPI_RECV(proc_assignments_string,buffer_length,MPI_CHAR,i,tag,MPI_COMM_MYWORLD,my_mpi_status,ierr_mpi)
                   IF (lscreen) WRITE(*,"(a)") TRIM(proc_assignments_string)
                END DO
             ELSE


### PR DESCRIPTION
Minor 'fix' to make SFINCS work again.
Added mpi_params.o to the .dep files in stelloptv2.

Renamed a variable from mpi_status to my_mpi_status in stellopt_sfincs.

I tried to see if this name change had any larger consequences, but I think someone else (Sam and/or Matt) might be able to confirm this.