### PR TITLE
[FIELDLINES] initialize geometry arrays

### DIFF
--- a/FIELDLINES/Sources/fieldlines_init_vmec.f90
+++ b/FIELDLINES/Sources/fieldlines_init_vmec.f90
@@ -164,6 +164,16 @@
             xm_temp = xm_nyq
             xn_temp = -xn_nyq/nfp  ! Because init_virtual_casing uses (mu+nv) not (mu-nv*nfp)
             IF(lverb) WRITE(6,'(A)')        '   NYQUIST DETECTED IN WOUT FILE!'
+            
+            ! Only non-Nyquist elements will be set in loops below, so zero out full array initially.
+            ! This prevents uninitialized array contents messing up the computation.
+            rmnc_temp = zero
+            zmns_temp = zero
+            if (lasym) then
+               rmns_temp = zero
+               zmnc_temp = zero
+            end if
+            
             DO u = 1,mnmax_temp
                DO v = 1, mnmax
                   IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN


### PR DESCRIPTION
The geometry coefficients `rmnc`, `zmns`, ... are always non-Nyquist-sized in the VMEC output. I assume they are copied into Nyquist-sized arrays here in order to be able to use only one inv-Fourier-transform routine (`mntouv_local`), working on Nyquist-sized arrays. In this case, the target arrays `rmnc_temp`, ... need to be zeroed initially, since only a subset of their entries are set from the VMEC output. All other (currently non-initialized) entries potentially contain garbage data, which, without these changes, enters (and potentially messes up) the calculation.