### PR TITLE
Added option to output pressure data on grid in FIELDLINES

### DIFF
--- a/FIELDLINES/Sources/fieldlines_grid.f90
+++ b/FIELDLINES/Sources/fieldlines_grid.f90
@@ -31,6 +31,7 @@
 !         B_R            Radial Magnetic Field [T]
 !         B_PHI          Toroidal Magnetic Field [T]
 !         B_Z            Vertical Magnetic Field [T]
+!         PRES_G         Plasma Pressure [Pa] on grid
 !         BR_spl         EZSpline Object for B_R/B_PHI
 !         BZ_spl         EZSpline Object for B_Z/B_PHI
 !-----------------------------------------------------------------------
@@ -39,10 +40,10 @@
       REAL(rprec) :: rmin, rmax, zmin, zmax, phimin, phimax, delta_phi,&
                      vc_adapt_tol
       INTEGER  ::    win_raxis, win_phiaxis, win_zaxis, win_B_R, win_B_PHI, win_B_Z, &
-                     win_MU, win_BR4D, win_BPHI4D, win_BZ4D, win_MODB4D, win_MU4D
+                     win_MU, win_BR4D, win_BPHI4D, win_BZ4D, win_MODB4D, win_MU4D, win_PRES
       REAL(rprec), POINTER :: raxis(:), zaxis(:), phiaxis(:)
       REAL(rprec), POINTER :: B_R(:,:,:), B_Z(:,:,:), B_PHI(:,:,:)
-      REAL(rprec), POINTER :: MU3D(:,:,:)
+      REAL(rprec), POINTER :: MU3D(:,:,:), PRES_G(:,:,:)
       REAL(rprec), DIMENSION(:,:,:,:), POINTER :: BR4D, BPHI4D, BZ4D, MODB4D, MU4D
       TYPE(EZspline3_r8) :: BR_spl, BZ_spl, MU_spl, MODB_spl
       REAL*8 ::      eps1, eps2, eps3

--- a/FIELDLINES/Sources/fieldlines_init.f90
+++ b/FIELDLINES/Sources/fieldlines_init.f90
@@ -184,11 +184,15 @@
          CALL mpialloc(B_R, nr, nphi, nz, myid_sharmem, 0, MPI_COMM_SHARMEM, win_B_R)
          CALL mpialloc(B_PHI, nr, nphi, nz, myid_sharmem, 0, MPI_COMM_SHARMEM, win_B_PHI)
          CALL mpialloc(B_Z, nr, nphi, nz, myid_sharmem, 0, MPI_COMM_SHARMEM, win_B_Z)
+         IF (lpres) THEN
+            CALL mpialloc(PRES_G, nr, nphi, nz, myid_sharmem, 0, MPI_COMM_SHARMEM, win_PRES)
+         END IF
          IF (myid_sharmem == master) THEN
             FORALL(i = 1:nr) raxis(i) = (i-1)*(rmax-rmin)/(nr-1) + rmin
             FORALL(i = 1:nz) zaxis(i) = (i-1)*(zmax-zmin)/(nz-1) + zmin
             FORALL(i = 1:nphi) phiaxis(i) = (i-1)*(phimax-phimin)/(nphi-1) + phimin
             B_R = 0; B_PHI = 0; B_Z = 0
+            IF (lpres) PRES_G = 0 
          END IF
          ! Put the vacuum field on the background grid
          IF (lmgrid) THEN

--- a/FIELDLINES/Sources/fieldlines_init_vars.f90
+++ b/FIELDLINES/Sources/fieldlines_init_vars.f90
@@ -26,6 +26,7 @@
       lmu      = .false.
       lvessel  = .false.
       lvac     = .false.
+      lpres    = .false.
       lrestart = .false.
       laxis_i  = .false.
       ladvanced = .false.

--- a/FIELDLINES/Sources/fieldlines_init_vmec.f90
+++ b/FIELDLINES/Sources/fieldlines_init_vmec.f90
@@ -20,9 +20,11 @@
                                  zaxis_g => zaxis, nr, nphi, nz, &
                                  rmin, rmax, zmin, zmax, phimin, &
                                  phimax, vc_adapt_tol, B_R, B_Z, B_PHI,&
-                                 BR_spl, BZ_spl
+                                 BR_spl, BZ_spl, PRES_G
       USE wall_mod, ONLY: wall_load_mn, wall_info,vertex,face
       USE mpi_params                                                    ! MPI
+      USE EZspline_obj
+      USE EZspline
 !      USE mpi
 !-----------------------------------------------------------------------
 !     Local Variables
@@ -48,9 +50,12 @@
                            rmns_temp(:,:),zmnc_temp(:,:),&
                            bumns_temp(:,:),bvmns_temp(:,:)
       LOGICAL :: lvolint = .false.
+      TYPE(EZspline1_r8) :: p_spl
+      INTEGER :: bcs1(2)
 !-----------------------------------------------------------------------
 !     Begin Subroutine
 !-----------------------------------------------------------------------
+      bcs1=(/0,0/)
       ! Handle what we do
       luse_vc = ((lcoil .or. lmgrid) .and. .not.lplasma_only)
 
@@ -84,12 +89,13 @@
       CALL MPI_BCAST(lwout_opened,1,MPI_LOGICAL, master, MPI_COMM_FIELDLINES,ierr_mpi)
       CALL MPI_BCAST(Aminor,1,MPI_DOUBLE_PRECISION, master, MPI_COMM_FIELDLINES,ierr_mpi)
       IF (myworkid /= master) THEN
-         ALLOCATE(phi_vmec(ns))
+         ALLOCATE(phi_vmec(ns),presf(ns))
          ALLOCATE(xm(mnmax),xn(mnmax),xm_nyq(mnmax_nyq),xn_nyq(mnmax_nyq))
          ALLOCATE(rmnc(mnmax,ns),zmns(mnmax,ns),bsupumnc(mnmax_nyq,ns),bsupvmnc(mnmax_nyq,ns))
          IF (lasym) ALLOCATE(rmns(mnmax,ns),zmnc(mnmax,ns),bsupumns(mnmax_nyq,ns),bsupvmns(mnmax_nyq,ns))
       END IF
       CALL MPI_BCAST(phi_vmec,ns,MPI_DOUBLE_PRECISION, master, MPI_COMM_FIELDLINES,ierr_mpi)
+      CALL MPI_BCAST(presf,ns,MPI_DOUBLE_PRECISION, master, MPI_COMM_FIELDLINES,ierr_mpi)
       CALL MPI_BCAST(xm,mnmax,MPI_DOUBLE_PRECISION, master, MPI_COMM_FIELDLINES,ierr_mpi)
       CALL MPI_BCAST(xn,mnmax,MPI_DOUBLE_PRECISION, master, MPI_COMM_FIELDLINES,ierr_mpi)
       CALL MPI_BCAST(xm_nyq,mnmax_nyq,MPI_DOUBLE_PRECISION, master, MPI_COMM_FIELDLINES,ierr_mpi)
@@ -204,7 +210,18 @@
          END IF
          DEALLOCATE(rmnc_temp,zmns_temp)
          DEALLOCATE(bumnc_temp,bvmnc_temp)
-         
+
+         IF (lpres) THEN
+            CALL EZspline_init(p_spl,ns,bcs1,ier)
+            IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,&
+                               'EZspline_init/fieldlines_init_vmec',ier)
+            p_spl%isHermite = 1
+            p_spl%x1 = phi_vmec/phi_vmec(ns) !Spline over normalized toroidal flux
+            CALL EZspline_setup(p_spl,presf,ier)
+            IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,&
+                               'EZspline_setup/fieldlines_init_vmec',ier)
+         END IF 
+
          adapt_tol = 0.0
          adapt_rel = vc_adapt_tol
          DEALLOCATE(xm_temp,xn_temp)
@@ -237,7 +254,7 @@
                   B_R(i,j,k)   = 0.0
                   B_PHI(i,j,k) = 1.0
                   B_Z(i,j,k)   = 0.0
-               ELSE IF (ier == -3 .or. bphi == 0 .or. s>1) THEN
+               ELSE IF (ier == -3 .or. bphi == 0 .or. sflx>1) THEN
                   xaxis_vc = raxis_g(i)*cos(phiaxis(j))
                   yaxis_vc = raxis_g(i)*sin(phiaxis(j))
                   zaxis_vc = zaxis_g(k)
@@ -282,11 +299,14 @@
                   B_R(i,j,k)   = br
                   B_PHI(i,j,k) = bphi
                   B_Z(i,j,k)   = bz
+                  IF (lpres) THEN 
+                     CALL EZspline_interp(p_spl,sflx,PRES_G(i,j,k),ier)
+                  END IF
                ELSE IF (lplasma_only) THEN
                   B_R(i,j,k)   = 0.0
                   B_PHI(i,j,k) = 1.0
                   B_Z(i,j,k)   = 0.0
-               ELSE IF (ier == -3 .or. bphi == 0 .or. s>1) THEN
+               ELSE IF (ier == -3 .or. bphi == 0 .or. sflx>1) THEN
                   xaxis_vc = raxis_g(i)*cos(phiaxis(j))
                   yaxis_vc = raxis_g(i)*sin(phiaxis(j))
                   zaxis_vc = zaxis_g(k)
@@ -298,6 +318,10 @@
                      IF (ABS(br_vc) > 0)   B_R(i,j,k)   = B_R(i,j,k) + br_vc
                      IF (ABS(bphi_vc) > 0) B_PHI(i,j,k) = B_PHI(i,j,k) + bphi_vc
                      IF (ABS(bz_vc) > 0)   B_Z(i,j,k)   = B_Z(i,j,k) + bz_vc
+                  END IF
+                  IF (lpres) THEN ! constant presssure outsise LCFS 
+                     sflx = 1.0
+                     CALL EZspline_interp(p_spl,sflx,PRES_G(i,j,k),ier)
                   END IF
                ELSE
                   ! This is an error code check
@@ -324,11 +348,13 @@
          CALL read_wout_deallocate
       ELSE
          lwout_opened = .FALSE.
-         DEALLOCATE(phi_vmec)
+         DEALLOCATE(phi_vmec,presf)
          DEALLOCATE(xm,xn,xm_nyq,xn_nyq)
          DEALLOCATE(rmnc,zmns,bsupumnc,bsupvmnc)
          IF (lasym) DEALLOCATE(rmns,zmnc,bsupumns,bsupvmns)
       END IF
+
+      IF (EZspline_allocated(p_spl)) CALL EZspline_free(p_spl,ier)
       
       IF (lverb) THEN
          CALL backspace_out(6,36)

--- a/FIELDLINES/Sources/fieldlines_main.f90
+++ b/FIELDLINES/Sources/fieldlines_main.f90
@@ -98,7 +98,9 @@
                    lverb=.false.
                case ("-vac")     ! Vacuum Fields Only
                    lvac=.true.
-               case ("-plasma") ! Plasma Field only
+               case ("-pres")    ! Calculate and output pressure 
+                   lpres=.true.
+               case ("-plasma") ! Plasma Region only
                    lplasma_only = .true.
                case ("-axis")
                    laxis_i  = .true.
@@ -270,6 +272,8 @@
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'fieldlines_main',ierr_mpi)
       CALL MPI_BCAST(lvac,1,MPI_LOGICAL, master, MPI_COMM_FIELDLINES,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'fieldlines_main',ierr_mpi)
+      CALL MPI_BCAST(lpres,1,MPI_LOGICAL, master, MPI_COMM_FIELDLINES,ierr_mpi)
+      IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'fieldlines_main',ierr_mpi)
       CALL MPI_BCAST(laxis_i,1,MPI_LOGICAL, master, MPI_COMM_FIELDLINES,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'fieldlines_main',ierr_mpi)
       CALL MPI_BCAST(lmu,1,MPI_LOGICAL, master, MPI_COMM_FIELDLINES,ierr_mpi)
@@ -346,6 +350,7 @@
       IF (ASSOCIATED(B_R)) CALL mpidealloc(B_R,win_B_R)
       IF (ASSOCIATED(B_PHI)) CALL mpidealloc(B_PHI,win_B_PHI)
       IF (ASSOCIATED(B_Z)) CALL mpidealloc(B_Z,win_B_Z)
+      IF (ASSOCIATED(PRES_G).and.lpres) CALL mpidealloc(PRES_G,win_PRES)
       IF (ASSOCIATED(BR4D)) CALL mpidealloc(BR4D,win_BR4D)
       IF (ASSOCIATED(BZ4D)) CALL mpidealloc(BZ4D,win_BZ4D)
       IF (ASSOCIATED(MU4D)) CALL mpidealloc(MU4D,win_MU4D)

--- a/FIELDLINES/Sources/fieldlines_runtime.f90
+++ b/FIELDLINES/Sources/fieldlines_runtime.f90
@@ -125,7 +125,7 @@
                          ladvanced, lauto, lplasma_only, lbfield_only,&
                          lreverse, lhitonly, lafield_only, lraw, lemc3, &
                          lerror_field, lwall_trans, ledge_start, lnescoil,&
-                         lmodb, lfield_start, lhint
+                         lmodb, lfield_start, lhint, lpres
       INTEGER         :: nextcur, npoinc, nruntype, num_hcp, &
                          nprocs_fieldlines, line_select
       REAL(rprec)     :: mu, dphi, follow_tol, pi, pi2, mu0, delta_hc, iota0

--- a/FIELDLINES/Sources/fieldlines_write.f90
+++ b/FIELDLINES/Sources/fieldlines_write.f90
@@ -16,7 +16,7 @@
       USE wall_mod, ONLY: nface,nvertex,face,vertex,ihit_array
       USE fieldlines_lines
       USE fieldlines_grid, ONLY: nr, nphi, nz, B_R, B_PHI, B_Z, raxis, &
-                                 zaxis, phiaxis
+                                 zaxis, phiaxis, PRES_G
       USE fieldlines_runtime, ONLY: id_string, npoinc, lverb, lvmec, &
                                     lpies, lspec, lcoil, lmgrid, lmu, &
                                     lvessel, lvac, laxis_i, handle_err,&
@@ -24,7 +24,7 @@
                                     HDF5_CLOSE_ERR, FIELDLINES_VERSION,&
                                     ladvanced, lbfield_only, lreverse,&
                                     lafield_only, lemc3, lmodb, &
-                                    MPI_BARRIER_ERR, iota0, lhint
+                                    MPI_BARRIER_ERR, iota0, lhint, lpres
       USE fieldlines_write_par
       USE mpi_inc
 !-----------------------------------------------------------------------
@@ -66,6 +66,8 @@
          IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'lvessel',ier)
          CALL write_scalar_hdf5(fid,'lvac',ier,BOOVAR=lvac,ATT='Vacuum calc',ATT_NAME='description')
          IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'lvac',ier)
+         CALL write_scalar_hdf5(fid,'lpres',ier,BOOVAR=lpres,ATT='Pressure output',ATT_NAME='description')
+         IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'lpres',ier)
          CALL write_scalar_hdf5(fid,'laxis_i',ier,BOOVAR=laxis_i,ATT='Axis calc',ATT_NAME='description')
          IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'laxis_i',ier)
          CALL write_scalar_hdf5(fid,'ladvanced',ier,BOOVAR=ladvanced,ATT='Advanced Grid Flag',ATT_NAME='description')
@@ -138,6 +140,10 @@
             IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'B_Z',ier)
             CALL write_var_hdf5(fid,'B_PHI',nr,nphi,nz,ier,DBLVAR=B_PHI,ATT='Toroidal Field (BPHI)',ATT_NAME='description')
             IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'B_PHI',ier)
+            IF (lpres) THEN
+               CALL write_var_hdf5(fid,'PRES',nr,nphi,nz,ier,DBLVAR=PRES_G,ATT='Plasma Pressure (PRES)',ATT_NAME='description')
+               IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'PRES',ier)
+            END IF
          ELSE
             CALL write_scalar_hdf5(fid,'nr',ier,INTVAR=nr,ATT='Number of Radial Gridpoints',ATT_NAME='description')
             IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'nr',ier)

--- a/VMEC2PIES/Sources/calc_metrics.f90
+++ b/VMEC2PIES/Sources/calc_metrics.f90
@@ -66,8 +66,8 @@
       END IF
       DO u=1,nu
          DO v=1,nv
-            rs(1:k-1,u,v) = (rreal(2:k,u,v)-rreal(0:k-2,u,v))/(rho(2:k)-rho(0:k))
-            zs(1:k-1,u,v) = (zreal(2:k,u,v)-zreal(0:k-2,u,v))/(rho(2:k)-rho(0:k))
+            rs(1:k-1,u,v) = (rreal(2:k,u,v)-rreal(0:k-2,u,v))/(rho(2:k)-rho(0:k-2))
+            zs(1:k-1,u,v) = (zreal(2:k,u,v)-zreal(0:k-2,u,v))/(rho(2:k)-rho(0:k-2))
             rs(0,u,v)     = (rreal(1,u,v) - rreal(0,u,v))/(rho(1)-rho(0))
             zs(0,u,v)     = (zreal(1,u,v) - zreal(0,u,v))/(rho(1)-rho(0))
             rs(k,u,v)     = (rreal(k,u,v) - rreal(k-1,u,v))/(rho(k)-rho(k-1))

--- a/VMEC2PIES/Sources/main.f90
+++ b/VMEC2PIES/Sources/main.f90
@@ -71,6 +71,9 @@
                               coils_file, lmake_coils, lfreeb, mustochf,&
                               lbrho
       USE pies_background, ONLY: k
+      USE mpi_sharmem
+      USE mpi_params
+      USE mpi_inc
 !-----------------------------------------------------------------------
 !     Local Variables
 !          numargs      Number of input arguments
@@ -172,6 +175,11 @@
          stop
       END IF
       DEALLOCATE(args)
+
+#if defined(MPI_OPT)
+      CALL MPI_INIT(ierr_mpi) !MPI
+#endif
+
       ! Initialize the Calculation
       CALL pies_init
       CALL write_pies_input

--- a/VMEC2PIES/Sources/pies_init_wout.f90
+++ b/VMEC2PIES/Sources/pies_init_wout.f90
@@ -454,7 +454,7 @@
       ! Now use virtual casing to calculate plasma response
       IF (lfreeb .and. extsurfs > 0) THEN
          ALLOCATE(bsmns_temp(1:mnmax,0:k),bumnc_temp(1:mnmax,0:k),bvmnc_temp(1:mnmax,0:k))
-         !CALL virtual_casing(vsurf)
+         CALL virtual_casing(vsurf)
          CALL mgrid_field(vsurf+1,1)
          CALL uvtomn(0,k,mnmax,nu,nv,xu,xv,bsmns_temp,xm,xn,bsreal,1,1)
          CALL uvtomn(0,k,mnmax,nu,nv,xu,xv,bumnc_temp,xm,xn,bureal,0,0)


### PR DESCRIPTION
Added '-pres' option to output pressure data on grid in FIELDLINES. This would allow free-boundary VMEC data (pressure and magnetic field) to be put on a cylindrical grid and then used to set up, for example, M3D-C1 simulations. Also included are some bug fixes to VMEC2PIES.