### PR TITLE
BEAMS3D: fixed pointers in FIDASIM namelist part

### DIFF
--- a/BEAMS3D/Sources/beams3d_input_mod.f90
+++ b/BEAMS3D/Sources/beams3d_input_mod.f90
@@ -99,9 +99,8 @@
                                B_kick_min, B_kick_max, freq_kick, E_kick, &
                                rmin_fida, rmax_fida, zmin_fida, &
                                zmax_fida,phimin_fida, phimax_fida, &
-                               raxis_fida, zaxis_fida, phiaxis_fida, &
                                nr_fida, nphi_fida, nz_fida, nenergy_fida, &
-                               npitch_fida, energy_fida, pitch_fida, t_fida
+                               npitch_fida, t_fida
       
 !-----------------------------------------------------------------------
 !     Subroutines

--- a/LIBSTELL/Sources/Modules/read_wout_mod.f90
+++ b/LIBSTELL/Sources/Modules/read_wout_mod.f90
@@ -3095,6 +3095,7 @@
 
       mpol1 = mpol-1
       rcc = 1;  zsc = 1
+      zcs = 0; zcc =  0; zss = 0 ! 11.21.2023 - SAL  
       IF (.not.lasym) THEN
          IF (lthreed) THEN
             ntmax = 2

--- a/LIBSTELL/Sources/Modules/vmec_utils.f
+++ b/LIBSTELL/Sources/Modules/vmec_utils.f
@@ -763,6 +763,7 @@ C-----------------------------------------------
       dwmins(:,1:mpol1:2) = dwlo_odd
       dwplus(:,1:mpol1:2) = dwhi_odd
 
+      zcs = 0; zcc =  0; zss = 0 ! 11.21.2023 - SAL  
       IF (.not.lasym) THEN
          IF (lthreed) THEN
             IF (ntmax .ne. 2) STOP 'ntmax != 2 in flx2cyl!'


### PR DESCRIPTION
This removes pointer variables from the BEAMS3D namelist (for FIDASIM) which should never have been there in the first place.