### PR TITLE
Lazerson oldget bcyl

### DIFF
--- a/BEAMS3D/Sources/beams3d_init_eqdsk.f90
+++ b/BEAMS3D/Sources/beams3d_init_eqdsk.f90
@@ -64,6 +64,27 @@
 #endif
       mylocalmaster = master
 
+      ! Calculate the minor radius
+      IF (myworkid == master) THEN
+         brtemp = 0.5*SQRT((raxis_g(nr)-raxis_g(1))**2 + (zaxis_g(nr)-zaxis_g(1))**2)
+         k = FLOOR(brtemp/0.001)
+         reff_eq = 0
+         s = 0
+         DO i = 0, 359, 1
+            INNERLOOP: DO j = 1, k
+               brtemp = raxis_eqdsk + 0.001*j*COSD(REAL(i))
+               bztemp = zaxis_eqdsk + 0.001*j*SIND(REAL(i))
+               CALL get_eqdsk_fluxspl(brtemp,bztemp,rhoflx,uflx)
+               IF (rhoflx .ge. 1) THEN
+                  reff_eq = reff_eq + 0.001*(j-0.5) ! halfway between last gridpoint and here.
+                  s = s + 1
+                  EXIT INNERLOOP
+               END IF
+            END DO INNERLOOP
+         END DO
+         reff_eq = reff_eq / s
+      end IF
+
       ! Write info to screen
       IF (lverb) THEN
          betatot = 0
@@ -79,6 +100,7 @@
          ELSE
             WRITE(6,'(A,F7.2,A)') '   I  = ',totcur,' [A]'
          END IF
+         WRITE(6,'(A,F7.2,A)')        '   AMINOR  = ',reff_eq,' [m]'
          WRITE(6,'(A,F7.2,A)')        '   P_MAX = ',MAXVAL(sp)*1E-3,' [kPa]'
          WRITE(6,'(A,F7.2,A)')        '   PSIEDGE = ',psisep,' [Wb]'
          IF (lcreate_wall) THEN
@@ -90,10 +112,12 @@
          END IF
       END IF
 
-
       ! Calculate the axis values
       req_axis(:) = raxis_eqdsk
       zeq_axis(:) = zaxis_eqdsk
+
+      ! Helpers
+      phiedge_eq = 1.0 ! normalized value
 
       ! Use the vessel as a mask for rho
       zsmax = MAXVAL(zbndry)

--- a/BEAMS3D/Sources/beams3d_init_eqdsk.f90
+++ b/BEAMS3D/Sources/beams3d_init_eqdsk.f90
@@ -72,8 +72,8 @@
          s = 0
          DO i = 0, 359, 1
             INNERLOOP: DO j = 1, k
-               brtemp = raxis_eqdsk + 0.001*j*COSD(REAL(i))
-               bztemp = zaxis_eqdsk + 0.001*j*SIND(REAL(i))
+               brtemp = raxis_eqdsk + 0.001*j*COS(i*pi2/360.0)
+               bztemp = zaxis_eqdsk + 0.001*j*SIN(i*pi2/360.0)
                CALL get_eqdsk_fluxspl(brtemp,bztemp,rhoflx,uflx)
                IF (rhoflx .ge. 1) THEN
                   reff_eq = reff_eq + 0.001*(j-0.5) ! halfway between last gridpoint and here.

--- a/BEAMS3D/Sources/beams3d_input_mod.f90
+++ b/BEAMS3D/Sources/beams3d_input_mod.f90
@@ -30,7 +30,7 @@
       IMPLICIT NONE
       ! These are helpers to give the ns1_prof variables user friendly names
       INTEGER :: nrho_dist, ntheta_dist, nzeta_dist, nvpara_dist, nvperp_dist
-
+      REAL(rprec) :: temp
 !-----------------------------------------------------------------------
 !     Input Namelists
 !         &beams3d_input
@@ -258,7 +258,12 @@
             ! Now calc Zeff(1)
             DO i1 = 1, nzeff
                ZEFF_AUX_S(i1) = NI_AUX_S(i1)
-               ZEFF_AUX_F(i1) = SUM(NI_AUX_F(:,i1)*NI_AUX_Z(:)*NI_AUX_Z(:))/SUM(NI_AUX_F(:,i1)*NI_AUX_Z(:))
+               temp = SUM(NI_AUX_F(:,i1)*NI_AUX_Z(:))
+               IF (temp > 0) THEN
+                  ZEFF_AUX_F(i1) = MAX(SUM(NI_AUX_F(:,i1)*NI_AUX_Z(:)*NI_AUX_Z(:))/temp,1.0)
+               ELSE
+                  ZEFF_AUX_F(i1) = 1
+               END IF
             END DO
             plasma_mass = SUM(NI_AUX_F(:,1)*NI_AUX_M*NI_AUX_M)/(SUM(NI_AUX_F(:,1)*NI_AUX_M))
             plasma_Zavg = SUM(NI_AUX_F(:,1)*NI_AUX_Z*NI_AUX_Z)/(SUM(NI_AUX_F(:,1)*NI_AUX_Z)) ! Note this is just Zeff
@@ -273,7 +278,12 @@
             ! Now calc Zeff(1)
             DO i1 = 1, nzeff
                ZEFF_AUX_S(i1) = NI_AUX_S(i1)
-               ZEFF_AUX_F(i1) = SUM(NI_AUX_F(:,i1)*NI_AUX_Z(:)*NI_AUX_Z(:))/SUM(NI_AUX_F(:,i1)*NI_AUX_Z(:))
+               temp = SUM(NI_AUX_F(:,i1)*NI_AUX_Z(:))
+               IF (temp > 0) THEN
+                  ZEFF_AUX_F(i1) = MAX(SUM(NI_AUX_F(:,i1)*NI_AUX_Z(:)*NI_AUX_Z(:))/temp,1.0)
+               ELSE
+                  ZEFF_AUX_F(i1) = 1
+               END IF
             END DO
             plasma_mass = SUM(NI_AUX_F(:,1)*NI_AUX_M*NI_AUX_M)/(SUM(NI_AUX_F(:,1)*NI_AUX_M))
             plasma_Zavg = SUM(NI_AUX_F(:,1)*NI_AUX_Z*NI_AUX_Z)/(SUM(NI_AUX_F(:,1)*NI_AUX_Z)) ! Note this is just Zeff

--- a/LIBSTELL/Sources/Modules/vmec_utils.f
+++ b/LIBSTELL/Sources/Modules/vmec_utils.f
@@ -1179,33 +1179,32 @@ C-----------------------------------------------
          nfe = nfe + 1
 
          sflux = MAX(xc_opt(1), zero)
-!        sflux = MIN(MAX(xc_opt(1), zero), one)
          uflux = xc_opt(2)
          c_flx(1) = sflux;  c_flx(2) = uflux
 
 !        COMPUTE R,Z, Ru, Zu
-!         CALL get_flxcoord(x0, c_flx, rs=rs1, zs=zs1, ru=ru1, zu=zu1)
-!         xu(1) = ru1; xu(3) = zu1
-!         xs(1) = rs1; xs(3) = zs1
-!        COMPUTE R,Z, Ru, Zu
-         CALL get_flxcoord(x0, c_flx, ru=ru1, zu=zu1)
+         CALL get_flxcoord(x0, c_flx, rs=rs1, zs=zs1, ru=ru1, zu=zu1)
          xu(1) = ru1; xu(3) = zu1
-
+         xs(1) = rs1; xs(3) = zs1
+!        COMPUTE R,Z, Ru, Zu
+!         CALL get_flxcoord(x0, c_flx, ru=ru1, zu=zu1)
+!         xu(1) = ru1; xu(3) = zu1
+!
 !        MAKE SURE sflux IS LARGE ENOUGH
 !        TO COMPUTE d(sqrt(s))/ds ACCURATELY NEAR ORIGIN
-         IF (sflux .ge. 1000*eps0) THEN
-            eps = eps0
-         ELSE
-            eps = eps0*sflux
-         END IF
-
+!         IF (sflux .ge. 1000*eps0) THEN
+!            eps = eps0
+!         ELSE
+!            eps = eps0*sflux
+!         END IF
+!
 !        COMPUTE Rs, Zs NUMERICALLY
-         eps = ABS(eps)
-         IF (sflux .ge. 1-eps) eps = -eps
-         c_flx(1) = sflux + eps
-         CALL get_flxcoord(r_cyl_out, c_flx)
-         xs = (r_cyl_out - x0)/eps
-         c_flx(1) = sflux
+!         eps = ABS(eps)
+!         IF (sflux .ge. 1-eps) eps = -eps
+!         c_flx(1) = sflux + eps
+!         CALL get_flxcoord(r_cyl_out, c_flx)
+!         xs = (r_cyl_out - x0)/eps
+!         c_flx(1) = sflux
 
          x0(1) = x0(1) - r_target
          x0(3) = x0(3) - z_target
@@ -1241,23 +1240,20 @@ C-----------------------------------------------
          IF (fmin .le. ftol) EXIT
 
          IF (ABS(dels) .gt. one)   dels = SIGN(one, dels)
-!         IF (ABS(delu) .gt. twopi/2) delu = SIGN(twopi/2, delu)
+         IF (ABS(delu) .gt. twopi/8) delu = SIGN(twopi/8, delu)
 
          snew = xc_opt(1) + dels*factor
          IF (snew .lt. zero) THEN
             xc_opt(1) = -snew/2               !Prevents oscillations around origin s=0
             xc_opt(2) = xc_opt(2) + twopi/2 
-            delu = -delu
-!             factor = (-snew/2-xc_opt(1))/dels
-!             xc_opt(1) = -snew/2
          ELSE
             xc_opt(1) = snew
+            xc_opt(2) = xc_opt(2) + delu*factor
          END IF
-         xc_opt(2) = xc_opt(2) + delu*factor
 
          IF (xc_opt(1) .gt. edge_value) THEN
             isgt1 = isgt1+1
-            IF (xc_opt(1) .gt. 2._dp) isgt1 = isgt1+1
+            !IF (xc_opt(1) .gt. 2._dp) isgt1 = isgt1+1
             IF (isgt1 .gt. 5) EXIT
          END IF
 

--- a/LIBSTELL/Sources/Modules/vmec_utils.f
+++ b/LIBSTELL/Sources/Modules/vmec_utils.f
@@ -107,23 +107,29 @@ C-----------------------------------------------
          c_flx(1) = one
       END IF
 
+!     OLD WAY
+!     2. Evaluate Bsupu, Bsupv at this point
+!
+      CALL tosuvspace (c_flx(1), c_flx(2), c_flx(3), 
+     1                 BSUPU=bsupu1, BSUPV=bsupv1)
+
 !
 !     2. Evaluate Jacobian
 !        sqrt(g)=R(dR/du*dZ/ds-dR/ds*dZ/du)
 !
-
-      g1 = R1*(Ru1*Zs1-Rs1*Zu1)
-
+!
+!      g1 = R1*(Ru1*Zs1-Rs1*Zu1)
+!
 !
 !     3. Evaluate Bsupu*sqrt(g), Bsupv*sqrt(g) at this point
 !        The factor of pi2 comes from normalization on
 !        dchi/ds and dphi/ds
 !
-      CALL tosuvspaceBsup (c_flx(1), c_flx(2), c_flx(3), 
-     1                 GBSUPU=bsupu1, GBSUPV=bsupv1)
-
-      bsupu1 = bsupu1/(ABS(g1)*pi2) ! Pi2 comes from chip and phip
-      bsupv1 = bsupv1/(ABS(g1)*pi2)
+!      CALL tosuvspaceBsup (c_flx(1), c_flx(2), c_flx(3), 
+!     1                 GBSUPU=bsupu1, GBSUPV=bsupv1)
+!
+!      bsupu1 = bsupu1/(ABS(g1)*pi2) ! Pi2 comes from chip and phip
+!      bsupv1 = bsupv1/(ABS(g1)*pi2)
 !
 !     3. Form Br, Bphi, Bz
 !
@@ -1178,25 +1184,28 @@ C-----------------------------------------------
          c_flx(1) = sflux;  c_flx(2) = uflux
 
 !        COMPUTE R,Z, Ru, Zu
-         CALL get_flxcoord(x0, c_flx, rs=rs1, zs=zs1, ru=ru1, zu=zu1)
+!         CALL get_flxcoord(x0, c_flx, rs=rs1, zs=zs1, ru=ru1, zu=zu1)
+!         xu(1) = ru1; xu(3) = zu1
+!         xs(1) = rs1; xs(3) = zs1
+!        COMPUTE R,Z, Ru, Zu
+         CALL get_flxcoord(x0, c_flx, ru=ru1, zu=zu1)
          xu(1) = ru1; xu(3) = zu1
-         xs(1) = rs1; xs(3) = zs1
 
 !        MAKE SURE sflux IS LARGE ENOUGH
 !        TO COMPUTE d(sqrt(s))/ds ACCURATELY NEAR ORIGIN
-!         IF (sflux .ge. 1000*eps0) THEN
-!            eps = eps0
-!         ELSE
-!            eps = eps0*sflux
-!         END IF
+         IF (sflux .ge. 1000*eps0) THEN
+            eps = eps0
+         ELSE
+            eps = eps0*sflux
+         END IF
 
 !        COMPUTE Rs, Zs NUMERICALLY
-!         eps = ABS(eps)
-!         IF (sflux .ge. 1-eps) eps = -eps
-!         c_flx(1) = sflux + eps
-!         CALL get_flxcoord(r_cyl_out, c_flx)
-!         xs = (r_cyl_out - x0)/eps
-!         c_flx(1) = sflux
+         eps = ABS(eps)
+         IF (sflux .ge. 1-eps) eps = -eps
+         c_flx(1) = sflux + eps
+         CALL get_flxcoord(r_cyl_out, c_flx)
+         xs = (r_cyl_out - x0)/eps
+         c_flx(1) = sflux
 
          x0(1) = x0(1) - r_target
          x0(3) = x0(3) - z_target
@@ -1237,8 +1246,8 @@ C-----------------------------------------------
          snew = xc_opt(1) + dels*factor
          IF (snew .lt. zero) THEN
             xc_opt(1) = -snew/2               !Prevents oscillations around origin s=0
-            !xc_opt(2) = xc_opt(2) + twopi/2 
-            !delu = -delu
+            xc_opt(2) = xc_opt(2) + twopi/2 
+            delu = -delu
 !             factor = (-snew/2-xc_opt(1))/dels
 !             xc_opt(1) = -snew/2
          ELSE


### PR DESCRIPTION
This fixes two issues.

- Reverts the changes to vmec_utils.f90, but keeps the analytic derivative for the Newton method which seems to improve lookup for the highly elongated configurations.
- Fixes bug in BEAMS3D related to multi-ion when ne is allowed to go to zero.