### PR TITLE
Hotfix nyquist modes in stellopt_kink

### DIFF
--- a/SHARE/make_docker.inc
+++ b/SHARE/make_docker.inc
@@ -137,3 +137,4 @@
 #######################################################################
 #            LIBSTELL Shared Options
 #######################################################################
+LIB_SHARE = -lc -lgfortran -lstdc++ -lmpi -lmpi_mpifh -lz -lc -lm -lpthread $(LIBS) -lc

--- a/SHARE/make_osx_brew.inc
+++ b/SHARE/make_osx_brew.inc
@@ -34,8 +34,8 @@
 #######################################################################
 #            Define Compiler Flags
 #######################################################################
-  FLAGS_R = -O2 
-  FLAGS_D = -O0 -g -fcheck=all -fbacktrace -Wextra \
+  FLAGS_R = -O2 -fallow-argument-mismatch # only used for GCC-10
+  FLAGS_D = -O0 -g -fcheck=all -fbacktrace -Wextra -fallow-argument-mismatch \
             -Wtarget-lifetime -fbounds-check -ffpe-trap=zero -finit-real=snan
   LIBS    = -L${SCALAPACK_HOME}/lib -lscalapack
 
@@ -45,7 +45,8 @@
   LMPI    = T
   MPI_COMPILE = mpif90
   MPI_COMPILE_FREE = mpif90 -ffree-form \
-                     -ffree-line-length-none -ffixed-line-length-none
+                     -ffree-line-length-none -ffixed-line-length-none \
+                     -fallow-argument-mismatch # only used for GCC-10
   MPI_COMPILE_C = mpicc 
   MPI_LINK = mpif90
   MPI_LINK = mpif90 -shared  -Wl,-no_compact_unwind

--- a/STELLOPTV2/Sources/General/stellopt_kink.f90
+++ b/STELLOPTV2/Sources/General/stellopt_kink.f90
@@ -63,8 +63,8 @@
 !DEC$ IF DEFINED (MPI_OPT)
             CALL MPI_BCAST(nrad,1,MPI_INTEGER,master,MPI_COMM_MYWORLD,ierr_mpi)
             IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_ERR,'stellopt_kink: BCAST nrad',ierr_mpi)
-            CALL MPI_BCAST(mnmax_vmec,1,MPI_INTEGER,master,MPI_COMM_MYWORLD,ierr_mpi)
-            IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_ERR,'stellopt_kink: BCAST mnmax_vmec',ierr_mpi)
+            CALL MPI_BCAST(mnmax_nyq_vmec,1,MPI_INTEGER,master,MPI_COMM_MYWORLD,ierr_mpi)
+            IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_ERR,'stellopt_kink: BCAST mnmax_nyq_vmec',ierr_mpi)
 !DEC$ ENDIF
             NI    = nrad - 1
             MMAXDF = mmaxdf_kink


### PR DESCRIPTION
@lazersos modified `stellopt_kink` to use the Nyquist mode (check #42 ), but a missing line will cause a problem that `MLMNV` on different CPUs are different and thus a divided_by_zero error will occur. 