### PR TITLE
Fix typo in MPI_INFO_SET "stripping"->"striping"

### DIFF
--- a/BEAMS3D/Sources/beams3d_interface_mod.f90
+++ b/BEAMS3D/Sources/beams3d_interface_mod.f90
@@ -54,7 +54,7 @@ CONTAINS
       ! Now we set some info
       CALL MPI_INFO_CREATE(mpi_info_beams3d, ierr_mpi)
       CALL MPI_INFO_SET(mpi_info_beams3d, "IBM_largeblock_io", "true",    ierr_mpi)
-      CALL MPI_INFO_SET(mpi_info_beams3d, "stripping_unit",    "1048576", ierr_mpi)
+      CALL MPI_INFO_SET(mpi_info_beams3d, "striping_unit",     "1048576", ierr_mpi)
       CALL MPI_INFO_SET(mpi_info_beams3d, "romio_ds_read",     "disable", ierr_mpi)
       CALL MPI_INFO_SET(mpi_info_beams3d, "romio_ds_write",    "disable", ierr_mpi)
 #endif

--- a/THRIFT/Sources/thrift_interface_mod.f90
+++ b/THRIFT/Sources/thrift_interface_mod.f90
@@ -58,7 +58,7 @@ MODULE THRIFT_INTERFACE_MOD
       ! Now we set some info
       CALL MPI_INFO_CREATE(mpi_info_thrift, ierr_mpi)
       CALL MPI_INFO_SET(mpi_info_thrift, "IBM_largeblock_io", "true",    ierr_mpi)
-      CALL MPI_INFO_SET(mpi_info_thrift, "stripping_unit",    "1048576", ierr_mpi)
+      CALL MPI_INFO_SET(mpi_info_thrift, "striping_unit",     "1048576", ierr_mpi)
       CALL MPI_INFO_SET(mpi_info_thrift, "romio_ds_read",     "disable", ierr_mpi)
       CALL MPI_INFO_SET(mpi_info_thrift, "romio_ds_write",    "disable", ierr_mpi)
 #endif


### PR DESCRIPTION
In THRIFT and BEAMS3D there is a typo in an MPI_INFO_SET call. `striping_unit` is misspelled as `stripping_unit`. 

See for example the [MPI 3.1 standard](https://www.mpi-forum.org/docs/mpi-3.1/mpi31-report.pdf) for the correct spelling.