### PR TITLE
Merge of feature/thrift from file to THRIFT

### DIFF
--- a/THRIFT/Sources/thrift_funcs.f90
+++ b/THRIFT/Sources/thrift_funcs.f90
@@ -52,14 +52,22 @@ SUBROUTINE update_vars()
         THRIFT_VP(i,mytimestep) = THRIFT_PHIEDGE(mytimestep)*temp
         InvAspect = THRIFT_AMINOR(i,mytimestep)/THRIFT_RMAJOR(i,mytimestep)
         q = ABS(1.0/q) ! iota -> q
-        ! eta breaks at rho=1(s=1) so look one gridpoint back
-        !CALL get_prof_etapara(MIN(rho,SQRT(THRIFT_S(nsj-1))),mytime,THRIFT_ETAPARA(i,mytimestep))
-        CALL get_prof_etaneo_sauter(MIN(rho,SQRT(THRIFT_S(nsj-1))),mytime, &
-            ftrap,q,THRIFT_RMAJOR(i,mytimestep),InvAspect,&
-            THRIFT_ETAPARA(i,mytimestep))
-        !PRINT *,rho,ftrap,q,THRIFT_RMAJOR(i,mytimestep),InvAspect,THRIFT_ETAPARA(i,mytimestep)
+        
+        ! Compute eta_par
+        IF(etapar_type == 'sauter') THEN
+            ! eta breaks at rho=1(s=1) so look one gridpoint back
+            CALL get_prof_etaneo_sauter(MIN(rho,SQRT(THRIFT_S(nsj-1))),mytime, &
+                ftrap,q,THRIFT_RMAJOR(i,mytimestep),InvAspect,&
+                THRIFT_ETAPARA(i,mytimestep))
+        ELSEIF(etapar_type == 'classic') THEN
+            ! eta breaks at rho=1(s=1) so look one gridpoint back
+            CALL get_prof_etapara(MIN(rho,SQRT(THRIFT_S(nsj-1))),mytime,THRIFT_ETAPARA(i,mytimestep))
+        ELSEIF(etapar_type == 'read_from_file') THEN
+            CALL get_prof_eta(rho,mytime,THRIFT_ETAPARA(i,mytimestep))
+        ENDIF
+        
         CALL get_prof_p(rho, mytime, THRIFT_P(i,mytimestep))
-     END DO
+    END DO
      THRIFT_S11 = ABS(THRIFT_S11)
 
      ! Handle NaN

--- a/THRIFT/Sources/thrift_init.f90
+++ b/THRIFT/Sources/thrift_init.f90
@@ -51,6 +51,7 @@
       IF (lverb) THEN 
          WRITE(6,'(A)') '   FILE:             input.' // TRIM(id_string)
          WRITE(6,'(A)') '   BOOTSTRAP MODEL:  ' // TRIM(bootstrap_type)
+         WRITE(6,'(A)') '   ETAPAR MODEL:  ' // TRIM(etapar_type)
          IF (leccd) WRITE(6,'(A)') '   ECCD MODEL:       ' // TRIM(eccd_type)
          IF (lnbcd) WRITE(6,'(A)') '   NBCD MODEL:       ' // TRIM(nbcd_type)
          WRITE(6,'(A)') ''

--- a/THRIFT/Sources/thrift_input_mod.f90
+++ b/THRIFT/Sources/thrift_input_mod.f90
@@ -35,7 +35,8 @@
                               targetposition_ecrh, rbeam_ecrh, &
                               rfocus_ecrh, nra_ecrh, nphi_ecrh, &
                               freq_ecrh, power_ecrh, &
-                              pecrh_aux_t, pecrh_aux_f, ecrh_rc, ecrh_w
+                              pecrh_aux_t, pecrh_aux_f, ecrh_rc, ecrh_w, &
+                              etapar_type
       
 !-----------------------------------------------------------------------
 !     Subroutines
@@ -47,6 +48,7 @@
       SUBROUTINE init_thrift_input
       IMPLICIT NONE
       bootstrap_type     = 'bootsj'
+      etapar_type        = 'sauter'
       eccd_type          = ''
       nparallel_runs     = 1
       mboz               = 32
@@ -113,6 +115,7 @@
          CLOSE(iunit)
       END IF
       CALL tolower(bootstrap_type)
+      CALL tolower(etapar_type)
       CALL tolower(eccd_type)
       leccd = eccd_type .ne. ''
       nsj = nrho;
@@ -137,6 +140,7 @@
       WRITE(iunit_out,'(A)') '!---------- GENERAL PARAMETERS ------------'
       WRITE(iunit_out,outint) 'NPARALLEL_RUNS',nparallel_runs
       WRITE(iunit_out,outstr) 'BOOTSTRAP_TYPE',bootstrap_type
+      WRITE(iunit_out,outstr) 'ETAPAR_TYPE',etapar_type
       WRITE(iunit_out,outflt) 'JTOL',jtol
       WRITE(iunit_out,outint) 'NPICARD',npicard
       WRITE(iunit_out,outflt) 'PICARD_FACTOR',picard_factor

--- a/THRIFT/Sources/thrift_profiles_mod.f90
+++ b/THRIFT/Sources/thrift_profiles_mod.f90
@@ -21,11 +21,11 @@ MODULE thrift_profiles_mod
     REAL(rprec) :: rhomin, rhomax, tmin, tmax, eps1, eps2
     REAL(rprec), DIMENSION(:), POINTER :: raxis_prof, taxis_prof, &
                                           Matom_prof, hr, hri, ht, hti
-    REAL(rprec), DIMENSION(:,:,:), POINTER :: NE3D, TE3D, P3D
+    REAL(rprec), DIMENSION(:,:,:), POINTER :: NE3D, TE3D, P3D, JBS3D, eta3D
     REAL(rprec), DIMENSION(:,:,:,:), POINTER :: NI4D, TI4D
     INTEGER :: win_raxis_prof, win_taxis_prof, win_NE3D, win_TE3D, &
                win_NI4D, win_TI4D, win_hr, win_ht, win_hri, win_hti, &
-               win_Matom_prof, win_Zatom_prof, win_P3D
+               win_Matom_prof, win_Zatom_prof, win_P3D, win_JBS3D, win_eta3D
 !-----------------------------------------------------------------------
 !     Input Namelists
 !         NONE
@@ -43,7 +43,8 @@ MODULE thrift_profiles_mod
 !         get_prof_coulln:    Returns the Coulomb Logarithm [-]
 !-----------------------------------------------------------------------
       PUBLIC  :: read_thrift_profh5, get_prof_ne, get_prof_te, &
-                 get_prof_ni, get_prof_ti, get_prof_p, free_profiles
+                 get_prof_ni, get_prof_ti, get_prof_p, get_prof_JBS, &
+                 get_prof_eta, free_profiles
       PRIVATE :: setup_grids
       CONTAINS
 
@@ -97,6 +98,8 @@ MODULE thrift_profiles_mod
       CALL mpialloc(P3D,  4, nt_prof, nrho_prof, myid_sharmem, 0, MPI_COMM_SHARMEM, win_P3D)
       CALL mpialloc(NI4D, 4, nt_prof, nrho_prof, nion_prof, myid_sharmem, 0, MPI_COMM_SHARMEM, win_NI4D)
       CALL mpialloc(TI4D, 4, nt_prof, nrho_prof, nion_prof, myid_sharmem, 0, MPI_COMM_SHARMEM, win_TI4D)
+      IF( bootstrap_type == 'read_from_file' ) CALL mpialloc(JBS3D, 4, nt_prof, nrho_prof, myid_sharmem, 0, MPI_COMM_SHARMEM, win_JBS3D)
+      IF( etapar_type == 'read_from_file' ) CALL mpialloc(eta3D, 4, nt_prof, nrho_prof, myid_sharmem, 0, MPI_COMM_SHARMEM, win_eta3D)
       IF (myid_sharmem == master) THEN
          ! Get the axis arrays
          CALL read_var_hdf5(fid,'raxis_prof',nrho_prof,ier,DBLVAR=raxis_prof)
@@ -141,7 +144,6 @@ MODULE thrift_profiles_mod
          CALL EZspline_free(temp_spl2d,ier)
          pres2d = pres2d*temp2d ! Te*ne
          ! Now work on Ion grid
-         DEALLOCATE(temp2d)
          ALLOCATE(temp_ni(nion_prof,nt_prof,nrho_prof))
          ALLOCATE(temp_ti(nion_prof,nt_prof,nrho_prof))
          ! NI
@@ -183,6 +185,37 @@ MODULE thrift_profiles_mod
          ! DEALLOCATE Helpers
          DEALLOCATE(temp_ti)
          DEALLOCATE(temp_ni)
+
+         ! Read J_BS if bootstrap_file = 'read_from_file'
+         IF( bootstrap_type == 'read_from_file' ) THEN
+            CALL read_var_hdf5(fid,'JBS_prof',nt_prof,nrho_prof,ier,DBLVAR=temp2d)
+            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'JBS_prof',ier)
+            IF (lverb) WRITE(6,'(A,F9.3,A,F9.3,A)') '   J_BS   = [', &
+                        MINVAL(temp2d)*1E-3,',',MAXVAL(temp2d)*1E-3,'] kA/m^2'
+            CALL EZspline_init(temp_spl2d,nt_prof,nrho_prof,bcs0,bcs0,ier)
+            temp_spl2d%x1          = taxis_prof
+            temp_spl2d%x2          = raxis_prof
+            temp_spl2d%isHermite   = 1
+            CALL EZspline_setup(temp_spl2d,temp2d,ier,EXACT_DIM=.true.)
+            JBS3D = temp_spl2d%fspl
+            CALL EZspline_free(temp_spl2d,ier)
+         ENDIF
+
+         IF( etapar_type == 'read_from_file' ) THEN
+            CALL read_var_hdf5(fid,'eta_prof',nt_prof,nrho_prof,ier,DBLVAR=temp2d)
+            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'eta_prof',ier)
+            IF (lverb) WRITE(6,'(A,F9.3,A,F9.3,A)') '   eta_par   = [', &
+                        MINVAL(temp2d)*1E7,',',MAXVAL(temp2d)*1e7,'] E-7 Ohm.m'
+            CALL EZspline_init(temp_spl2d,nt_prof,nrho_prof,bcs0,bcs0,ier)
+            temp_spl2d%x1          = taxis_prof
+            temp_spl2d%x2          = raxis_prof
+            temp_spl2d%isHermite   = 1
+            CALL EZspline_setup(temp_spl2d,temp2d,ier,EXACT_DIM=.true.)
+            eta3D = temp_spl2d%fspl
+            CALL EZspline_free(temp_spl2d,ier)
+         END IF
+         DEALLOCATE(temp2d)
+
          ! Close the HDF5 file
          CALL close_hdf5(fid,ier)
          IF (ier /= 0) CALL handle_err(HDF5_CLOSE_ERR,TRIM(filename),ier)
@@ -406,6 +439,30 @@ MODULE thrift_profiles_mod
       RETURN
       END SUBROUTINE get_prof_p
 
+      SUBROUTINE get_prof_JBS(rho_val,t_val,val)
+         IMPLICIT NONE
+         REAL(rprec), INTENT(in) :: rho_val
+         REAL(rprec), INTENT(in) :: t_val
+         REAL(rprec), INTENT(out) :: val
+         INTEGER     :: i
+         REAL(rprec) :: nk, tk
+         val = 0
+         CALL get_prof_f(rho_val,t_val,JBS3D,val)
+         RETURN
+      END SUBROUTINE get_prof_JBS
+
+      SUBROUTINE get_prof_eta(rho_val,t_val,val)
+         IMPLICIT NONE
+         REAL(rprec), INTENT(in) :: rho_val
+         REAL(rprec), INTENT(in) :: t_val
+         REAL(rprec), INTENT(out) :: val
+         INTEGER     :: i
+         REAL(rprec) :: nk, tk
+         val = 0
+         CALL get_prof_f(rho_val,t_val,eta3D,val)
+         RETURN
+      END SUBROUTINE get_prof_eta
+
       SUBROUTINE get_prof_pprime(rho_val,t_val,val)
       IMPLICIT NONE
       REAL(rprec), INTENT(in) :: rho_val
@@ -580,6 +637,10 @@ MODULE thrift_profiles_mod
       IF (ASSOCIATED(P3D))        CALL mpidealloc(TE3D,win_P3D)
       IF (ASSOCIATED(NI4D))       CALL mpidealloc(NI4D,win_NI4D)
       IF (ASSOCIATED(TI4D))       CALL mpidealloc(TI4D,win_TI4D)
+      IF(bootstrap_type=='read_from_file') THEN
+         IF (ASSOCIATED(JBS3D))       CALL mpidealloc(NE3D,win_JBS3D)
+         IF (ASSOCIATED(eta3D))       CALL mpidealloc(eta3D,win_eta3D)
+      END IF
       END SUBROUTINE free_profiles
 
 END MODULE thrift_profiles_mod

--- a/THRIFT/Sources/thrift_run_bootstrap.f90
+++ b/THRIFT/Sources/thrift_run_bootstrap.f90
@@ -20,7 +20,7 @@
 !-----------------------------------------------------------------------
       IMPLICIT NONE
       INTEGER :: i, ier
-      REAL(rprec) :: epsilon, pp1, pm1, ds
+      REAL(rprec) :: epsilon, pp1, pm1, ds, rho, s
       REAL(rprec), DIMENSION(:), ALLOCATABLE ::  j_temp
 !----------------------------------------------------------------------
 !     BEGIN SUBROUTINE
@@ -51,6 +51,14 @@
          CASE ('bootsj')
             CALL thrift_paraexe('booz_xform',proc_string,lscreen_subcodes)
             CALL thrift_paraexe('bootsj',proc_string,lscreen_subcodes)
+
+         CASE('read_from_file')
+            DO i = 1, nsj
+               s = THRIFT_S(i)
+               rho = SQRT(s)
+               CALL get_prof_JBS(rho,THRIFT_T(mytimestep),THRIFT_JBOOT(i,mytimestep))
+            END DO
+
          CASE ('sfincs')
       END SELECT
 

--- a/THRIFT/Sources/thrift_runtime.f90
+++ b/THRIFT/Sources/thrift_runtime.f90
@@ -75,7 +75,7 @@ MODULE thrift_runtime
                       eccd_type, nbcd_type, &
                       proc_string, vessel_ecrh, mirror_ecrh, &
                       targettype_ecrh, antennatype_ecrh, &
-                      magdiag_coil
+                      magdiag_coil, etapar_type
 
     REAL(rprec), PARAMETER :: THRIFT_VERSION = 0.50 
     !-----------------------------------------------------------------------

--- a/pySTEL/libstell/plasma.py
+++ b/pySTEL/libstell/plasma.py
@@ -8,6 +8,7 @@ EC = 1.602176634E-19 # Electron charge [C]
 DA = 1.66053906660E-27 # Dalton
 ME = 9.1093837E-31 # Electron mass [kg]
 MP = 1.672621637E-27 # Proton mass [kg]
+EPS0 = 8.8541878188E-12 # Vacuum permittivity [F/m]
 
 import numpy as np
 
@@ -143,6 +144,25 @@ class PLASMA:
         
         return dens
     
+    def get_density_der(self,species,rho):
+        # get derivative of density, dn/drho
+        # rho can be a number or a list of numbers
+        
+        #check if species exist in list_of_species
+        if species not in self.list_of_species:
+            print(f"ERROR: Species {species} is not in the plasma.")
+            exit(1)
+        
+        n0 = self.density[species]['n0']
+        nedge = self.density[species]['nedge']
+        exponent = self.density[species]['exponent']
+        
+        rho = np.array(rho)
+        
+        dens_der = (n0-nedge)*(-exponent*rho**(exponent-1))
+        
+        return dens_der
+    
     def get_temperature(self,species,rho):
         # rho can be a number or a list of numbers
         
@@ -160,6 +180,25 @@ class PLASMA:
         temp = Tedge + (T0-Tedge)*(1-rho**exponent)
         
         return temp
+    
+    def get_temperature_der(self,species,rho):
+        # get derivative of temperature, dT/drho
+        # rho can be a number or a list of numbers
+        
+        #check if species exist in list_of_species
+        if species not in self.list_of_species:
+            print(f"ERROR: Species {species} is not in the plasma.")
+            exit(1)
+        
+        T0 = self.temperature[species]['T0']
+        Tedge = self.temperature[species]['Tedge']
+        exponent = self.temperature[species]['exponent']
+        
+        rho = np.array(rho)
+        
+        temp_der = (T0-Tedge)*(-exponent*rho**(exponent-1))
+        
+        return temp_der
     
     def get_thermal_speed(self,species,rho):
         
@@ -188,9 +227,7 @@ class PLASMA:
         
         avg_profile = trapezoid(profile * dVdrho(rho), rho) / volume
         
-        return avg_profile
-        
-        
+        return avg_profile  
     
     def get_collisionality(self,species,rho,vtest=None):
         # computes collisionality of test particle of 'species' 
@@ -389,6 +426,7 @@ class PLASMA:
         # parts of this routine copied from STELLOPT/BENCHMARKS/THRIFT_TEST/make_profiles.py
         
         import h5py
+        import sys
         
         if filename is None:
             filename = 'profiles.h5'
@@ -441,13 +479,265 @@ class PLASMA:
         hf.create_dataset('te_prof', data=Te)
         hf.create_dataset('ni_prof', data=ni)
         hf.create_dataset('ti_prof', data=Ti)
-        
+
         hf.close()
         
+        print(f'{filename} created with success!')
+        
+    def get_pressure_polynomial_coefficients(self,deg_fit=10):
+        # this computes the AM coefficients and the PRES_SCALE scalar for a VMEC input
+        # assuming that PMASS_TYPE = 'power_series'
+        # p = sum(n_j*T_j), j=all species, and pressure comes in Pa
+        
+        # note that the AM coefficients correspond to the polynomial in s=roa^2
+        # so we will make a polyfit with deg_fit
+        
+        import matplotlib.pyplot as plt
+        from scipy.interpolate import CubicSpline
+        
+        roa = np.linspace(0,1,100)
+        s = roa**2
+        
+        p=0
+        for species in self.list_of_species:
+            
+            n = self.get_density(species,roa)
+            T = self.get_temperature(species,roa) 
+            
+            # total pressure polynomial in Pascal units
+            p += n*T*EC
+        
+        # make a polynomial fit. 
+        # in the future it might be better to use splines which VMEC accepts?    
+        p_pol = np.polyfit(s,p,deg_fit)
+        p_pol = np.poly1d(p_pol)
+            
+        # normalize p_pol by p(s=0) and use this value as PRES_SCALE
+        PRES_SCALE = p_pol(0.0)
+        p_pol = p_pol / PRES_SCALE
+        
+        AM = p_pol.c[-1:0:-1]
+        
+        plt.plot(s,p,'.-')
+        plt.plot(s,PRES_SCALE*p_pol(s),'-')
+        plt.xlabel('s')
+        plt.ylabel('pressure [Pa]')
+        plt.show
+        
+        print(f'PRES_SCALE = {PRES_SCALE:.7e}')
+        print(f'AM = {AM}')
+        
+        # make a cubic spline
+        cs = CubicSpline(s,p)
+        s_VMEC = np.linspace(0,1,50)
+        
+        pres = cs(s_VMEC)   
+        pres = pres / PRES_SCALE             
         
         
+        print("PMASS_TYPE = 'cubic_spline' ")
+        print(f'PRES_SCALE = {PRES_SCALE:.7e}')
+        print(f'AM_AUX_S = {s_VMEC}')
+        print(f'AM_AUX_F = {pres}')
         
+        return AM,PRES_SCALE
 
+        
+    def print_SFINCS_namelist(self,roa):
+        # prints in the command line physics and species parameters namelist of for SFINCS
+        
+        n_species = np.array( [self.get_density(species,rho=roa) for species in self.list_of_species] )
+        T_species = np.array( [self.get_temperature(species,rho=roa) for species in self.list_of_species] )
+        m_species = np.array( [self.mass[species] for species in self.list_of_species] )
+        Z_species = np.array( [self.Zcharge[species] for species in self.list_of_species] )
+        
+        nder_species = np.array( [self.get_density_der(species,rho=roa) for species in self.list_of_species] )
+        Tder_species = np.array( [self.get_temperature_der(species,rho=roa) for species in self.list_of_species] )
+
+        ## reference values
+        nBar = np.max(n_species) # pick largest value. must be in m^-3
+        mBar = MP # must be in kg 
+        TBar = np.max(T_species) # must be in eV
+        
+        vBar = np.sqrt(2*TBar*EC/mBar)
+        
+        print(f'nBar = {nBar}')
+        print(f'vBar = {vBar}')
+        
+        # mandatory values -- these values (BBar=1 and RBar=1) are mandatory when mag field is read from VMEC wout file (see SFINCS documentation)
+        BBar = 1.0
+        RBar = 1.0
+        
+        # print(f'jbs.B = {-1.2e-4*EC*nBar*vBar*BBar}')
+        
+        # compute loglambda as in PENTA
+        Te = self.get_temperature('electrons',rho=roa)
+        ne = self.get_density('electrons',rho=roa)
+        if(Te>50):
+            loglambda = 25.3 - 1.15*np.log10(ne/1e6) + 2.3*np.log10(Te)
+        else:
+            loglambda = 23.4 - 1.15*np.log10(ne/1e6) + 3.45*np.log10(Te)
+        
+        nuHat = 4*np.sqrt(2*np.pi)*nBar*EC**4*loglambda / ( 3*(4*np.pi*EPS0)**2 * np.sqrt(mBar) * (EC*TBar)**1.5 )
+        
+        # compute physics parameters
+        Delta = mBar*vBar / (EC*BBar*RBar)
+        alpha = 1.0
+        nu_n = nuHat * RBar/vBar
+        
+        mHats = m_species/mBar
+        nHats = n_species/nBar
+        THats = T_species/TBar
+        dNHatdrNs = nder_species/nBar
+        dTHatdrNs = Tder_species/TBar
+        
+        # print output
+        
+        print('&speciesParameters')
+        print(f"Zs = {' '.join(map(str, Z_species))}")
+        print(f"mHats = {' '.join(map(str, mHats))}")
+        print(f"nHats = {' '.join(map(str, nHats))}")
+        print(f"THats = {' '.join(map(str, THats))}")
+        print(f"dNHatdrNs = {' '.join(map(str, dNHatdrNs))}")
+        print(f"dTHatdrNs = {' '.join(map(str, dTHatdrNs))}")
+        print('/')
+
+        print('&physicsParameters')
+        print(f'Delta = {Delta}')
+        print(f'alpha = {alpha}')
+        print(f'nu_n = {nu_n}')
+
+        print('dont forget the rest of the parameters...')
+        
+        
+    def print_SFINCS_list_namelist(self,roa_list,folder_path):
+        # saves input.namlist inside folder_path/surface_k
+        
+        import os
+        
+        ## reference values
+        nBar = 1e20  # must be in m^-3
+        mBar = MP    # must be in kg 
+        TBar = 1e3   # must be in eV
+        
+        vBar = np.sqrt(2*TBar*EC/mBar)
+        
+        # mandatory values -- these values (BBar=1 and RBar=1) are mandatory when mag field is read from VMEC wout file (see SFINCS documentation)
+        BBar = 1.0
+        RBar = 1.0
+        
+        for k,roa in enumerate(roa_list):
+            
+            folder_name = f'surface_{k+1}'  # Folders will be surface_1, surface_2, etc.
+            os.makedirs(folder_path+'/'+folder_name, exist_ok=True)
+        
+            n_species = np.array( [self.get_density(species,rho=roa) for species in self.list_of_species] )
+            T_species = np.array( [self.get_temperature(species,rho=roa) for species in self.list_of_species] )
+            m_species = np.array( [self.mass[species] for species in self.list_of_species] )
+            Z_species = np.array( [self.Zcharge[species] for species in self.list_of_species] )
+            
+            nder_species = np.array( [self.get_density_der(species,rho=roa) for species in self.list_of_species] )
+            Tder_species = np.array( [self.get_temperature_der(species,rho=roa) for species in self.list_of_species] )
+
+            # compute loglambda as in PENTA
+            Te = self.get_temperature('electrons',rho=roa)
+            ne = self.get_density('electrons',rho=roa)
+            if(Te>50):
+                loglambda = 25.3 - 1.15*np.log10(ne/1e6) + 2.3*np.log10(Te)
+            else:
+                loglambda = 23.4 - 1.15*np.log10(ne/1e6) + 3.45*np.log10(Te)
+            
+            nuHat = 4*np.sqrt(2*np.pi)*nBar*EC**4*loglambda / ( 3*(4*np.pi*EPS0)**2 * np.sqrt(mBar) * (EC*TBar)**1.5 )
+            
+            # compute physics parameters
+            Delta = mBar*vBar / (EC*BBar*RBar)
+            alpha = 1.0
+            nu_n = nuHat * RBar/vBar
+            
+            mHats = m_species/mBar
+            nHats = n_species/nBar
+            THats = T_species/TBar
+            dNHatdrNs = nder_species/nBar
+            dTHatdrNs = Tder_species/TBar
+            
+            file_content = f"""! Input file for SFINCS version 3.
+
+&general
+ambipolarSolve = .true. !.false.
+Er_min = -10
+Er_max = 10
+NEr_ambipolarSolve = 10
+/
+
+&geometryParameters
+geometryScheme = 5
+
+inputRadialCoordinate = 3
+rN_wish = {roa}
+inputRadialCoordinateForGradients = 3   !the radial coordinate of the gradients given in species parameters is rN=sqrt(PHI/PHIEDGE)
+
+VMECRadialOption = 1  !get the nearest available flux surface from VMEC HALF grid 
+equilibriumFile = "wout_GIGA_v120.nc"
+min_Bmn_to_load = 1e-4
+/
+
+&speciesParameters
+Zs = {' '.join(map(str, Z_species))}
+mHats = {' '.join(map(str, mHats))}
+nHats = {' '.join(map(str, nHats))}
+THats = {' '.join(map(str, THats))}
+dNHatdrNs = {' '.join(map(str, dNHatdrNs))}
+dTHatdrNs = {' '.join(map(str, dTHatdrNs))}
+/
+
+&physicsParameters
+Delta = {Delta}
+alpha = {alpha}
+nu_n = {nu_n}
+
+dPhiHatdrN = 1.0 ! since we are looking for the ambipolar value, I guess this one is free??
+
+collisionOperator = 0
+
+includeXDotTerm = .true.
+includeElectricFieldTermInXiDot = .true.
+useDKESExBDrift = .false.
+
+includePhi1 = .false.  ! well, at some point this should be True to be more complete...
+
+magneticDriftScheme = 1  ! this includes poloidal and toroidal magnetic drifts
+/
+
+&resolutionParameters
+Ntheta = 23 ! needs to be an odd number
+Nzeta = 121 ! needs to be an odd number and at low collisionality might be needeed to be of the order 100 to converge
+
+Nxi = 100
+Nx = 6
+solverTolerance = 1d-6
+/
+
+&otherNumericalParameters
+/
+
+&preconditionerOptions
+/
+
+&export_f
+  export_full_f = .false.
+  export_delta_f = .false.
+/
+"""
+            
+             # Define the file path
+            file_path = os.path.join(folder_path+'/'+folder_name, 'input.namelist')
+            
+            # Write the content to the file
+            with open(file_path, 'w') as f:
+                f.write(file_content)
+
+            print(f"Created {file_path}")
+        
 
 # Main routine
 if __name__=="__main__":

--- a/pySTEL/libstell/thrift.py
+++ b/pySTEL/libstell/thrift.py
@@ -63,6 +63,13 @@ class THRIFT():
                 if temp in f:
                     setattr(self, temp, np.array(f[temp][:]))
                     
+        self.units_dictionary = {}
+        for current in ['THRIFT_I','THRIFT_IBOOT','THRIFT_IECCD','THRIFT_INBCD','THRIFT_IOHMIC','THRIFT_IPLASMA','THRIFT_ISOURCE']:
+            self.units_dictionary[current] = r'[A]'
+        for current_density in ['THRIFT_J','THRIFT_JBOOT','THRIFT_JECCD','THRIFT_JNBCD','THRIFT_JOHMIC','THRIFT_JPLASMA','THRIFT_JSOURCE']:
+            self.units_dictionary[current_density] = r'[A/m$^2]$'
+        self.units_dictionary['THRIFT_ETAPARA'] = r'$[\Omega\,$m]'
+                    
     def plot_vars_in_time(self,*vars,time_array=[0,1/4,1/2,3/4,1]):
         # plots var as a funciton of roa at different times
         # time_array is in fractions of t_end
@@ -82,11 +89,15 @@ class THRIFT():
             _, ax = plt.subplots(figsize=(11,8))
             for it,time in enumerate(times):
                 ax.plot(np.sqrt(self.THRIFT_S),plot_var[it,:],label=f't={time}s')
-                ax.set_xlabel('r/a')
-                ax.set_ylabel('')
+                ax.set_xlabel('r/a') 
                 ax.set_title(var)   
             ax.grid()    
             ax.legend()
+            try:
+                ax.set_ylabel(self.units_dictionary[var])
+            except:
+                ax.set_ylabel('')
+            # ax.set_yscale('log')
             plt.show()
             
     def check_var_shape(self,var, nt, nrho):
@@ -102,6 +113,37 @@ class THRIFT():
         else:
             print(f"{var} is not a numpy array.")
             exit(0)
+            
+    def plot_vars_vs_iota(self,*vars,time_array=[0,1/4,1/2,3/4,1]):
+        # plots var as a funciton of iota at different times
+        # time_array is in fractions of t_end
+        # vars is any variable of the type THRIFT_## with dimension (ntimesteps,nssize)
+        
+        for var in vars:
+            plot_var = getattr(self,var)
+            # check dimension of var is (ntimesteps,nssize)
+            self.check_var_shape(plot_var,self.ntimesteps,self.nssize)
+            t_end = self.THRIFT_T[-1]
+            times = np.array(time_array)*t_end
+            
+            idx = [np.argmin(np.abs(self.THRIFT_T-t)) for t in times]
+            times = self.THRIFT_T[idx]
+            plot_var = plot_var[idx,:]
+            
+            iota = self.THRIFT_IOTA[idx,:]
+            
+            _, ax = plt.subplots(figsize=(11,8))
+            for it,time in enumerate(times): 
+                ax.plot(iota[it,:],plot_var[it,:],label=f't={time}s')
+                ax.set_xlabel('iota') 
+                ax.set_title(var)   
+            ax.grid()    
+            ax.legend()
+            try:
+                ax.set_ylabel(self.units_dictionary[var])
+            except:
+                ax.set_ylabel('')
+            plt.show()
 
             
     # def compare_J(self,time_array=[0,1/4,1/2,3/4,1]):


### PR DESCRIPTION
I have included an option to read the bootstrap current and/or the parallel resistivity profiles from a file (the same file where the plasma profiles are stored). I have also created a new namelist variable, `etapar_type`, which allows to change from `sauter`, `classic`, `read_from_file` and, in the future, from `penta`.

I have also added new functionalities to the classes `dkes`, `plasma`, `thrift` and `penta`.

These changes should be merged into `develop` and also to the branch `THRIFT_DKES_PENTA`.