### PR TITLE
[DIAGNO] add afield diagnostic

### DIFF
--- a/DIAGNO/DIAGNO.dep
+++ b/DIAGNO/DIAGNO.dep
@@ -44,6 +44,14 @@ diagno_init_spec.o : \
       diagno_runtime.o
       
 
+diagno_afield.o : \
+      ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
+      ../../LIBSTELL/$(LOCTYPE)/virtual_casing_mod.o \
+      ../../LIBSTELL/$(LOCTYPE)/biotsavart.o \
+      ../../LIBSTELL/$(LOCTYPE)/safe_open_mod.o \
+      diagno_runtime.o
+
+
 diagno_bfield.o : \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
       ../../LIBSTELL/$(LOCTYPE)/virtual_casing_mod.o \

--- a/DIAGNO/ObjectList
+++ b/DIAGNO/ObjectList
@@ -1,5 +1,6 @@
 ObjectFiles = \
 dflux_simpson.o \
+diagno_afield.o \
 diagno_bfield.o \
 db_bode.o \
 dflux_midpoint.o \

--- a/DIAGNO/Sources/diagno.f90
+++ b/DIAGNO/Sources/diagno.f90
@@ -180,6 +180,7 @@
       
          ! Calculate diagnostic response
          if(lverb) write(6,*)' - Calculating diagnostic responses'
+         IF (LEN_TRIM(afield_points_file) > 1) CALL diagno_afield
          IF (LEN_TRIM(bfield_points_file) > 1) CALL diagno_bfield
          IF (LEN_TRIM(bprobes_file) > 1) CALL diagno_bprobes
          IF (LEN_TRIM(mirnov_file) > 1) CALL diagno_mirnov

--- a/DIAGNO/Sources/diagno_afield.f90
+++ b/DIAGNO/Sources/diagno_afield.f90
@@ -1,0 +1,205 @@
+!-----------------------------------------------------------------------
+!     Module:        diagno_afield
+!     Authors:       J. Schilling (jonathan.schilling@mail.de),
+!                    S. Lazerson (lazerson@pppl.gov)
+!     Date:          05/12/2024
+!     Description:   This subroutine calculates the vector potential
+!                    at a point in space.
+!-----------------------------------------------------------------------
+      SUBROUTINE diagno_afield
+!-----------------------------------------------------------------------
+!     Libraries
+!-----------------------------------------------------------------------
+      USE stel_kinds, ONLY: rprec
+      USE diagno_runtime
+      USE virtual_casing_mod
+      USE biotsavart
+      USE safe_open_mod
+      USE mpi_params
+      USE mpi_inc
+!-----------------------------------------------------------------------
+!     Local Variables
+!          ier            Error Flag
+!          iunit          File ID Number
+!-----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER, PARAMETER :: BYTE_8 = SELECTED_INT_KIND (8)
+#if defined(MPI_OPT)
+      INTEGER(KIND=BYTE_8),ALLOCATABLE :: mnum(:), moffsets(:)
+      INTEGER :: numprocs_local, mylocalid, mylocalmaster
+      INTEGER :: MPI_COMM_LOCAL
+#endif
+      INTEGER(KIND=BYTE_8) :: icount, chunk
+      INTEGER :: ier, iunit, ncoils, i, ig, iunit_out, ncg
+      REAL(rprec), ALLOCATABLE, DIMENSION(:) :: xp, yp, rp, phip, zp, ax, ay, ar, aphi, az, moda,&
+                     axp, ayp, azp
+      REAL(rprec), ALLOCATABLE, DIMENSION(:,:) :: ax_mut, ay_mut, az_mut
+      REAL(rprec) :: xvec(3),avec(3)
+
+!-----------------------------------------------------------------------
+!     Begin Subroutine
+!-----------------------------------------------------------------------
+      ! Basic copy of MPI_COMM_DIANGO
+      mylocalid = myworkid
+      mylocalmaster = master
+      MPI_COMM_LOCAL = MPI_COMM_DIAGNO
+      numprocs_local = nprocs_diagno
+      ncg = SIZE(coil_group)
+
+      ! Read File
+      if(lverb) write(6,*)' ---Calculating Vector Potential Test Points'
+      IF(lverb .and. lrphiz) THEN
+         WRITE(6,'(14X,A,7(6X,A,6X))') 'No','r','phi','z','Ar','Aphi','Az','|A|'
+      ELSE IF (lverb) THEN
+         WRITE(6,'(14X,A,7(6X,A,6X))') 'No','x','y','z','Ax','Ay','Az','|A|'
+      END IF
+      iunit = 26; iunit_out = 27;
+      IF (myworkid == master) THEN
+         CALL safe_open(iunit,ier,TRIM(afield_points_file),'old','formatted')
+         READ(iunit,*) ncoils
+         ALLOCATE(xp(ncoils), yp(ncoils), rp(ncoils), phip(ncoils), zp(ncoils), &
+                  ax(ncoils), ay(ncoils), ar(ncoils), aphi(ncoils), az(ncoils), &
+                  moda(ncoils), axp(ncoils), ayp(ncoils), azp(ncoils))
+         DO i = 1, ncoils
+            IF (lrphiz) THEN
+               READ(iunit,*) rp(i),phip(i),zp(i)
+               xp(i) = rp(i) * cos(phip(i))
+               yp(i) = rp(i) * sin(phip(i))
+            ELSE
+               READ(iunit,*) xp(i),yp(i),zp(i)
+            END IF
+         END DO
+         CLOSE(iunit)
+      END IF
+
+#if defined(MPI_OPT)
+      CALL MPI_BARRIER(MPI_COMM_DIAGNO,ierr_mpi)
+      IF (ierr_mpi /=0) CALL handle_err(MPI_BARRIER_ERR,'diagno_afield1',ierr_mpi)
+      CALL MPI_BCAST(ncoils,1,MPI_INTEGER, master, MPI_COMM_DIAGNO,ierr_mpi)
+      IF (ierr_mpi /=0) CALL handle_err(MPI_BCAST_ERR,'diagno_afield1',ierr_mpi)
+#endif
+      IF (myworkid /= master) ALLOCATE(xp(ncoils), yp(ncoils), rp(ncoils), phip(ncoils), zp(ncoils), &
+                                       ax(ncoils), ay(ncoils), ar(ncoils), aphi(ncoils), az(ncoils), &
+                                       moda(ncoils), axp(ncoils), ayp(ncoils), azp(ncoils))
+      ALLOCATE(ax_mut(ncoils,ncg), ay_mut(ncoils,ncg), az_mut(ncoils,ncg))
+
+#if defined(MPI_OPT)
+      CALL MPI_BARRIER(MPI_COMM_DIAGNO,ierr_mpi)
+      IF (ierr_mpi /=0) CALL handle_err(MPI_BARRIER_ERR,'diagno_afield2',ierr_mpi)
+      CALL MPI_BCAST(xp,ncoils,MPI_DOUBLE_PRECISION, master, MPI_COMM_DIAGNO,ierr_mpi)
+      IF (ierr_mpi /=0) CALL handle_err(MPI_BCAST_ERR,'diagno_afield2',ierr_mpi)
+      CALL MPI_BCAST(yp,ncoils,MPI_DOUBLE_PRECISION, master, MPI_COMM_DIAGNO,ierr_mpi)
+      IF (ierr_mpi /=0) CALL handle_err(MPI_BCAST_ERR,'diagno_afield2',ierr_mpi)
+      CALL MPI_BCAST(zp,ncoils,MPI_DOUBLE_PRECISION, master, MPI_COMM_DIAGNO,ierr_mpi)
+      IF (ierr_mpi /=0) CALL handle_err(MPI_BCAST_ERR,'diagno_afield2',ierr_mpi)
+      CALL MPI_BCAST(rp,ncoils,MPI_DOUBLE_PRECISION, master, MPI_COMM_DIAGNO,ierr_mpi)
+      IF (ierr_mpi /=0) CALL handle_err(MPI_BCAST_ERR,'diagno_afield2',ierr_mpi)
+      CALL MPI_BCAST(phip,ncoils,MPI_DOUBLE_PRECISION, master, MPI_COMM_DIAGNO,ierr_mpi)
+      IF (ierr_mpi /=0) CALL handle_err(MPI_BCAST_ERR,'diagno_afield2',ierr_mpi)
+#endif
+
+      ! Divide up the work
+      chunk = FLOOR(REAL(ncoils) / REAL(numprocs_local))
+      mystart = myworkid*chunk + 1
+      myend = mystart + chunk - 1
+#if defined(MPI_OPT)
+      IF (ALLOCATED(mnum)) DEALLOCATE(mnum)
+      IF (ALLOCATED(moffsets)) DEALLOCATE(moffsets)
+      ALLOCATE(mnum(numprocs_local), moffsets(numprocs_local))
+      CALL MPI_ALLGATHER(chunk,1,MPI_INTEGER,mnum,1,MPI_INTEGER,MPI_COMM_LOCAL,ierr_mpi)
+      CALL MPI_ALLGATHER(mystart,1,MPI_INTEGER,moffsets,1,MPI_INTEGER,MPI_COMM_LOCAL,ierr_mpi)
+      i = 1
+      DO
+         IF ((moffsets(numprocs_local)+mnum(numprocs_local)-1) == ncoils) EXIT
+         IF (i == numprocs_local) i = 1
+         mnum(i) = mnum(i) + 1
+         moffsets(i+1:numprocs_local) = moffsets(i+1:numprocs_local) + 1
+         i=i+1
+      END DO
+      mystart = moffsets(mylocalid+1)
+      chunk  = mnum(mylocalid+1)
+      myend   = mystart + chunk - 1
+#endif
+
+      ! Do Work
+      ax = 0; ay = 0; az = 0;
+      ax_mut = 0; ay_mut = 0; az_mut = 0;
+      DO i = mystart, myend
+         xvec(1) = xp(i); xvec(2)=yp(i); xvec(3)=zp(i)
+         IF (lcoil) THEN
+            DO ig = 1, ncg
+               avec=0
+               CALL bsc_a(coil_group(ig),xvec,avec)
+               ax_mut(i,ig) = avec(1)
+               ay_mut(i,ig) = avec(2)
+               az_mut(i,ig) = avec(3)
+            END DO
+         END IF
+         IF (lmut .or. lvac) CYCLE
+         CALL afield_vc(xp(i),yp(i),zp(i),ax(i),ay(i),az(i),ier)
+      END DO
+
+      ! Now handle the arrays
+      IF (lmut) THEN
+         IF (myworkid == master) THEN
+            CALL MPI_REDUCE(MPI_IN_PLACE,ax_mut,ncoils*ncg,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_DIAGNO,ierr_mpi)
+            CALL MPI_REDUCE(MPI_IN_PLACE,ay_mut,ncoils*ncg,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_DIAGNO,ierr_mpi)
+            CALL MPI_REDUCE(MPI_IN_PLACE,az_mut,ncoils*ncg,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_DIAGNO,ierr_mpi)
+         ELSE
+            CALL MPI_REDUCE(ax_mut,ax_mut,ncoils*ncg,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_DIAGNO,ierr_mpi)
+            CALL MPI_REDUCE(ay_mut,ay_mut,ncoils*ncg,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_DIAGNO,ierr_mpi)
+            CALL MPI_REDUCE(az_mut,az_mut,ncoils*ncg,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_DIAGNO,ierr_mpi)
+         END IF
+      ELSE
+         ! Plasma + vacuum
+         ax = ax + SUM(ax_mut, DIM=2)
+         ay = ay + SUM(ay_mut, DIM=2)
+         az = az + SUM(az_mut, DIM=2)
+#if defined(MPI_OPT)
+         CALL MPI_BARRIER(MPI_COMM_LOCAL,ierr_mpi)
+         IF (ierr_mpi /=0) CALL handle_err(MPI_BARRIER_ERR,'diagno_afield3',ierr_mpi)
+         CALL MPI_ALLGATHERV(MPI_IN_PLACE,0,MPI_DATATYPE_NULL,&
+                        ax,mnum,moffsets-1,MPI_DOUBLE_PRECISION,&
+                        MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_ALLGATHERV(MPI_IN_PLACE,0,MPI_DATATYPE_NULL,&
+                        ay,mnum,moffsets-1,MPI_DOUBLE_PRECISION,&
+                        MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_ALLGATHERV(MPI_IN_PLACE,0,MPI_DATATYPE_NULL,&
+                        az,mnum,moffsets-1,MPI_DOUBLE_PRECISION,&
+                        MPI_COMM_LOCAL,ierr_mpi)
+#endif
+      END IF
+
+      ! PRINT TO SCREEN
+      IF (myworkid == master) THEN
+         IF (lmut) THEN
+         ELSE
+            CALL safe_open(iunit_out,ier,'diagno_atest.'//TRIM(id_string),'replace','formatted')
+            moda = sqrt(ax*ax+ay*ay+az*az)
+            ar   = ax * cos(phip) + ay * sin(phip)
+            aphi = ay * cos(phip) - ax * sin(phip)
+            IF (lrphiz) THEN
+               DO i = 1, ncoils
+                  IF (lverb) WRITE(6,'(13X,I8,1X,7E14.5)') i,rp(i),phip(i),zp(i),ar(i),aphi(i),az(i),moda(i)
+                  WRITE(iunit_out,'(13X,I8,1X,7E14.5)') i,rp(i),phip(i),zp(i),ar(i),aphi(i),az(i),moda(i)
+               END DO
+               WRITE(iunit_out,'(A)')'   #   rp[m]    phip[deg]    zp[m]      A_R[Tm]    A_PHI[Tm]      A_Z[Tm]      |A|[Tm]'
+            ELSE
+               DO i = 1, ncoils
+                  IF (lverb) WRITE(6,'(13X,I8,1X,7E14.5)') i,xp(i),yp(i),zp(i),ax(i),ay(i),az(i),moda(i)
+                  WRITE(iunit_out,'(13X,I8,1X,7E14.5)') i,xp(i),yp(i),zp(i),ax(i),ay(i),az(i),moda(i)
+               END DO
+               WRITE(iunit_out,'(A)')'   #   xp[m]      yp[m]      zp[m]      A_X[Tm]      A_Y[Tm]      A_Z[Tm]      |A|[Tm]'
+            END IF
+            CLOSE(iunit_out)
+         END IF
+      END IF
+
+      ! Clean up
+      DEALLOCATE(xp, yp, rp, phip, zp, ax, ay, ar, aphi, az, moda, axp, ayp, azp)
+      DEALLOCATE(ax_mut,ay_mut,az_mut)
+      RETURN
+!-----------------------------------------------------------------------
+!     End Subroutine
+!-----------------------------------------------------------------------
+      END SUBROUTINE diagno_afield

--- a/DIAGNO/Sources/diagno_afield.f90
+++ b/DIAGNO/Sources/diagno_afield.f90
@@ -136,7 +136,7 @@
             END DO
          END IF
          IF (lmut .or. lvac) CYCLE
-         CALL afield_vc(xp(i),yp(i),zp(i),ax(i),ay(i),az(i),ier)
+         CALL vecpot_vc(xp(i),yp(i),zp(i),ax(i),ay(i),az(i),ier)
       END DO
 
       ! Now handle the arrays

--- a/DIAGNO/Sources/diagno_afield.f90
+++ b/DIAGNO/Sources/diagno_afield.f90
@@ -4,7 +4,7 @@
 !                    S. Lazerson (lazerson@pppl.gov)
 !     Date:          05/12/2024
 !     Description:   This subroutine calculates the vector potential
-!                    at a point in space.
+!                    at given points in space.
 !-----------------------------------------------------------------------
       SUBROUTINE diagno_afield
 !-----------------------------------------------------------------------

--- a/DIAGNO/Sources/diagno_input_mod.f90
+++ b/DIAGNO/Sources/diagno_input_mod.f90
@@ -28,6 +28,7 @@
 !           bprobes file          B-field probe specification
 !           mirnov_file           Mirnov Array specification
 !           seg_rog_file          Rogowski coils specification
+!           afield_points_file    A-field points specfication
 !           bfield_points_file    B-field points specfication
 !           flux_turns            Flux loop integer scale factors
 !           units                 Units (Assume all quantities in [m])
@@ -41,6 +42,7 @@
 !-----------------------------------------------------------------------
       namelist /diagno_in/ nu, nv, &
            flux_diag_file, bprobes_file, mirnov_file, seg_rog_file,  &
+           afield_points_file, &
            bfield_points_file, flux_turns, units, int_type, &
            int_step, lrphiz, vc_adapt_tol, vc_adapt_rel,&
            flux_mut_file, lvc_field, bprobe_turns, luse_extcur, &
@@ -64,6 +66,7 @@
       bprobes_file       = ''
       mirnov_file        = ''
       seg_rog_file       = ''
+      afield_points_file = ''
       bfield_points_file = ''
       bprobes_mut_file   = ''
       mir_mut_file      = ''
@@ -135,6 +138,8 @@
       mirnov_file = ADJUSTL(mirnov_file)
       seg_rog_file = TRIM(seg_rog_file)
       seg_rog_file = ADJUSTL(seg_rog_file)
+      afield_points_file = TRIM(afield_points_file)
+      afield_points_file = ADJUSTL(afield_points_file)
       bfield_points_file = TRIM(bfield_points_file)
       bfield_points_file = ADJUSTL(bfield_points_file)
       bprobes_mut_file = TRIM(bprobes_mut_file)
@@ -175,6 +180,7 @@
       WRITE(iunit,"(2X,A,1X,'=',1X,E22.14)") 'VC_ADAPT_REL',vc_adapt_rel
       WRITE(iunit,outstr) 'INT_TYPE',TRIM(int_type)
       WRITE(iunit,"(2X,A,1X,'=',1X,I0)") 'INT_STEP',int_step
+      WRITE(iunit,outstr) 'AFIELD_POINTS_FILE',TRIM(afield_points_file)
       WRITE(iunit,outstr) 'BFIELD_POINTS_FILE',TRIM(bfield_points_file)
       WRITE(iunit,outstr) 'BPROBES_FILE',TRIM(bprobes_file)
       WRITE(iunit,outstr) 'MIRNOV_FILE',TRIM(mirnov_file)
@@ -213,6 +219,8 @@
       CALL MPI_BCAST(int_type,256,MPI_CHARACTER,local_master,comm,istat)
       IF (istat .ne. 0) RETURN
       CALL MPI_BCAST(int_step,1,MPI_INTEGER,local_master,comm,istat)
+      IF (istat .ne. 0) RETURN
+      CALL MPI_BCAST(afield_points_file,256,MPI_CHARACTER,local_master,comm,istat)
       IF (istat .ne. 0) RETURN
       CALL MPI_BCAST(bfield_points_file,256,MPI_CHARACTER,local_master,comm,istat)
       IF (istat .ne. 0) RETURN

--- a/DIAGNO/Sources/diagno_runtime.f90
+++ b/DIAGNO/Sources/diagno_runtime.f90
@@ -70,6 +70,7 @@
 !          seg_rog_file   Segmented Rogowski Coil specification file
 !          int_type       Integration type ('midpoint','simpson','bode')
 !          flux_mut_file  Mutual inductance file
+!          afield_points_file  A-Field at a point diagnostic
 !          bfield_points_file  B-Field at a point diagnostic
 !          extcur         External currents for MGRID calculation
 !----------------------------------------------------------------------
@@ -111,7 +112,8 @@
       REAL(rprec)     :: vc_adapt_tol, units, phiedge, vc_adapt_rel
       REAL(rprec), ALLOCATABLE :: extcur(:)
       CHARACTER(256)  :: id_string, flux_diag_file, bprobes_file, &
-                         mirnov_file, seg_rog_file, bfield_points_file,&
+                         mirnov_file, seg_rog_file, afield_points_file, &
+                         bfield_points_file, &
                          int_type, coil_string, flux_mut_file, rog_mut_file,&
                          mir_mut_file, bprobes_mut_file
                          


### PR DESCRIPTION
These changes add a new diagnostic to DIAGNO, which evaluates the magnetic vector potential at a given set of points.

The corresponding diagnostic file for DIAGNO is `atest.diagno`:
```
4
1.0 2.0 3.0
1.1 2.1 3.1
1.2 2.2 3.2
1.3 2.3 3.3
```

It has to be registered in the `DIAGNO_IN` namelist as follows:
```
&DIAGNO_IN
  [...]
  AFIELD_POINTS_FILE = 'atest.diagno'  ! Path to A-Field test points file 
  [...]
/
```

The results are written to `diagno_atest.<runId>`:
```
                    1    0.10000E+01   0.20000E+01   0.30000E+01   0.13133E-01   0.26355E-01   0.10286E+00   0.10699E+00
                    2    0.11000E+01   0.21000E+01   0.31000E+01   0.14439E-01   0.27562E-01   0.99380E-01   0.10414E+00
                    3    0.12000E+01   0.22000E+01   0.32000E+01   0.15683E-01   0.28662E-01   0.95778E-01   0.10120E+00
                    4    0.13000E+01   0.23000E+01   0.33000E+01   0.16848E-01   0.29643E-01   0.92069E-01   0.98180E-01
   #   xp[m]      yp[m]      zp[m]      A_X[Tm]      A_Y[Tm]      A_Z[Tm]      |A|[Tm]

```

The results were checked against Extender for a W7-X free-boundary finite-beta case on the given example points.
Here are the values for the vector potential computed using the `EVECPOT` code:
```
#  i      x       y       z       A_x       A_y       A_z       H_x       H_y       H_z
       0  1.00000000e+00  2.00000000e+00  3.00000000e+00  1.31337063e-02  2.63548191e-02  1.02854489e-01  2.08715861e+01  4.96516732e+01  2.94720835e+02 
       1  1.10000000e+00  2.10000000e+00  3.10000000e+00  1.44404608e-02  2.75614375e-02  9.93735849e-02  2.36497298e+01  5.35878146e+01  2.90209615e+02 
       2  1.20000000e+00  2.20000000e+00  3.20000000e+00  1.56838028e-02  2.86615420e-02  9.57716709e-02  2.65621668e+01  5.75618445e+01  2.85309774e+02 
       3  1.30000000e+00  2.30000000e+00  3.30000000e+00  1.68492916e-02  2.96427921e-02  9.20630843e-02  2.95931735e+01  6.15371437e+01  2.79982016e+02
```

As one can see, the values for `A_X`, `A_Y` and `A_Z` match ok (some deviations in the last digits are probably because I did not do a careful convergence study yet. Keep in mind though that DIAGNO and Extender are anyways using slightly different implementations...).