### PR TITLE
EPS_EFF label in STELLOPT updated to EPS_EFF^(3/2)

### DIFF
--- a/STELLOPTV2/Sources/Chisq/chisq_neo.f90
+++ b/STELLOPTV2/Sources/Chisq/chisq_neo.f90
@@ -12,7 +12,7 @@
       USE stellopt_runtime
       USE stellopt_targets
       USE stellopt_vars, ONLY: equil_type
-      USE equil_vals, ONLY: eff_ripple
+      USE equil_vals, ONLY: eps_eff32
 !DEC$ IF DEFINED (NEO_OPT)
       USE neo_input_mod, ONLY: read_neoin_input, write_neoin_namelist
 !DEC$ ENDIF
@@ -39,14 +39,14 @@
       IF (iflag < 0) RETURN
       ik   = COUNT(sigma < bigno)
       IF (iflag == 1) WRITE(iunit_out,'(A,2(2X,I3.3))') 'NEO ',ik,4
-      IF (iflag == 1) WRITE(iunit_out,'(A)') 'TARGET  SIGMA  EFF_RIPPLE  #'
+      IF (iflag == 1) WRITE(iunit_out,'(A)') 'TARGET  SIGMA  EPS_EFF^(3/2)  #'
       IF (niter >= 0) THEN
          DO ik = 1, nsd
             IF (sigma(ik) < bigno) THEN
                mtargets = mtargets + 1
                targets(mtargets) = target(ik)
                sigmas(mtargets)  = sigma(ik)
-               vals(mtargets)    = eff_ripple(ik)
+               vals(mtargets)    = eps_eff32(ik)
                IF (iflag == 1) WRITE(iunit_out,'(3ES22.12E3,2X,I3.3)') target(ik),sigma(ik),vals(mtargets),ik
                IF (iflag == 1) CALL FLUSH(iunit_out)
             END IF

--- a/STELLOPTV2/Sources/General/stellopt_neo.f90
+++ b/STELLOPTV2/Sources/General/stellopt_neo.f90
@@ -11,7 +11,7 @@
 !-----------------------------------------------------------------------
       USE stellopt_runtime, ONLY:  proc_string, bigno
       USE stellopt_vars, ONLY: equil_type
-      USE equil_vals, ONLY: eff_ripple
+      USE equil_vals, ONLY: eps_eff32
       USE stellopt_targets, ONLY: sigma_neo
       USE safe_open_mod
       USE mpi_params
@@ -330,9 +330,9 @@
             END IF
             ! Loop over magnetic surfaces
             reff = 0
-            IF (ALLOCATED(eff_ripple)) DEALLOCATE(eff_ripple)
-            ALLOCATE(eff_ripple(ns_b))
-            eff_ripple = 0
+            IF (ALLOCATED(eps_eff32)) DEALLOCATE(eps_eff32)
+            ALLOCATE(eps_eff32(ns_b))
+            eps_eff32 = 0
             IF (lscreen) THEN
                WRITE(6,'(A)')           '==========================================='
                WRITE(6,'(A)')           '=================  N E O =================='
@@ -344,7 +344,7 @@
                WRITE(6,'(2X,2(A,I4.4))')'NSTEP_MIN = ',nstep_min,';   NSTEP_MAX = ',nstep_max
                WRITE(6,'(2X,A,I3.3)')   'NSTEP_PER = ',nstep_per
                WRITE(6,'(A)')           '------------------------------------------------------------------'
-               WRITE(6,'(A)')           '  SURF  EPS_EFF        REFF       IOTA        B_REF       R_REF'
+               WRITE(6,'(A)')           '  SURF  EPS_EFF^(3/2)  REFF       IOTA        B_REF       R_REF'
                WRITE(6,'(A)')           '------------------------------------------------------------------'
                CALL FLUSH(6)
             END IF
@@ -471,7 +471,7 @@
                         lambda_ps1,lambda_ps2,                                 &
                         lambda_b1,lambda_b2
                   END IF
-                  eff_ripple(fluxs_arr(fluxs_arr_i)) = epstot
+                  eps_eff32(fluxs_arr(fluxs_arr_i)) = epstot
                   IF (lscreen) WRITE(6,'(2X,I3,5(2X,E11.4))') fluxs_arr(fluxs_arr_i),epstot,reff,iota(psi_ind),b_ref,r_ref
                   CALL FLUSH(6)
                END DO

--- a/STELLOPTV2/Sources/Modules/equil_vals.f90
+++ b/STELLOPTV2/Sources/Modules/equil_vals.f90
@@ -29,7 +29,7 @@
       REAL(rprec) ::  aspect, betat, curtor, phiedge, volume, wp, drho,&
                       rbtor, r0, z0, iota_res_tgt, betap, beta, Rmajor, &
                       Aminor, mach0, kx_gene, kink_omega, Baxis
-      REAL(rprec),ALLOCATABLE :: rho(:), shat(:), extcur(:), eff_ripple(:), &
+      REAL(rprec),ALLOCATABLE :: rho(:), shat(:), extcur(:), eps_eff32(:), &
                                  orbit_lost_frac(:), radto_ece(:,:), radtx_ece(:,:)
       REAL(rprec),ALLOCATABLE :: balloon_grate(:,:,:)
       REAL(rprec),ALLOCATABLE :: txport_q(:,:,:), txport_q_all(:,:,:,:)


### PR DESCRIPTION
When NEO is used via STELLOPT, STELLOPT presently prints values to the screen under the label `EPS_EFF` that are actually epsilon_eff^(3/2). This pull request has a few changes so users do not misinterpret these numbers as epsilon_eff^1. The label in STELLOPT is changed to `EPS_EFF^(3/2)`, and the variable name `eff_ripple` is updated to `eps_eff32`.

The numbers printed to stdout and saved in the `neo_out` and `neolog` files come from the variable `epstot` in NEO. To see that `epstot` in NEO is actually epsilon_eff^(3/2) rather than epsilon_eff^1, here's where epstot is computed:
https://github.com/PrincetonUniversity/STELLOPT/blob/develop/NEO/Sources/flint_bo.f90#L426-L429
where `coeps` has the factors pi R^2 / (8 sqrt(2)) from  eq (29) in Nemov, PoP 6, 4622 (1999); doi: 10.1063/1.873749:
https://github.com/PrincetonUniversity/STELLOPT/blob/develop/NEO/Sources/flint_bo.f90#L135
Comparing to Nemov's (29), epstot must be eps_eff^(3/2).

This definition is also documented in NEO:

https://github.com/PrincetonUniversity/STELLOPT/blob/develop/NEO/Sources/flint_bo.f90#L17