### PR TITLE
Enhance buil_all script and revise a lot of dependence for parallel build

### DIFF
--- a/FIELDLINES/FIELDLINES.dep
+++ b/FIELDLINES/FIELDLINES.dep
@@ -43,10 +43,10 @@ fieldlines_init.o: \
       fieldlines_lines.o
       
 
-fmag_nag.o: \
+fmag_nag.o : \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
-      fieldlines_runtime.o \
-      fieldlines_grid.o 
+      fieldlines_grid.o \
+      fieldlines_runtime.o
       
 
 fieldlines_find_axis.o: \
@@ -107,8 +107,9 @@ fieldlines_lines.o: \
 
 fblin_nag.o: \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
-      fieldlines_grid.o \
-      fieldlines_runtime.o
+      fieldlines_runtime.o \
+      fieldlines_grid.o
+
       
 
 fblin_tanmap_nag.o: \
@@ -248,4 +249,5 @@ fieldlines_init_nescoil.o: \
       fieldlines_runtime.o \
       fieldlines_grid.o
       
-      
+normal_vector.o : \
+      fieldlines_runtime.o             

--- a/J_INVARIANT/J_INVARIANT.dep
+++ b/J_INVARIANT/J_INVARIANT.dep
@@ -13,9 +13,9 @@ j_inv_calc.o: \
       ../../LIBSTELL/$(LOCTYPE)/read_boozer_mod.o
    
   
-j_invariant.o: \
+J_invariant.o: \
       B_and_J_Library.o \
-      ../../LIBSTELL/$(LOCTYPE)/data_and_computer.o \
+      ../../LIBSTELL/$(LOCTYPE)/date_and_computer.o \
       ../../LIBSTELL/$(LOCTYPE)/safe_open_mod.o \
       ../../LIBSTELL/$(LOCTYPE)/read_boozer_mod.o
       
@@ -29,6 +29,7 @@ rhs.o: \
       
 
 sfmin.o: \
+      B_and_J_Library.o \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o
       
       

--- a/LIBSTELL/LIBSTELL.dep
+++ b/LIBSTELL/LIBSTELL.dep
@@ -541,6 +541,7 @@ eval_x_queued.o : \
 
 
 MAP_HYPERS.o : \
+      mpi_inc.o \
       safe_open_mod.o \
       stel_kinds.o
       
@@ -930,7 +931,8 @@ extcurz_T.o : \
 ipch_T.o : \
       stel_constants.o \
       stel_kinds.o \
-      safe_open_mod.o 
+      safe_open_mod.o \
+      integration_path.o 
       
 
 fftpack.o : \
@@ -1323,10 +1325,40 @@ coordinate_utilities.o : \
 
 suzuki_sigma.o : 
 
+stel_tools.o : \
+      ezspline.o \
+      ezspline_obj.o
 
+mir_tools.o : \
+      read_wout_mod.o \
+      ezspline_obj.o      
 
-      
+getcarg.o : \
+      mpi_inc.o
 
+vmec_chdir.o : \
+      mpi_inc.o
 
+thscte_T.o : \
+      stel_constants.o
 
+spline_cubic.o : \
+      mpi_inc.o
 
+second0.o : \
+      mpi_inc.o
+
+ezspline_cdfget3.o : \
+      ezcdf.o
+
+ezspline_cdfput3.o : \
+      ezcdf.o
+
+ezspline_cinterp.o : \
+      ezspline_obj.o
+
+gmres.o : \
+      mpi_inc.o
+
+compression.o : \
+      ezcdf.o

--- a/SHARE/make_osx_brew.inc
+++ b/SHARE/make_osx_brew.inc
@@ -27,16 +27,17 @@
   SCALAPACK_HOME ?= /usr/local/opt/scalapack
   FFTW_HOME ?= /usr/local/opt/fftw
   HDF5_HOME ?= /usr/local/opt/hdf5
-  NETCDF5_HOME ?= /usr/local/opt/netcdf
+  NETCDF_HOME ?= /usr/local/opt/netcdf
+  # netcdf needs manually installed netcdf-frotran; still have some issue
   
 
 #######################################################################
 #            Define Compiler Flags
 #######################################################################
-  FLAGS_R = -O2 -g -fexternal-blas -fbacktrace -fcheck=all 
-  FLAGS_D = -O0 -g -fexternal-blas -fcheck=all -fbacktrace -Wextra \
-   -Wtarget-lifetime -fbounds-check -ffpe-trap=zero -finit-real=snan
-  LIBS    = -lopenblas -L${SCALAPACK_HOME}/lib -lscalapack
+  FLAGS_R = -O2 -g -fbacktrace -fcheck=all 
+  FLAGS_D = -O0 -g -fcheck=all -fbacktrace -Wextra \
+            -Wtarget-lifetime -fbounds-check -ffpe-trap=zero -finit-real=snan
+  LIBS    = -L${SCALAPACK_HOME}/lib -lscalapack
 
 #######################################################################
 #            MPI Options
@@ -48,7 +49,7 @@
   MPI_COMPILE_C = mpicc 
   MPI_LINK = mpifort
   MPI_LINK = mpifort -shared  -Wl,-no_compact_unwind
-  MPI_RUN = mpiexec
+  MPI_RUN = mpirun
   MPI_RUN_OPTS = -np 2
 
 #######################################################################
@@ -61,8 +62,8 @@
 #            NETCDF Options
 #######################################################################
   LNETCDF = T
-  NETCDF_INC = -I${NETCDF5_HOME}/include
-  NETCDF_LIB = -L${NETCDF5_HOME}/lib -lnetcdf -lnetcdff
+  NETCDF_INC = -I${NETCDF_HOME}/include
+  NETCDF_LIB = -L${NETCDF_HOME}/lib -lnetcdf -lnetcdff
 
 #######################################################################
 #            FFTW3 Options
@@ -165,4 +166,4 @@
 #            LIBSTELL Shared Options
 #######################################################################
 
-LIB_SHARE = -L/opt/local/lib/gcc9 -lstdc++ -lgfortran -L/usr/lib -lz -lc -lm -lpthread $(LIBS)
+LIB_SHARE = -lc -lgfortran -lstdc++ -lmpi -lmpi_mpifh -lz -lc -lm -lpthread $(LIBS) -lc

--- a/SHARE/make_osx_brew.inc
+++ b/SHARE/make_osx_brew.inc
@@ -1,0 +1,168 @@
+#######################################################################
+#            Define User Specific Output Paths
+#######################################################################
+  # Set a default directory if one has not already been defined.
+  STELLOPT_HOME ?= $(HOME)/bin
+
+
+#######################################################################
+#            Define Basic Utilities
+#######################################################################
+  # Temporaryily copy STELLOPT_HOME to MYHOME since MYHOME is currently
+  # used in all the makefiles.
+  MYHOME = $(STELLOPT_HOME)
+  
+  SHELL = /bin/sh
+  PWD1 = `pwd`
+  PRECOMP:= cpp -traditional-cpp -E -P -C -DMACOSX
+  COMPILE = gfortran
+  COMPILE_FREE = gfortran -ffree-form -ffree-line-length-none -ffixed-line-length-none
+  LINK    = gfortran $(FLAGS) -o
+  LINK_AR = ar -ruvs
+  LINK_C  = gcc -shared -Wl,-no_compact_unwind
+
+#######################################################################
+#            Libraries path
+#######################################################################
+  SCALAPACK_HOME ?= /usr/local/opt/scalapack
+  FFTW_HOME ?= /usr/local/opt/fftw
+  HDF5_HOME ?= /usr/local/opt/hdf5
+  NETCDF5_HOME ?= /usr/local/opt/netcdf
+  
+
+#######################################################################
+#            Define Compiler Flags
+#######################################################################
+  FLAGS_R = -O2 -g -fexternal-blas -fbacktrace -fcheck=all 
+  FLAGS_D = -O0 -g -fexternal-blas -fcheck=all -fbacktrace -Wextra \
+   -Wtarget-lifetime -fbounds-check -ffpe-trap=zero -finit-real=snan
+  LIBS    = -lopenblas -L${SCALAPACK_HOME}/lib -lscalapack
+
+#######################################################################
+#            MPI Options
+#######################################################################
+  LMPI    = T
+  MPI_COMPILE = mpifort
+  MPI_COMPILE_FREE = mpif90 -ffree-form \
+                     -ffree-line-length-none -ffixed-line-length-none
+  MPI_COMPILE_C = mpicc 
+  MPI_LINK = mpifort
+  MPI_LINK = mpifort -shared  -Wl,-no_compact_unwind
+  MPI_RUN = mpiexec
+  MPI_RUN_OPTS = -np 2
+
+#######################################################################
+#            NAG Options
+#######################################################################
+  LNAG = F
+  NAG_LIB = -L$(NAG_ROOT)/lib -lnag_nag
+
+#######################################################################
+#            NETCDF Options
+#######################################################################
+  LNETCDF = T
+  NETCDF_INC = -I${NETCDF5_HOME}/include
+  NETCDF_LIB = -L${NETCDF5_HOME}/lib -lnetcdf -lnetcdff
+
+#######################################################################
+#            FFTW3 Options
+#######################################################################
+  LFFTW3 = T
+  FFTW3_INC = -I${FFTW_HOME}/include
+  FFTW3_LIB = -L${FFTW_HOME}/lib -lfftw3
+
+#######################################################################
+#            HDF5 Options
+#######################################################################
+  LHDF5 = T
+  HDF5_INC = -I${HDF5_HOME}/include
+  HDF5_LIB = -L${HDF5_HOME}/lib -lhdf5hl_fortran -lhdf5_hl \
+             -lhdf5_fortran -lhdf5 -lz -ldl -lm
+
+#######################################################################
+#             PGPLOT Options
+#######################################################################
+  LPGPLOT = T
+  PGPLOT_INC = -I/opt/local/include
+  PGPLOT_LIB = -L/opt/local/lib -lpgplot -lX11
+
+#######################################################################
+#             SILO Options
+#######################################################################
+  LSILO = F
+  SILO_INC = -I/opt/local/include
+  SILO_LIB = -L/opt/local/lib -lsilo
+
+#######################################################################
+#            DKES/NEO Options
+#######################################################################
+  LDKES = T
+  LNEO  = T
+
+#######################################################################
+#            GENE Options
+#######################################################################
+  LGENE = F
+  GENE_INC = -I$(GENE_PATH)
+  GENE_DIR = $(GENE_PATH)
+  LIB_GENE = libgene.a
+  GENE_LIB = $(GENE_DIR)/$(LIB_GENE) \
+             -L/u/slazerso/src/GENE17_2016/external/pppl_cluster/futils/src -lfutils \
+             -L$(FFTWHOME)/lib -lfftw3 \
+             -L$(SLEPC_DIR)/$(PETSC_ARCH)/lib -lslepc \
+             -L$(PETSC_DIR)/$(PETSC_ARCH)/lib -lpetsc -lX11
+
+#######################################################################
+#            COILOPT++ Options
+#######################################################################
+  LCOILOPT = F
+  COILOPT_INC = -I$(COILOPT_PATH)
+  COILOPTPP_DIR = $(COILOPT_PATH)
+  LIB_COILOPTPP = libcoilopt++.a
+  COILOPT_LIB = $(COILOPT_PATH)/$(LIB_COILOPTPP) \
+                -L$(GSLHOME)/lib -lgsl -lgslcblas -lstdc++ -lmpi_cxx
+
+#######################################################################
+#            TERPSICHORE Options
+#######################################################################
+  LTERPSICHORE= F
+  TERPSICHORE_INC = -I$(TERPSICHORE_PATH)
+  TERPSICHORE_DIR = $(TERPSICHORE_PATH)
+  LIB_TERPSICHORE = libterpsichore.a
+  TERPSICHORE_LIB = $(TERPSICHORE_DIR)/$(LIB_TERPSICHORE)
+
+#######################################################################
+#            TRAVIS Options
+#######################################################################
+  LTRAVIS= F
+  TRAVIS_DIR = $(TRAVIS_PATH)
+  LIB_TRAVIS = libtravis64_sopt.a
+  LIB_MCONF  = libmconf64.a
+  TRAVIS_LIB = $(TRAVIS_DIR)/lib/$(LIB_TRAVIS) \
+               $(TRAVIS_DIR)/magconf/lib/$(LIB_MCONF) -lstdc++
+
+#######################################################################
+#            REGCOIL Options
+#######################################################################
+  LREGCOIL= F
+  REGCOIL_DIR = $(REGCOIL_PATH)
+  REGCOIL_INC = -I$(REGCOIL_DIR) 
+  LIB_REGCOIL = libregcoil.a
+  REGCOIL_LIB = $(REGCOIL_DIR)/$(LIB_REGCOIL) -fopenmp
+
+#######################################################################
+#            SFINCS Options
+#######################################################################
+
+  LSFINCS = F
+  SFINCS_DIR = $(SFINCS_PATH)
+  SFINCS_INC = -I$(SFINCS_DIR)
+  LIB_SFINCS = libsfincs.a
+  SFINCS_LIB = $(SFINCS_DIR)/$(LIB_SFINCS) \
+             -L$(PETSC_DIR)/$(PETSC_ARCH)/lib -lpetsc -lX11
+
+#######################################################################
+#            LIBSTELL Shared Options
+#######################################################################
+
+LIB_SHARE = -L/opt/local/lib/gcc9 -lstdc++ -lgfortran -L/usr/lib -lz -lc -lm -lpthread $(LIBS)

--- a/STELLOPTV2/STELLOPTV2.dep
+++ b/STELLOPTV2/STELLOPTV2.dep
@@ -6,6 +6,7 @@ stellopt_write_auxfiles.o : \
       stellopt_input_mod.o 
 
 stellopt_write_eqfile.o : \
+      stellopt_input_mod.o \
       stellopt_runtime.o \
       $(LIB_DIR)/$(LOCTYPE)/mpi_inc.o \
       $(LIB_DIR)/$(LOCTYPE)/read_wout_mod.o
@@ -169,6 +170,7 @@ chisq_z0.o : \
 chisq_curvature.o : \
       stellopt_runtime.o \
       stellopt_targets.o \
+      equil_utils.o \
       equil_vals.o 
       
 
@@ -255,6 +257,7 @@ chisq_resjac.o : \
       stellopt_runtime.o \
       stellopt_targets.o \
       equil_vals.o \
+      equil_utils.o \
       $(LIB_DIR)/$(LOCTYPE)/read_boozer_mod.o
 
 chisq_iota.o : \
@@ -555,6 +558,8 @@ stellopt_fcn.o : \
       
 stellopt_main.o : \
       stellopt_runtime.o \
+      stellopt_input_mod.o \
+      $(LIB_DIR)/$(LOCTYPE)/mgrid_mod.o \
       $(LIB_DIR)/$(LOCTYPE)/mpi_params.o
       
       
@@ -823,3 +828,27 @@ chisq_y.o : \
       stellopt_runtime.o \
       stellopt_targets.o \
       stellopt_vars.o
+
+chisq_template.o : \
+      stellopt_targets.o
+
+chisq_jinvariant.o : \
+      stellopt_targets.o 
+
+chisq_coillen.o : \
+      stellopt_targets.o 
+
+chisq_coilsep.o : \
+      stellopt_targets.o 
+
+chisq_coilcrv.o : \
+      stellopt_targets.o 
+
+chisq_coilself.o : \
+      stellopt_targets.o 
+
+chisq_coiltorvar.o : \
+      stellopt_targets.o 
+
+chisq_coilrect.o : \
+      stellopt_targets.o 

--- a/VMEC2000/VMEC2000.dep
+++ b/VMEC2000/VMEC2000.dep
@@ -608,7 +608,8 @@ bextern.o : \
 
 fouri.o : \
       parallel_include_module.o \
-      vacmod.o 
+      vacmod.o \
+      timer_sub.o
       
 
 fourp.o : \

--- a/VMEC2000/VMEC2000.dep
+++ b/VMEC2000/VMEC2000.dep
@@ -46,6 +46,8 @@ blocktridiagonalsolver_bst.o : \
       parallel_vmec_module.o \
       ../../LIBSTELL/$(LOCTYPE)/mpi_inc.o \
 
+blocktridiagonalsolver.o : \
+      parallel_include_module.o 
       
 
 convert.o : \
@@ -586,6 +588,7 @@ analyt.o : \
       
 
 becoil.o : \
+      timer_sub.o \
       ../../LIBSTELL/$(LOCTYPE)/vparams.o \
       parallel_include_module.o \
       vacmod.o 
@@ -609,6 +612,7 @@ fouri.o : \
       
 
 fourp.o : \
+      timer_sub.o \
       parallel_include_module.o \
       vacmod.o 
       
@@ -752,6 +756,7 @@ evolve.o : \
       
 
 gmres_mod.o : \
+      precon2d.o \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
       ../../LIBSTELL/$(LOCTYPE)/gmres.o \
       parallel_include_module.o \

--- a/VMEC2PIES/VMEC2PIES.dep
+++ b/VMEC2PIES/VMEC2PIES.dep
@@ -100,6 +100,13 @@ cyl2suv.o: \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
       pies_realspace.o
       
-     
+write_pies_coil.o : \
+      pies_runtime.o \
+      pies_background.o
       
+toroidal_flux.o : \
+      pies_runtime.o 
 
+main.o : \
+      pies_runtime.o
+      

--- a/build_all
+++ b/build_all
@@ -1,51 +1,37 @@
 #!/bin/sh
-#     Script:     update
-#     Author:     S. Lazerson (lazerson@pppl.gov)
-#     Date:       10/06/11
-#     Purpose:    This script zips the various STELLOPT
-#                 programs into their zip files and then
-#                 zips these files into the STELLOPT zip
-#                 file.
-#
-#     Usage:      To compile all STELLOPT codes simply call this script:
-#                 `build_all`. To complile only individual codes/libraries
-#                 add the requested script names as arguments:
-#                 `build_all LIBSTELL VMEC2000`.
-#
-#     Options:
-#       --release
-#       --clean_release
-#       --debug
-#       --clean_debug
-#       --shared_release
 
 export FLAG_CALLED_FROM_BUILD_ALL=true
 
+# A POSIX variable
+OPTIND=1         # Reset in case getopts has been used previously in the shell.
 
-# Set the default.
-RELEASE_TYPE=--clean_release
+# Initialize variables:
+MAKE_OPTION="clean_release"
+NUM_PROCS=1
 
-# Check to see if a build options was givin
-if [ $# -ne 0 ]; then
-  for OPTION in --release --clean_release --debug --clean_debug
-  do
-    # If command line arguments were given, then check to see
-    # which codes should be compiled.  Otherwise compile everything.
-    echo $@|grep -q -- $OPTION
-    if [ $? -eq 0 ]; then
-      RELEASE_TYPE=$OPTION
-      break  
-    fi
-  done
-fi
+# Check optional build variables
+while getopts "h?o:j:" opt; do
+    case "$opt" in
+    h|\?)
+        echo "./build_all -o MAKE_OPTION -j NUM_PROCS CODE_NAME"
+	      echo "    MAKE_OPTION: compile options, one of {clean_release, release, clean_debug, debug}."
+	      echo "    NUM_PROCS: number of CPUs for parallel make (default: 1)."
+	      echo "    CODE: code list to be compiled (default: full list)"
+        exit 0
+        ;;
+    o)  MAKE_OPTION=$OPTARG
+        ;;
+    j)  NUM_PROCS=$OPTARG
+        ;;
+    esac
+done
 
-echo Beginning build of STELLOPT with options: $RELEASE_TYPE
-
-MAKE_OPTIONS=`echo $RELEASE_TYPE | cut -b 3-`
-
+echo "Begin building STELLOPT with option: $MAKE_OPTION with $NUM_PROCS CPUs."
 # Call the toplevel makfile to setup the output directories.
-make $MAKE_OPTIONS
+make $MAKE_OPTION
 
+shift $((OPTIND-1))
+[ "${1:-}" = "--" ] && shift
 
 # Loop through all the available codes and make the ones specified on the
 # command line.  If no codes were specified, then make all of them.
@@ -61,7 +47,6 @@ do
       match=1  
     fi
   else
-    echo $CODE
     match=1
   fi
 
@@ -71,13 +56,14 @@ do
   fi
 
   if [ $match -eq 1 ]; then
+    echo "Begin building $CODE"
     cd $CODE
-    make $MAKE_OPTIONS
-#    make $MAKE_OPTIONS -j
+    make $MAKE_OPTION -j $NUM_PROCS
     cd ..
   fi
 done
 
+# make a dynamic library
 cd LIBSTELL
 make shared_release
 cd ..


### PR DESCRIPTION
I have revised the `./buil_all` script to fix the bug of not being able to specify the build option over the command line #71 and allow for specifying the number of processors to parallel build. To enable parallel build, many dependence files have been updated. These files should be checked carefully in the future. Probably, we can find a tool to automatically generate dependence.

To use the new file, simply type `./build_all -h` and the help message is shown below.
```
./build_all -o MAKE_OPTION -j NUM_PROCS CODE_NAME
    MAKE_OPTION: compile options, one of {clean_release, release, clean_debug, debug}.
    NUM_PROCS: number of CPUs for parallel make (default: 1).
    CODE: code list to be compiled (default: full list)
```

I have tested on Macbook and PPPL cluster with various combinations. The `-j8` option will print some un-explainable errors, like 
```
mpif90 -ffree-form -ffree-line-length-none -ffixed-line-length-none -O2 -g -fbacktrace -fcheck=all  -I/Users/czhu/Documents/Code/STELLOPT/bin/libstell_dir -I/usr/local/opt/netcdf/include -I/usr/local/opt/fftw/include -I/usr/local/opt/hdf5/include  -I/usr/local/opt/netcdf/include -I/usr/local/opt/fftw/include -I/usr/local/opt/hdf5/include -I. -c ../Sources/fblin_rkh68.f90
../Sources/fmap_nag.f90:14:10:

   14 |       USE fieldlines_runtime, ONLY: lmu, mu, ladvanced
      |          1
Fatal Error: Cannot open module file 'fieldlines_runtime.mod' for reading at (1): No such file or directory
compilation terminated.
make[2]: *** [fmap_nag.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```
However, the `fieldlines_runtime.o` IS in the dependencies of `fmap_nag`. Probably, `-j8` is too violent. At least, `-j4` works well.