### PR TITLE
BEAMS3D: lower std. partvmax to save memory

### DIFF
--- a/BEAMS3D/Sources/beams3d_init.f90
+++ b/BEAMS3D/Sources/beams3d_init.f90
@@ -782,7 +782,7 @@
 
 
       ! Determine maximum particle velocity
-      partvmax=MAX(MAXVAL(ABS(vll_start))*6.0/5.0,partvmax)
+      partvmax=MAX(MAXVAL(ABS(vll_start)),partvmax)
       !IF (lverb) WRITE(6,'(A,F8.5)') '   PARTVMAX  = ',partvmax
       !partpmax=MAX(MAXVAL(ABS(partvmax*mass)),partpmax)
       nsh_prof4 = ns_prof4/2

--- a/BEAMS3D/Sources/beams3d_init_beams.f90
+++ b/BEAMS3D/Sources/beams3d_init_beams.f90
@@ -78,7 +78,7 @@
             mass(k1:k2)         = mass_beams(i)
             charge(k1:k2)       = charge_beams(i)
             Zatom(k1:k2)        = Zatom_beams(i)
-            partvmax            = MAX(partvmax,6*SQRT(2*E_beams(i)/mass_beams(i))/5.0)
+            partvmax            = MAX(partvmax,SQRT(2*E_beams(i)/mass_beams(i)))
             ! Energy distribution
             CALL gauss_rand(nparticles_start, Energy)
             Energy = sqrt( (E_beams(i) + E_error*E_beams(i)*Energy)*(E_beams(i) + E_error*E_beams(i)*Energy) )

--- a/BEAMS3D/Sources/beams3d_init_beams_bbnbi.f90
+++ b/BEAMS3D/Sources/beams3d_init_beams_bbnbi.f90
@@ -134,7 +134,7 @@
             mass(k1:k2)         = mass_beams(i)
             charge(k1:k2)       = charge_beams(i)
             Zatom(k1:k2)        = Zatom_beams(i)
-            partvmax            = MAX(partvmax,6*SQRT(2*E_beams(i)/mass_beams(i))/5.0)
+            partvmax            = MAX(partvmax,SQRT(2*E_beams(i)/mass_beams(i)))
             ! Energy distribution
             CALL gauss_rand(nparticles_start, Energy)
             Energy = sqrt( (E_beams(i) + E_error*E_beams(i)*Energy)*(E_beams(i) + E_error*E_beams(i)*Energy) )

--- a/BEAMS3D/Sources/beams3d_init_beams_w7x.f90
+++ b/BEAMS3D/Sources/beams3d_init_beams_w7x.f90
@@ -91,7 +91,7 @@
             mass(k1:k2)         = mass_beams(i)
             charge(k1:k2)       = charge_beams(i)
             Zatom(k1:k2)        = Zatom_beams(i)
-            partvmax            = MAX(partvmax,6*SQRT(2*E_beams(i)/mass_beams(i))/5.0)
+            partvmax            = MAX(partvmax,SQRT(2*E_beams(i)/mass_beams(i)))
             ! Energy distribution
             CALL gauss_rand(nparticles_start, Energy)
             Energy = sqrt( (E_beams(i) + E_error*E_beams(i)*Energy)*(E_beams(i) + E_error*E_beams(i)*Energy) )


### PR DESCRIPTION
Adressses #213 
Note that setting the maximum velocity to a larger value is still supported through the input namelist. I think as long as we dont have velocity diffusion, setting partvmax to the actual maximum velocity is a better default. We might of course want to calculate that accurately instead of just using vll_start when using the input namelist.
An option to set partvmax to a value lower than the maximum input velocity could be useful to zoom in on details of the distribution, but this can come when we have a concrete need for it.