### PR TITLE
Adding reverse flow to field lines diffusion

### DIFF
--- a/BENCHMARKS/makefile
+++ b/BENCHMARKS/makefile
@@ -292,22 +292,28 @@ test_fieldlines_full:
 	@cd $(FIELDLINES_TEST_DIR); ./compare_NCSX_s1.py
 	@echo ""
 
-test_fieldlines_coll: fieldlines_NCSX_s1.h5
+test_fieldlines_coll: FIELDLINES_TEST/fieldlines_NCSX_s1.h5
 	@echo $(MPI_RUN) $(MPI_RUN_OPTS_MD) $(MYHOME)/xfieldlines -vmec NCSX_s1_coll -coil coils.NCSX -vac -vessel NCSX_wall_trimesh.dat -hitonly -field_start fieldlines_NCSX_s1.h5 114
 	@cd $(FIELDLINES_TEST_DIR); $(MPI_RUN) $(MPI_RUN_OPTS_MD) $(MYHOME)/xfieldlines -vmec NCSX_s1_coll -vac -coil coils.NCSX -vac -vessel NCSX_wall_trimesh.dat -hitonly -field_start fieldlines_NCSX_s1.h5 114
 	@echo ""
 
-test_fieldlines_coll_acc: fieldlines_NCSX_s1.h5
+test_fieldlines_backflow: FIELDLINES_TEST/fieldlines_NCSX_s1.h5
+	@echo $(MPI_RUN) $(MPI_RUN_OPTS_MD) $(MYHOME)/xfieldlines -vmec NCSX_s1_coll -coil coils.NCSX -vac -vessel NCSX_wall_trimesh.dat -hitonly -field_start fieldlines_NCSX_s1.h5 114 -backflow
+	@cd $(FIELDLINES_TEST_DIR); $(MPI_RUN) $(MPI_RUN_OPTS_MD) $(MYHOME)/xfieldlines -vmec NCSX_s1_coll -vac -coil coils.NCSX -vac -vessel NCSX_wall_trimesh.dat -hitonly -field_start fieldlines_NCSX_s1.h5 114 -backflow
+	@echo ""
+
+test_fieldlines_coll_acc: FIELDLINES_TEST/fieldlines_NCSX_s1.h5
 	@echo $(MPI_RUN) $(MPI_RUN_OPTS_MD) $(MYHOME)/xfieldlines -vmec NCSX_s1_coll -coil coils.NCSX -vac -vessel NCSX_wall_trimesh_acc0.25v4.dat -hitonly -field_start fieldlines_NCSX_s1.h5 114
 	@cd $(FIELDLINES_TEST_DIR); $(MPI_RUN) $(MPI_RUN_OPTS_MD) $(MYHOME)/xfieldlines -vmec NCSX_s1_coll -vac -coil coils.NCSX -vac -vessel NCSX_wall_trimesh_acc0.25v4.dat -hitonly -field_start fieldlines_NCSX_s1.h5 114
 	@echo ""
 
-test_fieldlines_coll_ef: fieldlines_NCSX_s1.h5
+test_fieldlines_coll_ef: FIELDLINES_TEST/fieldlines_NCSX_s1.h5
 	@echo $(MPI_RUN) $(MPI_RUN_OPTS_MD) $(MYHOME)/xfieldlines -vmec NCSX_s1_coll_ef -coil coils.NCSX_nfp1 -vac -vessel NCSX_wall_trimesh.dat -hitonly -field_start fieldlines_NCSX_s1.h5 114
 	@cd $(FIELDLINES_TEST_DIR); $(MPI_RUN) $(MPI_RUN_OPTS_MD) $(MYHOME)/xfieldlines -vmec NCSX_s1_coll_ef -vac -coil coils.NCSX_nfp1 -vac -vessel NCSX_wall_trimesh.dat -hitonly -field_start fieldlines_NCSX_s1.h5 114
 	@echo ""
 
-fieldlines_NCSX_s1.h5: test_fieldlines_full
+FIELDLINES_TEST/fieldlines_NCSX_s1.h5: 
+	@$(MAKE) test_fieldlines_full
 
 clean_test:
 	@cd $(VMEC_TEST_DIR); rm -f dcon* jxbout* mercier* threed1* parvmecinfo* wout*

--- a/FIELDLINES/FIELDLINES.dep
+++ b/FIELDLINES/FIELDLINES.dep
@@ -44,6 +44,16 @@ fieldlines_init.o: \
       fieldlines_lines.o
       
 
+fieldlines_init_backflow.o: \
+      ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
+      ../../LIBSTELL/$(LOCTYPE)/vmec_input.o \
+      ../../LIBSTELL/$(LOCTYPE)/mpi_params.o \
+      ../../LIBSTELL/$(LOCTYPE)/mpi_inc.o \
+      ../../LIBSTELL/$(LOCTYPE)/mpi_sharmem.o \
+      fieldlines_runtime.o \
+      fieldlines_lines.o
+      
+
 fmag_nag.o : \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
       fieldlines_grid.o \

--- a/FIELDLINES/FIELDLINES.dep
+++ b/FIELDLINES/FIELDLINES.dep
@@ -46,10 +46,10 @@ fieldlines_init.o: \
 
 fieldlines_init_backflow.o: \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
-      ../../LIBSTELL/$(LOCTYPE)/vmec_input.o \
       ../../LIBSTELL/$(LOCTYPE)/mpi_params.o \
       ../../LIBSTELL/$(LOCTYPE)/mpi_inc.o \
       ../../LIBSTELL/$(LOCTYPE)/mpi_sharmem.o \
+      ../../LIBSTELL/$(LOCTYPE)/wall_mod.o \
       fieldlines_runtime.o \
       fieldlines_lines.o
       

--- a/FIELDLINES/ObjectList
+++ b/FIELDLINES/ObjectList
@@ -1,4 +1,5 @@
 ObjectFiles = \
+fieldlines_init_backflow.o \
 fieldlines_init_errorfield.o \
 fieldlines_init_hint.o \
 fieldlines_init_fline.o \

--- a/FIELDLINES/Sources/fieldlines_follow.f90
+++ b/FIELDLINES/Sources/fieldlines_follow.f90
@@ -19,9 +19,8 @@
       USE vessel_mod
       USE fieldlines_runtime
       USE fieldlines_lines
-      USE fieldlines_grid, ONLY: phimin, phimax, delta_phi,&
-                                 BR_spl, BZ_spl, MU_spl, MODB_spl
-      USE wall_mod, ONLY: ihit_array, nface, wall_free
+      USE fieldlines_grid, ONLY: phimin, phimax, delta_phi
+      USE wall_mod, ONLY: ihit_array, nface
       USE mpi_params
       USE mpi_inc
 !-----------------------------------------------------------------------

--- a/FIELDLINES/Sources/fieldlines_follow.f90
+++ b/FIELDLINES/Sources/fieldlines_follow.f90
@@ -34,7 +34,6 @@
 !          ier          Error flag
 !          l            Dummy index
 !          neqs_nag     Number of ODE's to solve (not limited to NAG routines)
-!          l2           Index helper
 !          itol         LSODE tolerance flag
 !          itask        LSODE flag (overshoot and interpolate)  
 !          istate       LSODE restart flag
@@ -42,7 +41,7 @@
       IMPLICIT NONE
       INTEGER,ALLOCATABLE :: mnum(:)
       INTEGER :: mystart,mypace, i
-      INTEGER     :: ier, l, neqs_nag, l2, itol, itask, &
+      INTEGER     :: ier, l, neqs_nag, itol, itask, &
                      istate, iopt, lrw, liw, mf
       INTEGER, ALLOCATABLE :: iwork(:)
       INTEGER :: MPI_COMM_LOCAL
@@ -83,7 +82,7 @@
       mf=21
 
       ! Break up the Work
-      CALL MPI_CALC_MYRANGE(MPI_COMM_FIELDLINES,1, nlines, mystart, myend)
+      CALL MPI_CALC_MYRANGE(MPI_COMM_FIELDLINES, 1, nlines, mystart, myend)
 
       ! Set the helper arrays
       IF (lhitonly) nsteps=2
@@ -151,7 +150,7 @@
                   dphi = SIGN(dphi,phi_end(l)-phi_start(l))  ! This should work 
                   ier     = 1
                   myline  = l
-                  myldex  = 0
+                  myldex  = ldex_default
                   CALL D02CJF(phi_nag,phif_nag,neqs_nag,q,fblin_nag,tol_nag,relab,out_fieldlines_nag,D02CJW,w,ier)
                   IF (ier < 0) CALL handle_err(D02CJF_ERR,'fieldlines_follow',ier)
                END DO
@@ -167,8 +166,7 @@
                   phi_nag = phi_start(l)
                   ier     = 0
                   myline  = l
-                  l2 = 0
-                  myldex  = 0
+                  myldex  = ldex_default
                   dphi = SIGN(dphi,phi_end(l)-phi_start(l))  ! This should work 
                   CALL out_fieldlines_nag(phi_nag,q)
                   phi_nag = phi_start(l)             ! Because out_fieldlines_nag increments phi_nag
@@ -203,14 +201,18 @@
                   ! Setup LSODE parameters
                   w = 0; iwork = 0; itask = 1; istate = 1;
                   myline  = l
-                  myldex  = 0
+                  myldex  = ldex_default
                   ier     = 0
-                  l2 = 0
                   q(1)    = R_start(l)
                   q(2)    = Z_start(l)
                   phi_nag = phi_start(l)
                   phif_nag = phi_start(l)
                   dphi = SIGN(dphi,phi_end(l)-phi_start(l))  ! This should work 
+                  IF (ldex_default==1) THEN
+                     xlast = q(1)*cos(phi_nag)
+                     ylast = q(1)*sin(phi_nag)
+                     zlast = q(2)
+                  END IF
                   DO 
                      IF (lmu) istate = 1
                      CALL DLSODE(fblin_lsode,neqs_nag,q,phi_nag,phif_nag,itol,rtol,atol,itask,istate,&

--- a/FIELDLINES/Sources/fieldlines_init.f90
+++ b/FIELDLINES/Sources/fieldlines_init.f90
@@ -68,7 +68,6 @@
          CALL wall_dump('test',ier)
       END IF
 
-
       ! Limit what the user can do
       IF (laxis_i .and. .not.lvac) lvac = .true.
       

--- a/FIELDLINES/Sources/fieldlines_init_backflow.f90
+++ b/FIELDLINES/Sources/fieldlines_init_backflow.f90
@@ -1,0 +1,112 @@
+!-----------------------------------------------------------------------
+!     Module:        fieldlines_init_backflow
+!     Authors:       S. Lazerson (samuel.lazerson@ipp.mpg.de)
+!     Date:          04/27/2021
+!     Description:   This subroutine sets up running the fieldlines in
+!                    reverse after wall hits. 
+!                    First the code allocates twice the number of
+!                    fieldlines it needs, but only uses the first half
+!                    We then store those results, overwrite them with
+!                    the reverse trace and then sort everything out
+!                    after calling follow a second time.
+!-----------------------------------------------------------------------
+      SUBROUTINE fieldlines_init_backflow
+!-----------------------------------------------------------------------
+!     Libraries
+!-----------------------------------------------------------------------
+      USE stel_kinds, ONLY: rprec
+      USE fieldlines_runtime
+      USE fieldlines_lines
+      USE mpi_sharmem
+      USE mpi_params
+      USE mpi_inc
+!-----------------------------------------------------------------------
+!     Local Variables
+!          ier            Error Flag
+!          iunit          File ID Number
+!-----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER :: MPI_COMM_LOCAL
+      INTEGER :: mystart, mynewstart, mynewend, i, &
+                 win_R_local, win_Z_local, win_phis_local, win_phie_local
+
+      REAL(rprec), POINTER :: R_local(:), Z_local(:), phis_local(:), &
+                              phie_local(:)
+!-----------------------------------------------------------------------
+!     Begin Subroutine
+!-----------------------------------------------------------------------
+      ! If not lhitonly get out of here
+      IF (.not. lhitonly) THEN
+         IF (lverb) WRITE(6,'(A)') '!!!!! Backtrace only with lhitonly!!!!!!!'
+         RETURN
+      END IF
+
+      ! Divide up the work
+      CALL MPI_CALC_MYRANGE(MPI_COMM_FIELDLINES,1, nlines, mystart, myend)
+
+      ! Allocate the local variables
+      CALL mpialloc(R_local, nlines*2, myid_sharmem, 0, MPI_COMM_SHARMEM, win_R_local)
+      CALL mpialloc(Z_local, nlines*2, myid_sharmem, 0, MPI_COMM_SHARMEM, win_Z_local)
+      CALL mpialloc(phis_local, nlines*2, myid_sharmem, 0, MPI_COMM_SHARMEM, win_phis_local)
+      CALL mpialloc(phie_local, nlines*2, myid_sharmem, 0, MPI_COMM_SHARMEM, win_phie_local)
+
+      ! Overwrite and start a new run (note _lines will be deallocated)
+      IF (lhitonly) THEN
+         ! These are the reruns of the hit
+         R_local(mystart:myend)    =  R_lines(mystart:myend,0)
+         Z_local(mystart:myend)    =  Z_lines(mystart:myend,0)
+         phis_local(mystart:myend) =  PHI_lines(mystart:myend,0)
+         phie_local(mystart:myend) =  PHI_lines(mystart:myend,2)
+         ! Now load the back trace
+         ! We use the zero point to avoid hitting the wall
+         mynewstart = mystart + nlines
+         mynewend   = myend   + nlines
+         R_local(mynewstart:mynewend)      =  R_lines(mystart:myend,0)
+         Z_local(mynewstart:mynewend)      =  R_lines(mystart:myend,0)
+         phis_local(mynewstart:mynewend)   =  PHI_lines(mystart:myend,0)
+         phie_local(mynewstart:mynewend)   = -PHI_end(mystart:myend)
+      ELSE
+         PRINT *,'lhitonly must be active'
+      END IF
+
+      ! Now we exchange data
+      i = MPI_UNDEFINED
+      IF (myid_sharmem == master) i = 0
+      CALL MPI_COMM_SPLIT( MPI_COMM_FIELDLINES,i,myworkid,MPI_COMM_LOCAL,ierr_mpi)
+      IF (myid_sharmem == master) THEN
+         CALL MPI_ALLREDUCE(MPI_IN_PLACE,R_local,nlines*2,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_ALLREDUCE(MPI_IN_PLACE,Z_local,nlines*2,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_ALLREDUCE(MPI_IN_PLACE,phis_local,nlines*2,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_ALLREDUCE(MPI_IN_PLACE,phie_local,nlines*2,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_COMM_FREE(MPI_COMM_LOCAL,ierr_mpi)
+      END IF
+      CALL MPI_BARRIER(MPI_COMM_FIELDLINES, ierr_mpi)
+
+      ! Restore data
+      R_start = R_local
+      Z_start = Z_local
+      PHI_start = phis_local
+      PHI_end   = phie_local
+
+      ! now deallocate the helpers
+      IF (ASSOCIATED(R_local))    CALL mpidealloc(R_local,    win_R_local)
+      IF (ASSOCIATED(Z_local))    CALL mpidealloc(Z_local,    win_Z_local)
+      IF (ASSOCIATED(phis_local)) CALL mpidealloc(phis_local, win_phis_local)
+      IF (ASSOCIATED(phie_local)) CALL mpidealloc(phie_local, win_phie_local)
+
+      ! Change some things to get it right
+      lmu = .FALSE. ! Turns off diffusion
+      nlines = nlines*2 ! Twice the number of lines
+      ldex_default = 1
+
+      ! Now run the reverse trace
+      CALL fieldlines_follow
+
+      ! Reset a thing or two
+      lmu = .TRUE.
+
+
+!-----------------------------------------------------------------------
+!     End Subroutine
+!-----------------------------------------------------------------------    
+      END SUBROUTINE fieldlines_init_backflow

--- a/FIELDLINES/Sources/fieldlines_init_backflow.f90
+++ b/FIELDLINES/Sources/fieldlines_init_backflow.f90
@@ -17,6 +17,7 @@
       USE stel_kinds, ONLY: rprec
       USE fieldlines_runtime
       USE fieldlines_lines
+      USE wall_mod, ONLY: ihit_array, nface
       USE mpi_sharmem
       USE mpi_params
       USE mpi_inc
@@ -98,8 +99,10 @@
       lmu = .FALSE. ! Turns off diffusion
       nlines = nlines*2 ! Twice the number of lines
       ldex_default = 1
+      IF (myid_sharmem == master) ihit_array = 0 ! reset it to zero
 
       ! Now run the reverse trace
+      IF (lverb) WRITE(6,'(A)') '===========BackFlow of Wall Hits=========='
       CALL fieldlines_follow
 
       ! Reset a thing or two

--- a/FIELDLINES/Sources/fieldlines_init_backflow.f90
+++ b/FIELDLINES/Sources/fieldlines_init_backflow.f90
@@ -67,15 +67,15 @@
          R_local(mystart:myend)    =  R_lines(mystart:myend,0)
          Z_local(mystart:myend)    =  Z_lines(mystart:myend,0)
          phis_local(mystart:myend) =  PHI_lines(mystart:myend,0)
-         phie_local(mystart:myend) =  PHI_lines(mystart:myend,2)
+         phie_local(mystart:myend) =  phi_end(mystart:myend)
          ! Now load the back trace
          ! We use the zero point to avoid hitting the wall
          mynewstart = mystart + nlines
          mynewend   = myend   + nlines
          R_local(mynewstart:mynewend)      =  R_lines(mystart:myend,0)
-         Z_local(mynewstart:mynewend)      =  R_lines(mystart:myend,0)
+         Z_local(mynewstart:mynewend)      =  Z_lines(mystart:myend,0)
          phis_local(mynewstart:mynewend)   =  PHI_lines(mystart:myend,0)
-         phie_local(mynewstart:mynewend)   =  PHI_lines(mystart:myend,0)-PHI_end(mystart:myend)
+         phie_local(mynewstart:mynewend)   =  PHI_lines(mystart:myend,0)-phi_end(mystart:myend)
       ELSE
          PRINT *,'lhitonly must be active'
       END IF

--- a/FIELDLINES/Sources/fieldlines_init_backflow.f90
+++ b/FIELDLINES/Sources/fieldlines_init_backflow.f90
@@ -65,7 +65,7 @@
          R_local(mynewstart:mynewend)      =  R_lines(mystart:myend,0)
          Z_local(mynewstart:mynewend)      =  R_lines(mystart:myend,0)
          phis_local(mynewstart:mynewend)   =  PHI_lines(mystart:myend,0)
-         phie_local(mynewstart:mynewend)   = -PHI_end(mystart:myend)
+         phie_local(mynewstart:mynewend)   =  PHI_lines(mystart:myend,0)-PHI_end(mystart:myend)
       ELSE
          PRINT *,'lhitonly must be active'
       END IF

--- a/FIELDLINES/Sources/fieldlines_init_vars.f90
+++ b/FIELDLINES/Sources/fieldlines_init_vars.f90
@@ -50,6 +50,7 @@
       vessel_string = ''
       restart_string = ''
       line_select = 96
+      ldex_default = 0
       
       RETURN
 !-----------------------------------------------------------------------

--- a/FIELDLINES/Sources/fieldlines_main.f90
+++ b/FIELDLINES/Sources/fieldlines_main.f90
@@ -166,6 +166,8 @@
                case ("-full")
                    nruntype = runtype_full
                    lauto = .true.
+               case ("-backflow")
+                   nruntype = runtype_backflow
                case ("-field_start")
                    lfield_start = .true.
                    i = i + 1
@@ -194,6 +196,7 @@
                   write(6,*)'     -vac           Only vacuum field'
                   write(6,*)'     -plasma        Only Plasma field (in equilibrium)'
                   write(6,*)'     -reverse       Follow field backwards'
+                  write(6,*)'     -backflow      Follow wall hits in reverse'
                   write(6,*)'     -auto          Auto calculate starting points'
                   write(6,*)'     -edge          Auto calculate starting points (from VMEC edge)'
                   write(6,*)'     -field         Output B-Field on Grid (no fieldlines)'
@@ -333,6 +336,9 @@
             CALL fieldlines_follow  ! This call on subgrid grid
             !CALL fieldlines_periodic_orbits  ! This call on subgrid grid
             !IF (lverb) CALL fieldlines_calc_surface_fit(25)
+         CASE(runtype_backflow)
+            CALL fieldlines_follow
+            CALL fieldlines_init_backflow
          CASE(runtype_norun)
       END SELECT
       ! Output Date

--- a/FIELDLINES/Sources/fieldlines_main.f90
+++ b/FIELDLINES/Sources/fieldlines_main.f90
@@ -337,6 +337,7 @@
             !CALL fieldlines_periodic_orbits  ! This call on subgrid grid
             !IF (lverb) CALL fieldlines_calc_surface_fit(25)
          CASE(runtype_backflow)
+            IF (lverb) WRITE(6,'(A)') '===========Wall Hits=========='
             CALL fieldlines_follow
             CALL fieldlines_init_backflow
          CASE(runtype_norun)

--- a/FIELDLINES/Sources/fieldlines_runtime.f90
+++ b/FIELDLINES/Sources/fieldlines_runtime.f90
@@ -116,8 +116,9 @@
       INTEGER, PARAMETER ::  runtype_advanced  = 1
       INTEGER, PARAMETER ::  runtype_full      = 327
       INTEGER, PARAMETER ::  runtype_norun     = 328
+      INTEGER, PARAMETER ::  runtype_backflow  = 329
       
-      INTEGER, PARAMETER ::  MAXLINES   = 2**18
+      INTEGER, PARAMETER ::  MAXLINES   = 2**19
       INTEGER, PARAMETER ::  NLOCAL = 128  ! Number of local processors
       
       LOGICAL         :: lverb, lvmec, lpies, lspec, lcoil, lmgrid, &
@@ -127,7 +128,7 @@
                          lerror_field, lwall_trans, ledge_start, lnescoil,&
                          lmodb, lfield_start, lhint, lpres
       INTEGER         :: nextcur, npoinc, nruntype, num_hcp, &
-                         nprocs_fieldlines, line_select
+                         nprocs_fieldlines, line_select, ldex_default
       REAL(rprec)     :: mu, dphi, follow_tol, pi, pi2, mu0, delta_hc, &
                          iota0
       REAL(rprec), DIMENSION(20)           :: errorfield_amp, errorfield_phase


### PR DESCRIPTION
A new feature has been added to the FIELDLINES code which allows reverse flow when conducting field line diffusion calculations.  The general idea is that once a field line diffusion marker hits a wall element, that same marker then is then traced backwards without diffusion till it hits the wall.  The general idea is that there are co- and counter propagating flows in the SOL.  This feature (invoked with the `-backflow` command line option) is not implemented in the FIELDLINES code.