### PR TITLE
Feature/BEAMS3D max S

### DIFF
--- a/BEAMS3D/Sources/beams3d_grid.f90
+++ b/BEAMS3D/Sources/beams3d_grid.f90
@@ -54,7 +54,8 @@
       REAL(rprec) :: rmin, rmax, zmin, zmax, phimin, phimax, tmin, tmax, delta_t, &
                      vc_adapt_tol, psiedge_eq, phiedge_eq, plasma_Zmean, plasma_mass, &
                      reff_eq, therm_factor, B_kick_min, B_kick_max, &
-                     E_kick, freq_kick, t_fida, rho_fullorbit, rho_help
+      E_kick, freq_kick, t_fida, rho_fullorbit, rho_help,&
+      s_max,s_max_te, s_max_ne,s_max_zeff,s_max_ti, s_max_pot
       REAL(rprec), POINTER :: raxis(:), zaxis(:), phiaxis(:)
       REAL(rprec), POINTER :: req_axis(:), zeq_axis(:)
       REAL :: rmin_fida, rmax_fida, zmin_fida, zmax_fida, phimin_fida, phimax_fida, emin_fida, pimin_fida

--- a/BEAMS3D/Sources/beams3d_init.f90
+++ b/BEAMS3D/Sources/beams3d_init.f90
@@ -193,7 +193,7 @@
             CALL EZspline_setup(TE_spl_s,TE_AUX_F(1:nte),ier,EXACT_DIM=.true.)
             IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'beams3d_init2',ier)
          IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4,A,F8.5)') '   Te   = [', &
-            MINVAL(TE_AUX_F(1:nte))*1E-3,',',MAXVAL(TE_AUX_F(1:nte))*1E-3,'] keV;  NTE:   ',nte, ';  S_MAX_TI: ',s_max_te
+            MINVAL(TE_AUX_F(1:nte))*1E-3,',',MAXVAL(TE_AUX_F(1:nte))*1E-3,'] keV;  NTE:   ',nte, ';  S_MAX_TE: ',s_max_te
          END IF
          ! TI
          IF (nti>0) THEN

--- a/BEAMS3D/Sources/beams3d_init.f90
+++ b/BEAMS3D/Sources/beams3d_init.f90
@@ -219,7 +219,7 @@
             NE_spl_s%isHermite   = 0
              CALL EZspline_setup(NE_spl_s,NE_AUX_F(1:nne),ier,EXACT_DIM=.true.)
             IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'beams3d_init6',ier)
-         IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4,A,A,F8.5)') '   Ne   = [', &
+         IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4,A,F8.5)') '   Ne   = [', &
             MINVAL(NE_AUX_F(1:nne))*1E-20,',',MAXVAL(NE_AUX_F(1:nne))*1E-20,'] E20 m^-3;  NNE:   ',nne, ';  S_MAX_NE: ',s_max_ne
          END IF
          ! NION

--- a/BEAMS3D/Sources/beams3d_init.f90
+++ b/BEAMS3D/Sources/beams3d_init.f90
@@ -192,8 +192,8 @@
             TE_spl_s%x1          = TE_AUX_S(1:nte)
             CALL EZspline_setup(TE_spl_s,TE_AUX_F(1:nte),ier,EXACT_DIM=.true.)
             IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'beams3d_init2',ier)
-            IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4)') '   Te   = [', &
-                        MINVAL(TE_AUX_F(1:nte))*1E-3,',',MAXVAL(TE_AUX_F(1:nte))*1E-3,'] keV;  NTE:   ',nte
+         IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4,A,F8.5)') '   Te   = [', &
+            MINVAL(TE_AUX_F(1:nte))*1E-3,',',MAXVAL(TE_AUX_F(1:nte))*1E-3,'] keV;  NTE:   ',nte, ';  S_MAX_TI: ',s_max_te
          END IF
          ! TI
          IF (nti>0) THEN
@@ -203,8 +203,8 @@
             TI_spl_s%x1          = TI_AUX_S(1:nti)
             CALL EZspline_setup(TI_spl_s,TI_AUX_F(1:nti),ier,EXACT_DIM=.true.)
             IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'beams3d_init4',ier)
-            IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4)') '   Ti   = [', &
-                        MINVAL(TI_AUX_F(1:nti))*1E-3,',',MAXVAL(TI_AUX_F(1:nti))*1E-3,'] keV;  NTI:   ',nti
+         IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4,A,F8.5)') '   Ti   = [', &
+            MINVAL(TI_AUX_F(1:nti))*1E-3,',',MAXVAL(TI_AUX_F(1:nti))*1E-3,'] keV;  NTI:   ',nti, ';  S_MAX_TI: ',s_max_ti
          END IF
          ! NE
          IF (nne>0) THEN
@@ -219,8 +219,8 @@
             NE_spl_s%isHermite   = 0
              CALL EZspline_setup(NE_spl_s,NE_AUX_F(1:nne),ier,EXACT_DIM=.true.)
             IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'beams3d_init6',ier)
-            IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4,A)') '   Ne   = [', &
-                        MINVAL(NE_AUX_F(1:nne))*1E-20,',',MAXVAL(NE_AUX_F(1:nne))*1E-20,'] E20 m^-3;  NNE:   ',nne
+         IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4,A,A,F8.5)') '   Ne   = [', &
+            MINVAL(NE_AUX_F(1:nne))*1E-20,',',MAXVAL(NE_AUX_F(1:nne))*1E-20,'] E20 m^-3;  NNE:   ',nne, ';  S_MAX_NE: ',s_max_ne
          END IF
          ! NION
          DO i = 1, NION
@@ -231,9 +231,9 @@
             NI_spl_s(i)%isHermite   = 0
             CALL EZspline_setup(NI_spl_s(i),NI_AUX_F(i,1:k),ier,EXACT_DIM=.true.)
             IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'beams3d_init10b',ier)
-            IF (lverb .and. ANY(NI_AUX_F(i,:)>0)) WRITE(6,'(A,I1,A,F9.5,A,F9.5,A,I3,A,I2)') '   Ni(',i,')= [', &
+         IF (lverb .and. ANY(NI_AUX_F(i,:)>0)) WRITE(6,'(A,I1,A,F9.5,A,F9.5,A,I3,A,I2,A,F8.5)') '   Ni(',i,')= [', &
                         MINVAL(NI_AUX_F(i,1:k))*1E-20,',',MAXVAL(NI_AUX_F(i,1:k))*1E-20,'] E20 m^-3;  M: ',&
-                        NINT(NI_AUX_M(i)/1.66053906660E-27),' amu;  Z: ',NI_AUX_Z(i)
+            NINT(NI_AUX_M(i)/1.66053906660E-27),' amu;  Z: ',NI_AUX_Z(i), ';  S_MAX_NI: ',s_max_zeff
          END DO
          ! ZEFF
          IF (nzeff>0) THEN
@@ -243,8 +243,8 @@
             ZEFF_spl_s%x1          = ZEFF_AUX_S(1:nzeff)
             CALL EZspline_setup(ZEFF_spl_s,ZEFF_AUX_F(1:nzeff),ier,EXACT_DIM=.true.)
             IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'beams3d_init8',ier)
-            IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4)') '   Zeff = [', &
-                        MINVAL(ZEFF_AUX_F(1:nzeff)),',',MAXVAL(ZEFF_AUX_F(1:nzeff)),'];  NZEFF: ',nzeff
+         IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4,A,F8.5)') '   Zeff = [', &
+            MINVAL(ZEFF_AUX_F(1:nzeff)),',',MAXVAL(ZEFF_AUX_F(1:nzeff)),'];  NZEFF: ',nzeff, ';  S_MAX_ZEFF: ',s_max_zeff
          END IF
          ! POTENTIAL
          IF (npot>0) THEN
@@ -254,8 +254,8 @@
             POT_spl_s%isHermite   = 0
             CALL EZspline_setup(POT_spl_s,POT_AUX_F(1:npot),ier,EXACT_DIM=.true.)
             IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'beams3d_init10',ier)
-            IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4)') '   V    = [', &
-                        MINVAL(POT_AUX_F(1:npot))*1E-3,',',MAXVAL(POT_AUX_F(1:npot))*1E-3,'] kV;  NPOT: ',npot
+         IF (lverb) WRITE(6,'(A,F9.5,A,F9.5,A,I4,A,F8.5)') '   V    = [', &
+            MINVAL(POT_AUX_F(1:npot))*1E-3,',',MAXVAL(POT_AUX_F(1:npot))*1E-3,'] kV;  NPOT: ',npot, ';  S_MAX_POT: ',s_max_pot
          END IF
 
          IF (lverb) THEN

--- a/BEAMS3D/Sources/beams3d_init_eqdsk.f90
+++ b/BEAMS3D/Sources/beams3d_init_eqdsk.f90
@@ -179,17 +179,17 @@
          IF (uflx<0)  uflx = uflx+pi2
          U_ARR(i,:,k)=uflx
 
-         IF (sflx <= 1) THEN
-            tetemp = 0; netemp = 0; titemp=0; pottemp=0; zetemp=0
-            IF (nte > 0) CALL EZspline_interp(TE_spl_s,sflx,tetemp,ier)
-            IF (nne > 0) CALL EZspline_interp(NE_spl_s,sflx,netemp,ier)
-            IF (nti > 0) CALL EZspline_interp(TI_spl_s,sflx,titemp,ier)
-            IF (npot > 0) CALL EZspline_interp(POT_spl_s,sflx,pottemp,ier)
-            !IF (nzeff > 0) CALL EZspline_interp(ZEFF_spl_s,sflx,zetemp,ier)
-            IF (nzeff > 0) THEN 
-               CALL EZspline_interp(ZEFF_spl_s,sflx,zetemp,ier)
-               DO u=1, NION
-                  CALL EZspline_interp(NI_spl_s(u),sflx,nitemp,ier)
+      IF (sflx <= s_max) THEN
+         tetemp = 0; netemp = 0; titemp=0; pottemp=0; zetemp=0
+         IF (nte > 0) CALL EZspline_interp(TE_spl_s,MIN(sflx,s_max_te),tetemp,ier)
+         IF (nne > 0) CALL EZspline_interp(NE_spl_s,MIN(sflx,s_max_ne),netemp,ier)
+         IF (nti > 0) CALL EZspline_interp(TI_spl_s,MIN(sflx,s_max_ti),titemp,ier)
+         IF (npot > 0) CALL EZspline_interp(POT_spl_s,MIN(sflx,s_max_pot),pottemp,ier)
+         !IF (nzeff > 0) CALL EZspline_interp(ZEFF_spl_s,sflx,zetemp,ier)
+         IF (nzeff > 0) THEN
+            CALL EZspline_interp(ZEFF_spl_s,MIN(sflx,s_max_zeff),zetemp,ier)
+            DO u=1, NION
+               CALL EZspline_interp(NI_spl_s(u),MIN(sflx,s_max_zeff),nitemp,ier)
                   NI(u,i,:,k)=nitemp
                END DO
             END IF
@@ -240,6 +240,8 @@
          CALL backspace_out(6,36)
          WRITE(6,*)
          CALL FLUSH(6)
+      END IF    
+   END IF
       END IF    
 
       ! Fix ZEFF

--- a/BEAMS3D/Sources/beams3d_init_eqdsk.f90
+++ b/BEAMS3D/Sources/beams3d_init_eqdsk.f90
@@ -25,7 +25,8 @@
                                  nte, nne, nti, TE, NE, TI, Vp_spl_s, S_ARR,&
                                  U_ARR, POT_ARR, POT_spl_s, nne, nte, nti, npot, &
                                  ZEFF_spl_s, nzeff, ZEFF_ARR, req_axis, zeq_axis, &
-                                 phiedge_eq, reff_eq, NI_spl_s, NI
+                                 phiedge_eq, reff_eq, NI_spl_s, NI,&
+                                 s_max,s_max_te, s_max_ne,s_max_zeff,s_max_ti, s_max_pot
       USE beams3d_lines, ONLY: GFactor, ns_prof1
       USE wall_mod, ONLY: wall_load_seg
       USE mpi_params
@@ -191,15 +192,15 @@
             DO u=1, NION
                CALL EZspline_interp(NI_spl_s(u),MIN(sflx,s_max_zeff),nitemp,ier)
                   NI(u,i,:,k)=nitemp
-               END DO
-            END IF
+            END DO
+         END IF
             NE(i,:,k) = netemp; TE(i,:,k) = tetemp; TI(i,:,k) = titemp
             POT_ARR(i,:,k) = pottemp; ZEFF_ARR(i,:,k) = zetemp
-         ELSE
-            pottemp = 0; sflx = 1
-            IF (npot > 0) CALL EZspline_interp(POT_spl_s,sflx,pottemp,ier)
-            POT_ARR(i,:,k) = pottemp
-         END IF
+      ELSE
+         pottemp = 0; sflx = 1
+         IF (npot > 0) CALL EZspline_interp(POT_spl_s,sflx,pottemp,ier)
+         POT_ARR(i,:,k) = pottemp
+      END IF
          IF (MOD(s,nr) == 0) THEN
             IF (lverb) THEN
                CALL backspace_out(6,6)
@@ -240,9 +241,7 @@
          CALL backspace_out(6,36)
          WRITE(6,*)
          CALL FLUSH(6)
-      END IF    
-   END IF
-      END IF    
+      END IF     
 
       ! Fix ZEFF
       IF (mylocalid == mylocalmaster) WHERE(ZEFF_ARR < 1) ZEFF_ARR = 1

--- a/BEAMS3D/Sources/beams3d_init_fieldlines.f90
+++ b/BEAMS3D/Sources/beams3d_init_fieldlines.f90
@@ -18,7 +18,8 @@
                                  nte, nne, nti, TE, NE, TI, Vp_spl_s, S_ARR,&
                                  U_ARR, POT_ARR, POT_spl_s, nne, nte, nti, npot, &
                                  ZEFF_spl_s, nzeff, ZEFF_ARR, req_axis, zeq_axis, &
-                                 phiedge_eq, reff_eq, NI_spl_s, NI
+                                 phiedge_eq, reff_eq, NI_spl_s, NI,&
+                                 s_max,s_max_te, s_max_ne,s_max_zeff,s_max_ti, s_max_pot
       USE beams3d_lines, ONLY: GFactor, ns_prof1
       USE read_fieldlines_mod, ONLY: get_fieldlines_grid, get_fieldlines_B, &
                                read_fieldlines_deallocate, setup_fieldlines_rhogrid, &
@@ -107,16 +108,16 @@
          S_ARR(i,j,k) = sflx
          U_ARR(i,j,k) = uflx
 
-         IF (sflx <= 1) THEN
+         IF (sflx <= s_max) THEN
             tetemp = 0; netemp = 0; titemp=0; pottemp=0; zetemp=0
-            IF (nte > 0) CALL EZspline_interp(TE_spl_s,sflx,tetemp,ier)
-            IF (nne > 0) CALL EZspline_interp(NE_spl_s,sflx,netemp,ier)
-            IF (nti > 0) CALL EZspline_interp(TI_spl_s,sflx,titemp,ier)
-            IF (npot > 0) CALL EZspline_interp(POT_spl_s,sflx,pottemp,ier)
+            IF (nte > 0) CALL EZspline_interp(TE_spl_s,MIN(sflx,s_max_te),tetemp,ier)
+            IF (nne > 0) CALL EZspline_interp(NE_spl_s,MIN(sflx,s_max_ne),netemp,ier)
+            IF (nti > 0) CALL EZspline_interp(TI_spl_s,MIN(sflx,s_max_ti),titemp,ier)
+            IF (npot > 0) CALL EZspline_interp(POT_spl_s,MIN(sflx,s_max_pot),pottemp,ier)
             IF (nzeff > 0) THEN 
-               CALL EZspline_interp(ZEFF_spl_s,sflx,ZEFF_ARR(i,j,k),ier)
+               CALL EZspline_interp(ZEFF_spl_s,MIN(sflx,s_max_zeff),ZEFF_ARR(i,j,k),ier)
                DO u=1, NION
-                  CALL EZspline_interp(NI_spl_s(u),sflx,NI(u,i,j,k),ier)
+                  CALL EZspline_interp(NI_spl_s(u),MIN(sflx,s_max_zeff),NI(u,i,j,k),ier)
                END DO
             END IF
             NE(i,j,k) = netemp; TE(i,j,k) = tetemp; TI(i,j,k) = titemp

--- a/BEAMS3D/Sources/beams3d_init_restartgrid.f90
+++ b/BEAMS3D/Sources/beams3d_init_restartgrid.f90
@@ -18,7 +18,8 @@ SUBROUTINE beams3d_init_restartgrid
       nte, nne, nti, TE, NE, TI, Vp_spl_s, S_ARR,&
       U_ARR, POT_ARR, POT_spl_s, nne, nte, nti, npot, &
       ZEFF_spl_s, nzeff, ZEFF_ARR, req_axis, zeq_axis, &
-      phiedge_eq, reff_eq, NI_spl_s, NI
+      phiedge_eq, reff_eq, NI_spl_s, NI,&
+      s_max,s_max_te, s_max_ne,s_max_zeff,s_max_ti, s_max_pot
    USE beams3d_lines, ONLY: GFactor, ns_prof1
    USE read_beams3d_mod, ONLY: get_beams3d_grid, get_beams3d_B, &
       read_beams3d_deallocate, &
@@ -105,16 +106,16 @@ SUBROUTINE beams3d_init_restartgrid
       S_ARR(i,j,k) = sflx
       U_ARR(i,j,k) = uflx
 
-      IF (sflx <= 1) THEN
+      IF (sflx < s_max) THEN
          tetemp = 0; netemp = 0; titemp=0; pottemp=0; zetemp=0
-         IF (nte > 0) CALL EZspline_interp(TE_spl_s,sflx,tetemp,ier)
-         IF (nne > 0) CALL EZspline_interp(NE_spl_s,sflx,netemp,ier)
-         IF (nti > 0) CALL EZspline_interp(TI_spl_s,sflx,titemp,ier)
-         IF (npot > 0) CALL EZspline_interp(POT_spl_s,sflx,pottemp,ier)
+         IF (nte > 0) CALL EZspline_interp(TE_spl_s,MIN(sflx,s_max_te),tetemp,ier)
+         IF (nne > 0) CALL EZspline_interp(NE_spl_s,MIN(sflx,s_max_ne),netemp,ier)
+         IF (nti > 0) CALL EZspline_interp(TI_spl_s,MIN(sflx,s_max_ti),titemp,ier)
+         IF (npot > 0) CALL EZspline_interp(POT_spl_s,MIN(sflx,s_max_pot),pottemp,ier)
          IF (nzeff > 0) THEN
-            CALL EZspline_interp(ZEFF_spl_s,sflx,ZEFF_ARR(i,j,k),ier)
+            CALL EZspline_interp(ZEFF_spl_s,MIN(sflx,s_max_zeff),ZEFF_ARR(i,j,k),ier)
             DO u=1, NION
-               CALL EZspline_interp(NI_spl_s(u),sflx,NI(u,i,j,k),ier)
+               CALL EZspline_interp(NI_spl_s(u),MIN(sflx,s_max_zeff),NI(u,i,j,k),ier)
             END DO
          END IF
          NE(i,j,k) = netemp; TE(i,j,k) = tetemp; TI(i,j,k) = titemp

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -24,7 +24,8 @@
                                  nte, nne, nti, TE, NE, TI, Vp_spl_s, S_ARR,&
                                  U_ARR, POT_ARR, POT_spl_s, nne, nte, nti, npot, &
                                  ZEFF_spl_s, nzeff, ZEFF_ARR, req_axis, zeq_axis, &
-                                 phiedge_eq, reff_eq, NI_spl_s, NI
+                                 phiedge_eq, reff_eq, NI_spl_s, NI,&
+                                 s_max,s_max_te, s_max_ne,s_max_zeff,s_max_ti, s_max_pot
       USE beams3d_lines, ONLY: GFactor, ns_prof1
       USE wall_mod, ONLY: wall_load_mn
       USE mpi_params

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -343,17 +343,17 @@
                B_Z(i,j,k)   = bz
                sflx = 1.5 ! Assume s=1 for lplasma_only
             END IF
-            IF (sflx <= 1) THEN
-               IF (nte > 0) CALL EZspline_interp(TE_spl_s,sflx,TE(i,j,k),ier)
-               IF (nne > 0) CALL EZspline_interp(NE_spl_s,sflx,NE(i,j,k),ier)
-               IF (nti > 0) CALL EZspline_interp(TI_spl_s,sflx,TI(i,j,k),ier)
-               IF (npot > 0) CALL EZspline_interp(POT_spl_s,sflx,POT_ARR(i,j,k),ier)
-               IF (nzeff > 0) THEN 
-                  CALL EZspline_interp(ZEFF_spl_s,sflx,ZEFF_ARR(i,j,k),ier)
-                  DO u=1, NION
-                     CALL EZspline_interp(NI_spl_s(u),sflx,NI(u,i,j,k),ier)
-                  END DO
-               END IF
+         IF (sflx <= s_max) THEN
+            IF (nte > 0) CALL EZspline_interp(TE_spl_s,MIN(sflx,s_max_te),TE(i,j,k),ier)
+            IF (nne > 0) CALL EZspline_interp(NE_spl_s,MIN(sflx,s_max_ne),NE(i,j,k),ier)
+            IF (nti > 0) CALL EZspline_interp(TI_spl_s,MIN(sflx,s_max_ti),TI(i,j,k),ier)
+            IF (nzeff > 0) THEN
+               CALL EZspline_interp(ZEFF_spl_s,MIN(sflx,s_max_zeff),ZEFF_ARR(i,j,k),ier)
+               DO u=1, NION
+                  CALL EZspline_interp(NI_spl_s(u),MIN(sflx,s_max_zeff),NI(u,i,j,k),ier)
+               END DO
+            END IF
+            IF (npot > 0) CALL EZspline_interp(POT_spl_s,MIN(sflx,s_max_pot),POT_ARR(i,j,k),ier)
             ELSE
                br = 1
                IF (npot > 0) CALL EZspline_interp(POT_spl_s,br,POT_ARR(i,j,k),ier)

--- a/BEAMS3D/Sources/beams3d_input_mod.f90
+++ b/BEAMS3D/Sources/beams3d_input_mod.f90
@@ -289,28 +289,27 @@
          END IF
          nte = 0
          DO WHILE ((TE_AUX_S(nte+1) >= 0.0).and.(nte<MAXPROFLEN))
+            s_max_te=TE_AUX_S(nte+1)
             nte = nte + 1
-         s_max_te=TE_AUX_S(nte+1)
          END DO
          nne = 0
          DO WHILE ((NE_AUX_S(nne+1) >= 0.0).and.(nne<MAXPROFLEN))
+            s_max_ne=NE_AUX_S(nne+1)
             nne = nne + 1
-         s_max_ne=NE_AUX_S(nne+1)
          END DO
          nti = 0
          DO WHILE ((TI_AUX_S(nti+1) >= 0.0).and.(nti<MAXPROFLEN))
+            s_max_ti=TI_AUX_S(nti+1)
             nti = nti + 1
-         s_max_ti=TI_AUX_S(nti+1)
          END DO
          nzeff = 0
          DO WHILE ((ZEFF_AUX_S(nzeff+1) >= 0.0).and.(nzeff<MAXPROFLEN))
             nzeff = nzeff + 1
-         s_max_zeff=ZEFF_AUX_S(nzeff+1)
          END DO
          npot = 0
          DO WHILE ((POT_AUX_S(npot+1) >= 0.0).and.(npot<MAXPROFLEN))
+            s_max_pot=POT_AUX_S(npot+1)
             npot = npot + 1
-         s_max_pot=POT_AUX_S(npot+1)
          END DO
 
          ! Handle multiple ion species
@@ -339,6 +338,7 @@
             END DO
             !WRITE(6,*) ' Tritium index: ',dexionT
             !WRITE(6,*) ' Deuturium index: ',dexionD
+            s_max_zeff=ZEFF_AUX_S(nzeff+1)
          ELSEIF (lfusion) THEN ! Assume 50/50 D T
             nzeff=nne
             NI_AUX_S = NE_AUX_S

--- a/BEAMS3D/Sources/beams3d_input_mod.f90
+++ b/BEAMS3D/Sources/beams3d_input_mod.f90
@@ -380,6 +380,7 @@
             NI_AUX_Z(1) = 1
             NI_AUX_M(1) = plasma_mass
          END IF
+      s_max_zeff=ZEFF_AUX_S(nzeff)
 
          nparticles = 0
          DO WHILE ((r_start_in(nparticles+1) >= 0.0).and.(nparticles<MAXPARTICLES))

--- a/BEAMS3D/Sources/beams3d_input_mod.f90
+++ b/BEAMS3D/Sources/beams3d_input_mod.f90
@@ -23,7 +23,8 @@
                               rmin_fida, rmax_fida, zmin_fida, zmax_fida, phimin_fida, phimax_fida, &
                               raxis_fida, zaxis_fida, phiaxis_fida, nr_fida, nphi_fida, nz_fida, &
                               nenergy_fida, npitch_fida, energy_fida, pitch_fida, t_fida, &
-                              dexionT, dexionD
+                              dexionT, dexionD,&
+                              s_max,s_max_te, s_max_ne,s_max_zeff,s_max_ti, s_max_pot
       USE safe_open_mod, ONLY: safe_open
       USE mpi_params
       USE mpi_inc
@@ -80,7 +81,7 @@
                                int_type, Adist_beams, Asize_beams, &
                                Div_beams, E_beams, Dex_beams, &
                                mass_beams, charge_beams, Zatom_beams, &
-                               r_beams, z_beams, phi_beams, TE_AUX_S, &
+      r_beams, z_beams, phi_beams, s_max, TE_AUX_S, &
                                TE_AUX_F, NE_AUX_S, NE_AUX_F, TI_AUX_S, &
                                TI_AUX_F, POT_AUX_S, POT_AUX_F, &
                                NI_AUX_S, NI_AUX_F, NI_AUX_Z, NI_AUX_M, &
@@ -147,6 +148,12 @@
       charge_beams = 0.0_rprec
       Zatom_beams = 1.0_rprec
       P_beams = 0.0_rprec
+      s_max = 1.0_rprec
+      s_max_te = 0.0_rprec
+      s_max_ti = 0.0_rprec
+      s_max_ne = 0.0_rprec
+      s_max_zeff = 0.0_rprec
+      s_max_pot = 0.0_rprec
       TE_AUX_S = -1
       TE_AUX_F = -1
       NE_AUX_S = -1
@@ -283,22 +290,27 @@
          nte = 0
          DO WHILE ((TE_AUX_S(nte+1) >= 0.0).and.(nte<MAXPROFLEN))
             nte = nte + 1
+         s_max_te=TE_AUX_S(nte+1)
          END DO
          nne = 0
          DO WHILE ((NE_AUX_S(nne+1) >= 0.0).and.(nne<MAXPROFLEN))
             nne = nne + 1
+         s_max_ne=NE_AUX_S(nne+1)
          END DO
          nti = 0
          DO WHILE ((TI_AUX_S(nti+1) >= 0.0).and.(nti<MAXPROFLEN))
             nti = nti + 1
+         s_max_ti=TI_AUX_S(nti+1)
          END DO
          nzeff = 0
          DO WHILE ((ZEFF_AUX_S(nzeff+1) >= 0.0).and.(nzeff<MAXPROFLEN))
             nzeff = nzeff + 1
+         s_max_zeff=ZEFF_AUX_S(nzeff+1)
          END DO
          npot = 0
          DO WHILE ((POT_AUX_S(npot+1) >= 0.0).and.(npot<MAXPROFLEN))
             npot = npot + 1
+         s_max_pot=POT_AUX_S(npot+1)
          END DO
 
          ! Handle multiple ion species
@@ -306,6 +318,7 @@
             nzeff = 0
             DO WHILE ((NI_AUX_S(nzeff+1) >= 0.0).and.(nzeff<MAXPROFLEN))
                nzeff = nzeff + 1
+            s_max_zeff=ZEFF_AUX_S(nzeff+1)
             END DO
             ! Now calc Zeff(1)
             DO i1 = 1, nzeff

--- a/BENCHMARKS/makefile
+++ b/BENCHMARKS/makefile
@@ -92,7 +92,6 @@ test_beams3d:
 	$(MAKE) test_beams3d_er
 	$(MAKE) test_beams3d_loss
 	$(MAKE) test_beams3d_slow
-	$(MAKE) test_beams3d_depo
 	@if [ -n "$(ADASDIR)" ]; then \
 		if [ -d $(ADASDIR) ]; then \
 			$(MAKE) test_beams3d_depo_adas;\


### PR DESCRIPTION
This implements functionality in BEAMS3D to be able to specify profiles for S>1. Each profile (ne, te, ti, ni, zeff, pot) can have different maximum S values. The global maximum S value is set by the new S_MAX parameter in the namelist and is defaulted to 1. The rest of the maximum values are determined from the profiles given in the namelist. This information is also printed in the terminal output.
Note that, as there is no nni parameter in BEAMS3D, there is also no s_max_ni. Instead, the length of the ion density profiles is the same as the zeff profile, so s_max_zeff is used instead.