### PR TITLE
Arch variable and gfortran>9

### DIFF
--- a/SHARE/make_ubuntu.inc
+++ b/SHARE/make_ubuntu.inc
@@ -2,6 +2,7 @@
 #            Define Basic Utilities
 #######################################################################
   SHELL = /bin/sh
+  ARCH := $(shell uname -m)
   PWD1 = `pwd`
   MYHOME = $(HOME)/bin
   PRECOMP:= /lib/cpp -traditional -DLINUX
@@ -15,10 +16,17 @@
 #            Define Compiler Flags
 #######################################################################
   FLAGS_R = -O2 -fexternal-blas -fbacktrace -fcheck=all,no-array-temps
-  FLAGS_D = -g -O0 -fexternal-blas -fbacktrace -fcheck=all 
+  FLAGS_D = -g -O0 -fexternal-blas -fbacktrace -fcheck=all
   LIBS    = -L/usr/lib -lblas -llapack -lscalapack-openmpi
   FLAGS_R += -Wno-argument-mismatch
   FLAGS_D += -Wno-argument-mismatch
+
+  # Need to allow argument mismatch for gfortran version 10 and above
+  GFORTRAN_VERSION := $(shell $(FC) -dumpversion)
+  ifeq "$(shell [ $(GFORTRAN_VERSION) -gt 9 ] && echo true)" "true"
+      FLAGS_R += -fallow-argument-mismatch
+      FLAGS_D += -fallow-argument-mismatch
+  endif
 
 #######################################################################
 #            MPI Options
@@ -62,7 +70,7 @@
 #######################################################################
   LHDF5 = T
   HDF5_INC = -I/usr/include/hdf5/openmpi
-  HDF5_LIB = -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi \
+  HDF5_LIB = -L/usr/lib/$(ARCH)-linux-gnu/hdf5/openmpi \
              -lhdf5 -lhdf5hl_fortran -lhdf5_hl -lhdf5_fortran
 
 #######################################################################
@@ -70,21 +78,21 @@
 #######################################################################
   LPGPLOT = F
   PGPLOT_INC = -I$(PGPLOT_DIR)
-  PGPLOT_LIB = -L$(PGPLOT_DIR) -lpgplot -L/usr/lib/x86_64-linux-gnu -lX11
+  PGPLOT_LIB = -L$(PGPLOT_DIR) -lpgplot -L/usr/lib/$(ARCH)-linux-gnu -lX11
 
 #######################################################################
 #             SILO Options
 #######################################################################
   LSILO = F
   SILO_INC = -I$(SILOHOME)/include
-  SILO_LIB = -L$(SILOHOME)/lib/x86_64-linux-gnu -lsiloh5
+  SILO_LIB = -L$(SILOHOME)/lib/$(ARCH)-linux-gnu -lsiloh5
 
 #######################################################################
 #            FFTW3 Options
 #######################################################################
   LFFTW3 = F
-  FFTW3_INC = 
-  FFTW3_LIB = 
+  FFTW3_INC =
+  FFTW3_LIB =
 
 #######################################################################
 #            DKES/NEO Options
@@ -113,7 +121,7 @@
   COILOPTPP_DIR = $(COILOPT_PATH)
   LIB_COILOPTPP = libcoilopt++.a
   COILOPT_LIB = $(COILOPT_PATH)/$(LIB_COILOPTPP) \
-                -L$(GSLHOME)/lib/x86_64-linux-gnu -lgsl -lgslcblas -lstdc++ -lmpi_cxx
+                -L$(GSLHOME)/lib/$(ARCH)-linux-gnu -lgsl -lgslcblas -lstdc++ -lmpi_cxx
 
 #######################################################################
 #            TERPSICHORE Options
@@ -139,7 +147,7 @@
 #######################################################################
   LREGCOIL= F
   REGCOIL_DIR = $(REGCOIL_PATH)
-  REGCOIL_INC = -I$(REGCOIL_DIR) 
+  REGCOIL_INC = -I$(REGCOIL_DIR)
   LIB_REGCOIL = libregcoil.a
   REGCOIL_LIB = $(REGCOIL_DIR)/$(LIB_REGCOIL) -fopenmp
 
@@ -148,7 +156,7 @@
 #######################################################################
   LAEOPT= F
   AEOPT_DIR = $(AEOPT_PATH)
-  AEOPT_INC = -I$(AEOPT_DIR) 
+  AEOPT_INC = -I$(AEOPT_DIR)
   LIB_AEOPT = libtrapAE.a
   AEOPT_LIB = $(AEOPT_PATH)/$(LIB_AEOPT)
 
@@ -156,35 +164,35 @@
 #            System-specific path and binary definitions
 #######################################################################
 FC = gfortran
-BLASHOME = /usr/lib/x86_64-linux-gnu
-BLACS_HOME = /usr/lib/x86_64-linux-gnu
-SCALAPACK_HOME = /usr/lib/x86_64-linux-gnu
-MPIHOME = /usr/lib/x86_64-linux-gnu
-NETCDF_HOME = /usr/lib/x86_64-linux-gnu
-HDF5_HOME = /usr/lib/x86_64-linux-gnu
-PGPLOT_DIR = /usr/lib/x86_64-linux-gnu
-SILOHOME = /usr/lib/x86_64-linux-gnu
+BLASHOME = /usr/lib/$(ARCH)-linux-gnu
+BLACS_HOME = /usr/lib/$(ARCH)-linux-gnu
+SCALAPACK_HOME = /usr/lib/$(ARCH)-linux-gnu
+MPIHOME = /usr/lib/$(ARCH)-linux-gnu
+NETCDF_HOME = /usr/lib/$(ARCH)-linux-gnu
+HDF5_HOME = /usr/lib/$(ARCH)-linux-gnu
+PGPLOT_DIR = /usr/lib/$(ARCH)-linux-gnu
+SILOHOME = /usr/lib/$(ARCH)-linux-gnu
 
 #######################################################################
 #            LIBSTELL Shared Options
 #######################################################################
-#LIB_SHARE = $(BLASHOME)/lib/x86_64-linux-gnu/libblas.so \
+#LIB_SHARE = $(BLASHOME)/lib/$(ARCH)-linux-gnu/libblas.so \
           $(SCALAPACK_HOME)/lib/libscalapack-openmpi.so \
           $(BLACS_HOME)/lib/libblacs-openmpi.so  $(BLACS_HOME)/lib/libblacsCinit-openmpi.so $(BLACS_HOME)/lib/libblacsF77init-openmpi.so \
-          $(HDF5_HOME)/lib/x86_64-linux-gnu/libhdf5_hl.so $(HDF5_HOME)/lib/x86_64-linux-gnu/libhdf5_fortran.so $(HDF5_HOME)/lib/x86_64-linux-gnu/libhdf5hl_fortran.so $(HDF5_HOME)/lib/x86_64-linux-gnu/libhdf5.so \
-          $(HDF5_HOME)/lib/x86_64-linux-gnu/libmpi_usempif08.so $(HDF5_HOME)/lib/x86_64-linux-gnu/libhdf5_openmpi_fortran.so \
-          $(NETCDF_HOME)/lib/x86_64-linux-gnu/libnetcdf.so $(NETCDF_HOME)/lib/x86_64-linux-gnu/libnetcdff.so $(NETCDF_HOME)/lib/x86_64-linux-gnu/libnetcdf_c++.so \
-          $(SILOHOME)/lib/x86_64-linux-gnu/libsiloh5.so \
-          $(GSLHOME)/lib/x86_64-linux-gnu/libgsl.so \
+          $(HDF5_HOME)/lib/$(ARCH)-linux-gnu/libhdf5_hl.so $(HDF5_HOME)/lib/$(ARCH)-linux-gnu/libhdf5_fortran.so $(HDF5_HOME)/lib/$(ARCH)-linux-gnu/libhdf5hl_fortran.so $(HDF5_HOME)/lib/$(ARCH)-linux-gnu/libhdf5.so \
+          $(HDF5_HOME)/lib/$(ARCH)-linux-gnu/libmpi_usempif08.so $(HDF5_HOME)/lib/$(ARCH)-linux-gnu/libhdf5_openmpi_fortran.so \
+          $(NETCDF_HOME)/lib/$(ARCH)-linux-gnu/libnetcdf.so $(NETCDF_HOME)/lib/$(ARCH)-linux-gnu/libnetcdff.so $(NETCDF_HOME)/lib/$(ARCH)-linux-gnu/libnetcdf_c++.so \
+          $(SILOHOME)/lib/$(ARCH)-linux-gnu/libsiloh5.so \
+          $(GSLHOME)/lib/$(ARCH)-linux-gnu/libgsl.so \
           $(GCC6_HOME)/libgfortran.so $(GCC6_HOME)/libstdc++.so \
-          $(MPIHOME)/lib/x86_64-linux-gnu/libmpi.so $(MPIHOME)/lib/x86_64-linux-gnu/libmpi_mpifh.so \
-          /usr/lib/x86_64-linux-gnu/libm.so /usr/lib/liblapack.so /usr/lib/x86_64-linux-gnu/libdl.so
+          $(MPIHOME)/lib/$(ARCH)-linux-gnu/libmpi.so $(MPIHOME)/lib/$(ARCH)-linux-gnu/libmpi_mpifh.so \
+          /usr/lib/$(ARCH)-linux-gnu/libm.so /usr/lib/liblapack.so /usr/lib/$(ARCH)-linux-gnu/libdl.so
 #LIB_SHARE = $(BLASHOME)/libblas.so \
           $(SCALAPACK_HOME)/libscalapack-openmpi.so.1 \
           $(BLACS_HOME)/libblacs-openmpi.so.1 \
           $(BLACS_HOME)/libblacsCinit-openmpi.so.1 \
           $(BLACS_HOME)/libblacsF77init-openmpi.so.1 \
-          $(HDF5_HOME)/x86_64-linux-gnu/libhdf5_openmpi_fortran.so \
+          $(HDF5_HOME)/$(ARCH)-linux-gnu/libhdf5_openmpi_fortran.so \
           $(NETCDF_HOME)/libnetcdf.so \
           $(NETCDF_HOME)/libnetcdff.so \
           $(NETCDF_HOME)/libnetcdf_c++.so \
@@ -194,10 +202,8 @@ SILOHOME = /usr/lib/x86_64-linux-gnu
           $(GCC49_HOME)/libstdc++.so \
           $(MPIHOME)/lib/libmpi.so \
           $(MPIHOME)/lib/libmpif77.so \
-          /usr/lib/x86_64-linux-gnu/libm.so \
+          /usr/lib/$(ARCH)-linux-gnu/libm.so \
           /usr/lib/liblapack.so \
-          /usr/lib/x86_64-linux-gnu/libdl.so
+          /usr/lib/$(ARCH)-linux-gnu/libdl.so
 
-LIB_SHARE = $(BLASHOME)/libblas.so 
-
-
+LIB_SHARE = $(BLASHOME)/libblas.so


### PR DESCRIPTION
Minor modification of `make_ubuntu.inc` so that

1. Architectures besides `x86_64` (e.g. `aarch64`) work,
2. GNU Fortran > 9 version doesn't throw argument mismatch errors (see also #139, #140)

Tested on Docker image on an M1 Mac. The editor also removed some unnecessary whitespaces.