### PR TITLE
[DIAGNO] add an option to write a more accurate output file for the bfield_points diagnostic

### DIFF
--- a/DIAGNO/Sources/diagno_bfield.f90
+++ b/DIAGNO/Sources/diagno_bfield.f90
@@ -177,18 +177,35 @@
             modb = sqrt(bx*bx+by*by+bz*bz)
             br   = bx * cos(phip) + by * sin(phip)
             bphi = by * cos(phip) - bx * sin(phip)
-            IF (lrphiz) THEN
-               DO i = 1, ncoils
-                  IF (lverb) WRITE(6,'(13X,I8,1X,7E14.5)') i,rp(i),phip(i),zp(i),br(i),bphi(i),bz(i),modb(i)
-                  WRITE(iunit_out,'(13X,I8,1X,7E14.5)') i,rp(i),phip(i),zp(i),br(i),bphi(i),bz(i),modb(i)
-               END DO
-               WRITE(iunit_out,'(A)')'   #   rp[m]    phip[deg]    zp[m]      B_R[T]    B_PHI[T]      B_Z[T]      |B|[T]'
+            IF (lbpoints_accurate_output) THEN
+               ! more digits of accuracy, if enabled
+               WRITE(iunit_out,'(1X,I6.6)') ncoils ! also write number of points first
+               IF (lrphiz) THEN
+                  DO i = 1, ncoils
+                     IF (lverb) WRITE(6,'(13X,I8,1X,7E14.5)') i,rp(i),phip(i),zp(i),br(i),bphi(i),bz(i),modb(i)
+                     WRITE(iunit_out,'(13X,I8,1X,7ES22.12E3)') i,rp(i),phip(i),zp(i),br(i),bphi(i),bz(i),modb(i)
+                  END DO
+               ELSE
+                  DO i = 1, ncoils
+                     IF (lverb) WRITE(6,'(13X,I8,1X,7E14.5)') i,xp(i),yp(i),zp(i),bx(i),by(i),bz(i),modb(i)
+                     WRITE(iunit_out,'(13X,I8,1X,7ES22.12E3)') i,xp(i),yp(i),zp(i),bx(i),by(i),bz(i),modb(i)
+                  END DO
+               END IF
             ELSE
-               DO i = 1, ncoils
-                  IF (lverb) WRITE(6,'(13X,I8,1X,7E14.5)') i,xp(i),yp(i),zp(i),bx(i),by(i),bz(i),modb(i)
-                  WRITE(iunit_out,'(13X,I8,1X,7E14.5)') i,xp(i),yp(i),zp(i),bx(i),by(i),bz(i),modb(i)
-               END DO
-               WRITE(iunit_out,'(A)')'   #   xp[m]      yp[m]      zp[m]      B_X[T]      B_Y[T]      B_Z[T]      |B|[T]'
+               ! backward compatibility output
+               IF (lrphiz) THEN
+                  DO i = 1, ncoils
+                     IF (lverb) WRITE(6,'(13X,I8,1X,7E14.5)') i,rp(i),phip(i),zp(i),br(i),bphi(i),bz(i),modb(i)
+                     WRITE(iunit_out,'(13X,I8,1X,7E14.5)') i,rp(i),phip(i),zp(i),br(i),bphi(i),bz(i),modb(i)
+                  END DO
+                  WRITE(iunit_out,'(A)')'   #   rp[m]    phip[deg]    zp[m]      B_R[T]    B_PHI[T]      B_Z[T]      |B|[T]'
+               ELSE
+                  DO i = 1, ncoils
+                     IF (lverb) WRITE(6,'(13X,I8,1X,7E14.5)') i,xp(i),yp(i),zp(i),bx(i),by(i),bz(i),modb(i)
+                     WRITE(iunit_out,'(13X,I8,1X,7E14.5)') i,xp(i),yp(i),zp(i),bx(i),by(i),bz(i),modb(i)
+                  END DO
+                  WRITE(iunit_out,'(A)')'   #   xp[m]      yp[m]      zp[m]      B_X[T]      B_Y[T]      B_Z[T]      |B|[T]'
+               END IF
             END IF
             CLOSE(iunit_out)
          END IF

--- a/DIAGNO/Sources/diagno_input_mod.f90
+++ b/DIAGNO/Sources/diagno_input_mod.f90
@@ -38,13 +38,15 @@
 !           vc_adapt_rel          Adaptive integration relative tollerance
 !           flux_mut_file         Mutual induction file (not fully implemented)
 !           lvc_field             Use virtual casing instead of volume integral for free boundary
+!           lbpoints_accurate_output  Enable writing bpoints outputs with more digits
 !-----------------------------------------------------------------------
       namelist /diagno_in/ nu, nv, &
            flux_diag_file, bprobes_file, mirnov_file, seg_rog_file,  &
            bfield_points_file, flux_turns, units, int_type, &
            int_step, lrphiz, vc_adapt_tol, vc_adapt_rel,&
            flux_mut_file, lvc_field, bprobe_turns, luse_extcur, &
-           bprobes_mut_file, mir_mut_file, rog_mut_file, segrog_turns
+           bprobes_mut_file, mir_mut_file, rog_mut_file, segrog_turns, &
+           lbpoints_accurate_output
       
 !-----------------------------------------------------------------------
 !     Subroutines
@@ -81,6 +83,7 @@
       vc_adapt_rel   = 1.0E-04_rprec
       lvc_field      = .TRUE.
       luse_extcur(:) = .TRUE.  ! Do this so we default to using the whole coil if the user forgets
+      lbpoints_accurate_output = .false. ! default for backward compatibility
       ! Read namelist
       istat=0; iunit = 25
       INQUIRE(FILE='input.'//TRIM(filename),EXIST=lexist)

--- a/DIAGNO/Sources/diagno_runtime.f90
+++ b/DIAGNO/Sources/diagno_runtime.f90
@@ -72,6 +72,7 @@
 !          flux_mut_file  Mutual inductance file
 !          bfield_points_file  B-Field at a point diagnostic
 !          extcur         External currents for MGRID calculation
+!          lbpoints_accurate_output  Enable writing bpoints outputs with more digits
 !----------------------------------------------------------------------
       IMPLICIT NONE
       
@@ -103,7 +104,8 @@
       INTEGER, PARAMETER ::  MAXLINES   = 256
       
       LOGICAL         :: lverb, lvmec, lpies, lspec, lcoil, lvac, &
-                         lrphiz, lmut, luse_mut, lvc_field
+                         lrphiz, lmut, luse_mut, lvc_field, &
+                         lbpoints_accurate_output
       LOGICAL         :: luse_extcur(512),lskip_flux(2048),lskip_rogo(2048)
       INTEGER         :: nextcur, int_step, nu, nv, nfp_diagno, eq_sgns,&
                          nprocs_diagno, mystart, myend


### PR DESCRIPTION
With this patch, the user can use a `DIAGNO_IN` namelist flag `lbpoints_accurate_output` to activate a different output file format for the `diagno_btest.<runId>` output file, which has:
1. the number of points that were written in the first line (for easier parsing, similar to the fluxloop and segmented Rogowski output files) and
2. more digits of accuracy for each of the outputs (the output format was copied from the corresponding writing routine for the segmented Rogowski sensors)

By default, this option is disabled in order to retain backwards compatibility.