### PR TITLE
pySTEL: Fixed missing negative sign for xn_nyq.

### DIFF
--- a/pySTEL/libstell/vmec.py
+++ b/pySTEL/libstell/vmec.py
@@ -37,6 +37,7 @@ class VMEC(FourierRep):
 			setattr(self, key, wout_dict[key])
 		# (mu-nv) -> (mu+nv)
 		self.xn = -self.xn
+		self.xn_nyq = -self.xn_nyq
 		# Half to full grid
 		self.buco = self.h2f(self.buco)
 		self.bvco = self.h2f(self.bvco)


### PR DESCRIPTION
Fixes issue where a negative sign was missing. Closes #250 