### PR TITLE
STELLOPTV2: Fixed boozer bug when nprocs>nboozer

### DIFF
--- a/STELLOPTV2/Sources/General/stellopt_neo.f90
+++ b/STELLOPTV2/Sources/General/stellopt_neo.f90
@@ -372,11 +372,11 @@
             ALLOCATE(save_array(no_fluxs,17)); save_array=0
             DO fluxs_arr_i = mystart,myend
                psi_ind = fluxs_arr_i
-               !IF (psi_ind .GE. 1 .AND. psi_ind .LE. npsi) THEN
                CALL neo_init_s(psi,dpsi)
                IF(psi_ind.EQ.1) dpsi=psi
                CALL flint_bo()
-               reff=reff+drdpsi*dpsi
+               !reff=reff+drdpsi*dpsi
+               reff = drdpsi*dpsi
                IF (reff /= reff) reff = 0
                IF (calc_cur .EQ. 1) CALL flint_cur()
                IF (ref_swi .EQ. 1) THEN
@@ -385,12 +385,6 @@
                ELSE IF (ref_swi .EQ. 2) THEN
                   b_ref = bmref
                   r_ref = rt0
-               ELSE
-                  ! This is checked above and would break the code if caught here
-                  !IF (lscreen) WRITE (6,*) 'FATAL: This ref_swi ',ref_swi,' is not implemented!'
-                  !IF (myworkid == master) CLOSE(w_u3)
-                  !iflag = -1
-                  !RETURN
                END IF
                epstot = epstot * (b_ref/bmref)**2 * (r_ref/rt0)**2
                epspar = epspar * (b_ref/bmref)**2 * (r_ref/rt0)**2
@@ -421,6 +415,12 @@
             END IF
 !DEC$ ENDIF
             IF (myworkid == master) THEN
+               ! Fix reff
+               reff = 0
+               DO fluxs_arr_i = 1, no_fluxs
+                  reff = reff + save_array(fluxs_arr_i,2)
+                  save_array(fluxs_arr_i,2) = reff
+               END DO
                DO fluxs_arr_i = 1, no_fluxs
                   psi_ind = fluxs_arr_i
                   epstot = save_array(fluxs_arr_i,1)

--- a/STELLOPTV2/Sources/General/stellopt_toboozer.f90
+++ b/STELLOPTV2/Sources/General/stellopt_toboozer.f90
@@ -159,6 +159,7 @@
             END DO
             irun_setup_booz = 0
             CALL boozer_coords(ik,irun_setup_booz)
+            IF (myend<=ik) mystart = myend + 1 ! we did it
             IF (myworkid /= master) THEN
                rmncb = 0
                zmnsb = 0
@@ -177,9 +178,9 @@
                mystart = ik+1
             END IF
 !DEC$ ENDIF
-            !DO ik = 0,numprocs_local-1
-            !   IF (myworkid == ik) PRINT *,myworkid,mystart,chunk,myend,irun_setup_booz
-            !END DO
+!            DO ik = 0,numprocs_local-1
+!               IF (myworkid == ik) PRINT *,myworkid,mystart,chunk,myend,irun_setup_booz
+!            END DO
             ! Calculate Boozer Coordinates
             DO ik = mystart, myend
                IF (lbooz(ik)) CALL boozer_coords(ik,irun_setup_booz)


### PR DESCRIPTION
Fixes a bug where having more threads available than boozer coordinates to evaluate caused the first coordinate evaluation to be double calculated.  Also fixes a bug where `reff` was incorrectly calculated in the `NEO` interface.