### PR TITLE
BEAMS3D: Pointers nullified so ASSOCIATED statements work.

### DIFF
--- a/BEAMS3D/BEAMS3D.dep
+++ b/BEAMS3D/BEAMS3D.dep
@@ -11,6 +11,9 @@ beams3d_beam_density.o: \
 
 beams3d_interface_mod.o: \
       beams3d_input_mod.o \
+      beams3d_runtime.o \
+      beams3d_grid.o \
+      beams3d_lines.o \
       ../../LIBSTELL/$(LOCTYPE)/wall_mod.o \
       ../../LIBSTELL/$(LOCTYPE)/mpi_inc.o \
       ../../LIBSTELL/$(LOCTYPE)/mpi_params.o 

--- a/BEAMS3D/ObjectList
+++ b/BEAMS3D/ObjectList
@@ -1,4 +1,5 @@
 ObjectFiles = \
+beams3d_interface_mod.o \
 beams3d_beam_density.o \
 beams3d_duplicate_part.o \
 outpart_beams3d_nag.o \
@@ -6,7 +7,6 @@ beams3d_follow.o \
 beams3d_follow_fo.o \
 beams3d_init_fieldlines.o \
 beams3d_init_restartgrid.o \
-beams3d_interface_mod.o \
 beams3d_imas_module.o \
 fpart_nag.o \
 fpart_lsode.o \

--- a/BEAMS3D/Sources/beams3d_imas_module.f90
+++ b/BEAMS3D/Sources/beams3d_imas_module.f90
@@ -97,6 +97,9 @@ SUBROUTINE BEAMS3D_IMAS(IDS_EQ_IN, PROF_IN, MARKERS_IN, WALL_IN, DIST_OUT, INDAT
 
   !----  BEAMS3D MPI
   CALL beams3d_init_mpi
+  
+  !----  BEAMS3D Nullify pointers
+  CALL beams3d_init_pointers
 
   !----  BEAMS3D HDF5
   CALL beams3d_init_hdf5

--- a/BEAMS3D/Sources/beams3d_interface_mod.f90
+++ b/BEAMS3D/Sources/beams3d_interface_mod.f90
@@ -70,6 +70,20 @@ CONTAINS
 #endif
    END SUBROUTINE beams3d_init_mpi_split
 
+   SUBROUTINE beams3d_init_pointers
+   USE beams3d_grid
+   USE beams3d_lines
+   IMPLICIT NONE
+   ! Nullify pointers
+   NULLIFY(raxis,phiaxis,zaxis,hr,hp,hz,hri,hpi,hzi,B_R,B_PHI,B_Z, &
+            MODB,TE,NE,TI,ZEFF_ARR,POT_ARR,S_ARR,U_ARR,X_ARR,Y_ARR,NI, &
+            raxis_fida,zaxis_fida,phiaxis_fida,energy_fida,pitch_fida, &
+            req_axis,zeq_axis,TE4D,NE4D,TI4D,ZEFF4D,NI5D,BR4D,BPHI4D, &
+            BZ4D,MODB4D,S4D,U4D,X4D,Y4D,POT4D,dist5d_prof,dist5d_fida, &
+            BEAM_DENSITY)
+   END SUBROUTINE
+  
+
    SUBROUTINE beams3d_cleanup
       IMPLICIT NONE
       INTEGER :: ier

--- a/BEAMS3D/Sources/beams3d_interface_mod.f90
+++ b/BEAMS3D/Sources/beams3d_interface_mod.f90
@@ -80,7 +80,8 @@ CONTAINS
             raxis_fida,zaxis_fida,phiaxis_fida,energy_fida,pitch_fida, &
             req_axis,zeq_axis,TE4D,NE4D,TI4D,ZEFF4D,NI5D,BR4D,BPHI4D, &
             BZ4D,MODB4D,S4D,U4D,X4D,Y4D,POT4D,dist5d_prof,dist5d_fida, &
-            BEAM_DENSITY)
+            BEAM_DENSITY,wall_load,wall_shine, ndot_prof, epower_prof, &
+            ipower_prof,j_prof,dense_prof)
    END SUBROUTINE
   
 

--- a/BEAMS3D/Sources/beams3d_main.f90
+++ b/BEAMS3D/Sources/beams3d_main.f90
@@ -26,6 +26,9 @@ PROGRAM BEAMS3D
     ! Setup MPI
     CALL beams3d_init_mpi
 
+    ! Nullify pointers
+    CALL beams3d_init_pointers
+
     ! Setup HDF5
     CALL beams3d_init_hdf5
     ! Initialize constanst


### PR DESCRIPTION
This branch fixes an issue in BEASM3D due to the way Fortran handles pointers.  We use pointers to arrays to do allocation of shared memory through MPI.  However, Fortran does not automatically nullify pointers.  So when we call `ASSOCIATED` on the pointers, it returns true even if the pointer wants associated a shared memory. This chnage adds a routine where all pointers in the code can be nullified at the very beginning.  Should fix #200 and another undocumented bug regarding the output of the beam density.