### PR TITLE
Merge of feature/thrift_restart into develop and feature/THRIFT_DKES_PENTA

### DIFF
--- a/THRIFT/Sources/thrift_init.f90
+++ b/THRIFT/Sources/thrift_init.f90
@@ -212,11 +212,6 @@
             DEALLOCATE(temp2d,temp1d)
 
          END IF
-
-         ! Bcast tstart
-         CALL MPI_BARRIER(MPI_COMM_SHARMEM,ierr_mpi)
-         CALL MPI_BCAST(tstart,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_SHARMEM,ierr_mpi)
-         IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_ERR,'set tstart',ierr_mpi)
       END IF
 
       ! Check that tend > tstart

--- a/THRIFT/Sources/thrift_init.f90
+++ b/THRIFT/Sources/thrift_init.f90
@@ -158,7 +158,7 @@
       CALL read_thrift_profh5(TRIM(prof_string))
 
       ! Read restart file
-      IF (restart_from_file) THEN
+      IF (lrestart_from_file) THEN
          UGRID_RESTART = 0.0
          IF (lverb) THEN 
             WRITE(6,'(A)') '----- Reading Restart File -----'

--- a/THRIFT/Sources/thrift_input_mod.f90
+++ b/THRIFT/Sources/thrift_input_mod.f90
@@ -36,7 +36,7 @@
                               rfocus_ecrh, nra_ecrh, nphi_ecrh, &
                               freq_ecrh, power_ecrh, &
                               pecrh_aux_t, pecrh_aux_f, ecrh_rc, ecrh_w, &
-                              etapar_type
+                              etapar_type, restart_from_file, restart_filename
       
 !-----------------------------------------------------------------------
 !     Subroutines
@@ -47,6 +47,8 @@
 
       SUBROUTINE init_thrift_input
       IMPLICIT NONE
+      restart_from_file  = .FALSE.
+      restart_filename   = 'restart_THRIFT.h5'
       bootstrap_type     = 'bootsj'
       etapar_type        = 'sauter'
       eccd_type          = ''
@@ -58,7 +60,7 @@
       ntimesteps         = 32
       n_eq               = 99
       npicard            = 5
-      tstart             = 0.1
+      tstart             = 0.0
       tend               = 1.0
       jtol               = 0.01
       picard_factor      = 0.5
@@ -117,6 +119,7 @@
       CALL tolower(bootstrap_type)
       CALL tolower(etapar_type)
       CALL tolower(eccd_type)
+      CALL tolower(restart_filename)
       leccd = eccd_type .ne. ''
       nsj = nrho;
       RETURN
@@ -139,6 +142,8 @@
       WRITE(iunit_out,'(A)') '&THRIFT_INPUT'
       WRITE(iunit_out,'(A)') '!---------- GENERAL PARAMETERS ------------'
       WRITE(iunit_out,outint) 'NPARALLEL_RUNS',nparallel_runs
+      WRITE(iunit_out,outint) 'RESTART_FROM_FILE',restart_from_file
+      WRITE(iunit_out,outint) 'RESTART_FILENAME',restart_filename
       WRITE(iunit_out,outstr) 'BOOTSTRAP_TYPE',bootstrap_type
       WRITE(iunit_out,outstr) 'ETAPAR_TYPE',etapar_type
       WRITE(iunit_out,outflt) 'JTOL',jtol

--- a/THRIFT/Sources/thrift_input_mod.f90
+++ b/THRIFT/Sources/thrift_input_mod.f90
@@ -117,7 +117,6 @@
       CALL tolower(bootstrap_type)
       CALL tolower(etapar_type)
       CALL tolower(eccd_type)
-      CALL tolower(restart_filename)
       leccd = eccd_type .ne. ''
       nsj = nrho;
       RETURN

--- a/THRIFT/Sources/thrift_input_mod.f90
+++ b/THRIFT/Sources/thrift_input_mod.f90
@@ -36,7 +36,7 @@
                               rfocus_ecrh, nra_ecrh, nphi_ecrh, &
                               freq_ecrh, power_ecrh, &
                               pecrh_aux_t, pecrh_aux_f, ecrh_rc, ecrh_w, &
-                              etapar_type, restart_from_file, restart_filename
+                              etapar_type
       
 !-----------------------------------------------------------------------
 !     Subroutines
@@ -47,8 +47,6 @@
 
       SUBROUTINE init_thrift_input
       IMPLICIT NONE
-      restart_from_file  = .FALSE.
-      restart_filename   = 'restart_THRIFT.h5'
       bootstrap_type     = 'bootsj'
       etapar_type        = 'sauter'
       eccd_type          = ''
@@ -142,8 +140,6 @@
       WRITE(iunit_out,'(A)') '&THRIFT_INPUT'
       WRITE(iunit_out,'(A)') '!---------- GENERAL PARAMETERS ------------'
       WRITE(iunit_out,outint) 'NPARALLEL_RUNS',nparallel_runs
-      WRITE(iunit_out,outint) 'RESTART_FROM_FILE',restart_from_file
-      WRITE(iunit_out,outint) 'RESTART_FILENAME',restart_filename
       WRITE(iunit_out,outstr) 'BOOTSTRAP_TYPE',bootstrap_type
       WRITE(iunit_out,outstr) 'ETAPAR_TYPE',etapar_type
       WRITE(iunit_out,outflt) 'JTOL',jtol

--- a/THRIFT/Sources/thrift_interface_mod.f90
+++ b/THRIFT/Sources/thrift_interface_mod.f90
@@ -185,9 +185,13 @@ MODULE THRIFT_INTERFACE_MOD
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'thrift_main', ierr_mpi)
       CALL MPI_BCAST(prof_string, 256, MPI_CHARACTER, master, MPI_COMM_THRIFT, ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'thrift_main', ierr_mpi)
+      CALL MPI_BCAST(restart_filename, 256, MPI_CHARACTER, master, MPI_COMM_THRIFT, ierr_mpi)
+      IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'thrift_main', ierr_mpi)
       CALL MPI_BCAST(lvmec, 1, MPI_LOGICAL, master, MPI_COMM_THRIFT, ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'thrift_main', ierr_mpi)
       CALL MPI_BCAST(limas, 1, MPI_LOGICAL, master, MPI_COMM_THRIFT, ierr_mpi)
+      IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'thrift_main', ierr_mpi)
+      CALL MPI_BCAST(lrestart_from_file, 1, MPI_LOGICAL, master, MPI_COMM_THRIFT, ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'thrift_main', ierr_mpi)
 #endif
       RETURN

--- a/THRIFT/Sources/thrift_interface_mod.f90
+++ b/THRIFT/Sources/thrift_interface_mod.f90
@@ -136,7 +136,9 @@ MODULE THRIFT_INTERFACE_MOD
         limas = .false.
         lverb = .true.
         lvmec = .false.
+        lrestart_from_file = .false.
         id_string = ''
+        restart_filename = ''
 
         ! First Handle the input arguments
         CALL GETCARG(1, arg1, numargs)
@@ -156,14 +158,19 @@ MODULE THRIFT_INTERFACE_MOD
                 i = i + 1
                 lvmec = .true.
                 CALL GETCARG(i, prof_string, numargs)
+            case ("-restart")
+                i = i + 1
+                lrestart_from_file = .true.
+                CALL GETCARG(i, restart_filename, numargs)
             case ("-diagno")
                 ldiagno = .true.
             case ("-help", "-h") ! Output Help message
-                write(6, *) ' Beam MC Code'
+                write(6, *) ' THRIFT Current Evolution Code'
                 write(6, *) ' Usage: xthrift <options>'
                 write(6, *) '    <options>'
                 write(6, *) '     -vmec ext:     VMEC input/wout extension'
                 write(6, *) '     -prof file:    Profile file'
+                write(6, *) '     -restart file: Previous run file'
                 write(6, *) '     -diagno:       Compute Magnetic Diagnostic Response'
                 write(6, *) '     -noverb:       Supress all screen output'
                 write(6, *) '     -help:         Output help message'

--- a/THRIFT/Sources/thrift_jinductive.f90
+++ b/THRIFT/Sources/thrift_jinductive.f90
@@ -44,8 +44,8 @@
       ! If mytimestep = 1 and am reading from restart, then set the following:
       IF (mytimestep==1 .and. restart_from_file) THEN
             THRIFT_UGRID(:,mytimestep) = UGRID_RESTART
-            prevtimestep = 1 
-            dt = THRIFT_T(2)-THRIFT_T(1) ! dt = delta t this iter
+            prevtimestep = 1 !this is a trick in order to use UGRID_RESTART as the array of the previous iter
+            dt = dt_first_iter
       ELSE 
             prevtimestep = mytimestep-1   ! previous time step index
             dt = THRIFT_T(mytimestep)-THRIFT_T(prevtimestep) ! dt = delta t this iter

--- a/THRIFT/Sources/thrift_jinductive.f90
+++ b/THRIFT/Sources/thrift_jinductive.f90
@@ -33,11 +33,20 @@
 !----------------------------------------------------------------------
 !     BEGIN SUBROUTINE
 !======================================================================
-      ! If mytimestep = 1 ITOT=0 and continue to next iteration
-      IF (mytimestep==1) THEN
+      ! If mytimestep = 1 and not reading from restart, then ITOT=0 and continue to next iteration
+      IF (mytimestep==1 .and. restart_from_file .eqv. .false.) THEN
             THRIFT_JPLASMA(:,mytimestep) = -THRIFT_JSOURCE(:,mytimestep)
             THRIFT_IPLASMA(:,mytimestep) = -THRIFT_ISOURCE(:,mytimestep)
             THRIFT_I(:,mytimestep) = THRIFT_IPLASMA(:,mytimestep)+THRIFT_ISOURCE(:,mytimestep)
+            RETURN 
+      END IF
+
+      ! If mytimestep = 1 and am reading from restart, then set the following:
+      IF (mytimestep==1 .and. restart_from_file .eqv. .true.) THEN
+            THRIFT_JPLASMA(:,mytimestep) = JPLASMA_RESTART
+            THRIFT_IPLASMA(:,mytimestep) = IPLASMA_RESTART
+            THRIFT_I(:,mytimestep) = THRIFT_IPLASMA(:,mytimestep)+THRIFT_ISOURCE(:,mytimestep)
+            THRIFT_UGRID(:,mytimestep) = UGRID_RESTART
             RETURN 
       END IF
 

--- a/THRIFT/Sources/thrift_jinductive.f90
+++ b/THRIFT/Sources/thrift_jinductive.f90
@@ -24,7 +24,7 @@
       IMPLICIT NONE
       INTEGER :: i, j, prevtimestep, ier
       INTEGER :: bcs0(2)
-      REAL(rprec) :: rho,s,ds,dt,mytime,temp,Lext,rmaj,amin
+      REAL(rprec) :: rho,s,ds,dt,temp,Lext,rmaj,amin
       REAL(rprec), DIMENSION(:), ALLOCATABLE ::j_temp,&
                      A_temp,B_temp,C_temp,D_temp,&
                      BP_temp, CP_temp, DP_temp,temp_arr,  &
@@ -34,7 +34,7 @@
 !     BEGIN SUBROUTINE
 !======================================================================
       ! If mytimestep = 1 and not reading from restart, then ITOT=0 and continue to next iteration
-      IF (mytimestep==1 .and. restart_from_file .eqv. .false.) THEN
+      IF (mytimestep==1 .and. .not. restart_from_file) THEN
             THRIFT_JPLASMA(:,mytimestep) = -THRIFT_JSOURCE(:,mytimestep)
             THRIFT_IPLASMA(:,mytimestep) = -THRIFT_ISOURCE(:,mytimestep)
             THRIFT_I(:,mytimestep) = THRIFT_IPLASMA(:,mytimestep)+THRIFT_ISOURCE(:,mytimestep)
@@ -42,19 +42,16 @@
       END IF
 
       ! If mytimestep = 1 and am reading from restart, then set the following:
-      IF (mytimestep==1 .and. restart_from_file .eqv. .true.) THEN
-            THRIFT_JPLASMA(:,mytimestep) = JPLASMA_RESTART
-            THRIFT_IPLASMA(:,mytimestep) = IPLASMA_RESTART
-            THRIFT_I(:,mytimestep) = THRIFT_IPLASMA(:,mytimestep)+THRIFT_ISOURCE(:,mytimestep)
+      IF (mytimestep==1 .and. restart_from_file) THEN
             THRIFT_UGRID(:,mytimestep) = UGRID_RESTART
-            RETURN 
+            prevtimestep = 1 
+            dt = THRIFT_T(2)-THRIFT_T(1) ! dt = delta t this iter
+      ELSE 
+            prevtimestep = mytimestep-1   ! previous time step index
+            dt = THRIFT_T(mytimestep)-THRIFT_T(prevtimestep) ! dt = delta t this iter
       END IF
 
-      ! Time variables
-      prevtimestep = mytimestep-1   ! previous time step index
-      dt = THRIFT_T(mytimestep)-THRIFT_T(prevtimestep) ! dt = delta t this iter
-      mytime = THRIFT_T(mytimestep)
- 
+
       ! If at zero beta, copy previous value of JPLASMA and skip
       IF (eq_beta == 0) THEN
          IF (mytimestep /= 1) THEN

--- a/THRIFT/Sources/thrift_jinductive.f90
+++ b/THRIFT/Sources/thrift_jinductive.f90
@@ -34,7 +34,7 @@
 !     BEGIN SUBROUTINE
 !======================================================================
       ! If mytimestep = 1 and not reading from restart, then ITOT=0 and continue to next iteration
-      IF (mytimestep==1 .and. .not. restart_from_file) THEN
+      IF (mytimestep==1 .and. .not. lrestart_from_file) THEN
             THRIFT_JPLASMA(:,mytimestep) = -THRIFT_JSOURCE(:,mytimestep)
             THRIFT_IPLASMA(:,mytimestep) = -THRIFT_ISOURCE(:,mytimestep)
             THRIFT_I(:,mytimestep) = THRIFT_IPLASMA(:,mytimestep)+THRIFT_ISOURCE(:,mytimestep)
@@ -42,7 +42,7 @@
       END IF
 
       ! If mytimestep = 1 and am reading from restart, then set the following:
-      IF (mytimestep==1 .and. restart_from_file) THEN
+      IF (mytimestep==1 .and. lrestart_from_file) THEN
             THRIFT_UGRID(:,mytimestep) = UGRID_RESTART
             prevtimestep = 1 !this is a trick in order to use UGRID_RESTART as the array of the previous iter
             dt = dt_first_iter

--- a/THRIFT/Sources/thrift_runtime.f90
+++ b/THRIFT/Sources/thrift_runtime.f90
@@ -67,7 +67,7 @@ MODULE thrift_runtime
     DOUBLE PRECISION, PARAMETER :: electron_mass = 9.10938356D-31 !m_e
     DOUBLE PRECISION, PARAMETER :: e_charge      = 1.60217662E-19 !e_c
 
-    LOGICAL :: lverb, lvmec, lread_input, limas
+    LOGICAL :: lverb, lvmec, lread_input, limas, restart_from_file
     INTEGER :: nprocs_thrift, nparallel_runs, mboz, nboz, ier_paraexe, &
                mytimestep, nsubsteps
     REAL(rprec) :: pi, pi2, invpi2, mu0, to3
@@ -75,7 +75,7 @@ MODULE thrift_runtime
                       eccd_type, nbcd_type, &
                       proc_string, vessel_ecrh, mirror_ecrh, &
                       targettype_ecrh, antennatype_ecrh, &
-                      magdiag_coil, etapar_type
+                      magdiag_coil, etapar_type, restart_filename
 
     REAL(rprec), PARAMETER :: THRIFT_VERSION = 0.50 
     !-----------------------------------------------------------------------

--- a/THRIFT/Sources/thrift_runtime.f90
+++ b/THRIFT/Sources/thrift_runtime.f90
@@ -67,7 +67,7 @@ MODULE thrift_runtime
     DOUBLE PRECISION, PARAMETER :: electron_mass = 9.10938356D-31 !m_e
     DOUBLE PRECISION, PARAMETER :: e_charge      = 1.60217662E-19 !e_c
 
-    LOGICAL :: lverb, lvmec, lread_input, limas, restart_from_file
+    LOGICAL :: lverb, lvmec, lread_input, limas, lrestart_from_file
     INTEGER :: nprocs_thrift, nparallel_runs, mboz, nboz, ier_paraexe, &
                mytimestep, nsubsteps
     REAL(rprec) :: pi, pi2, invpi2, mu0, to3

--- a/THRIFT/Sources/thrift_vars.f90
+++ b/THRIFT/Sources/thrift_vars.f90
@@ -36,6 +36,11 @@ MODULE thrift_vars
     !          THRIFT_IPLASMA   Total enclosed induced current  
     !          THRIFT_IXXXXX    Total enclosed bootstrap/driven currents 
     !
+    !     Restart variables
+    !          JPLASMA_RESTART  Restart Jplasma
+    !          IPLASMA_RESTART  Restart Iplasma
+    !          UGRID_RESTART    Restart Ugrid
+    !
     !     Profile variables
     !          THRIFT_ETAPARA   Parallel electrical resistivity
     !          THRIFT_PPRIME    Radial pressure gradient
@@ -77,10 +82,12 @@ MODULE thrift_vars
                                  win_thrift_coeff_bp, win_thrift_coeff_cp, win_thrift_coeff_dp, &
              win_thrift_alpha1,  win_thrift_alpha2,   win_thrift_alpha3,   win_thrift_alpha4,   &
              win_thrift_matld,   win_thrift_matmd,    win_thrift_matud,    win_thrift_matrhs,   &
-             win_thrift_bvav
+             win_thrift_bvav,                                                                   &
+             win_thrift_jplasma_restart, win_thrift_iplasma_restart, win_thrift_ugrid_restart                                
     REAL(rprec) :: tstart, tend, jtol, picard_factor, boot_factor
     REAL(rprec), DIMENSION(:), POINTER :: THRIFT_RHO(:), THRIFT_RHOFULL(:), THRIFT_PHIEDGE(:), &
-                                          THRIFT_S(:),   THRIFT_SNOB(:),  THRIFT_T(:)
+                                          THRIFT_S(:),   THRIFT_SNOB(:),  THRIFT_T(:),         &
+                                          JPLASMA_RESTART(:), IPLASMA_RESTART(:), UGRID_RESTART(:)
     REAL(rprec), DIMENSION(:,:), POINTER :: &
                  THRIFT_J,THRIFT_I,THRIFT_UGRID, &
                  THRIFT_JPLASMA, THRIFT_IPLASMA, &
@@ -97,7 +104,8 @@ MODULE thrift_vars
                                  THRIFT_COEFF_BP,THRIFT_COEFF_CP,THRIFT_COEFF_DP,&
                  THRIFT_ALPHA1,  THRIFT_ALPHA2,  THRIFT_ALPHA3,  THRIFT_ALPHA4,  &
                  THRIFT_MATLD,   THRIFT_MATMD,   THRIFT_MATUD,   THRIFT_MATRHS,  &
-                 THRIFT_BVAV
+                 THRIFT_BVAV                                                  
+                 
 
     ! For ECCD in general
     INTEGER, PARAMETER :: ntime_ecrh = 200

--- a/THRIFT/Sources/thrift_vars.f90
+++ b/THRIFT/Sources/thrift_vars.f90
@@ -37,8 +37,6 @@ MODULE thrift_vars
     !          THRIFT_IXXXXX    Total enclosed bootstrap/driven currents 
     !
     !     Restart variables
-    !          JPLASMA_RESTART  Restart Jplasma
-    !          IPLASMA_RESTART  Restart Iplasma
     !          UGRID_RESTART    Restart Ugrid
     !
     !     Profile variables
@@ -83,11 +81,11 @@ MODULE thrift_vars
              win_thrift_alpha1,  win_thrift_alpha2,   win_thrift_alpha3,   win_thrift_alpha4,   &
              win_thrift_matld,   win_thrift_matmd,    win_thrift_matud,    win_thrift_matrhs,   &
              win_thrift_bvav,                                                                   &
-             win_thrift_jplasma_restart, win_thrift_iplasma_restart, win_thrift_ugrid_restart                                
+             win_thrift_ugrid_restart                                
     REAL(rprec) :: tstart, tend, jtol, picard_factor, boot_factor
     REAL(rprec), DIMENSION(:), POINTER :: THRIFT_RHO(:), THRIFT_RHOFULL(:), THRIFT_PHIEDGE(:), &
                                           THRIFT_S(:),   THRIFT_SNOB(:),  THRIFT_T(:),         &
-                                          JPLASMA_RESTART(:), IPLASMA_RESTART(:), UGRID_RESTART(:)
+                                          UGRID_RESTART(:)
     REAL(rprec), DIMENSION(:,:), POINTER :: &
                  THRIFT_J,THRIFT_I,THRIFT_UGRID, &
                  THRIFT_JPLASMA, THRIFT_IPLASMA, &

--- a/THRIFT/Sources/thrift_vars.f90
+++ b/THRIFT/Sources/thrift_vars.f90
@@ -82,7 +82,7 @@ MODULE thrift_vars
              win_thrift_matld,   win_thrift_matmd,    win_thrift_matud,    win_thrift_matrhs,   &
              win_thrift_bvav,                                                                   &
              win_thrift_ugrid_restart                                
-    REAL(rprec) :: tstart, tend, jtol, picard_factor, boot_factor
+    REAL(rprec) :: tstart, tend, jtol, picard_factor, boot_factor, dt_first_iter
     REAL(rprec), DIMENSION(:), POINTER :: THRIFT_RHO(:), THRIFT_RHOFULL(:), THRIFT_PHIEDGE(:), &
                                           THRIFT_S(:),   THRIFT_SNOB(:),  THRIFT_T(:),         &
                                           UGRID_RESTART(:)

--- a/pySTEL/libstell/thrift.py
+++ b/pySTEL/libstell/thrift.py
@@ -58,8 +58,8 @@ class THRIFT():
 				'THRIFT_IBOOT','THRIFT_IECCD','THRIFT_INBCD','THRIFT_IOHMIC','THRIFT_IOTA','THRIFT_IPLASMA','THRIFT_ISOURCE',\
 				'THRIFT_J','THRIFT_JBOOT','THRIFT_JECCD','THRIFT_JNBCD','THRIFT_JOHMIC','THRIFT_JPLASMA','THRIFT_JSOURCE',\
 				'THRIFT_MATLD','THRIFT_MATMD','THRIFT_MATRHS','THRIFT_MATUD','THRIFT_P','THRIFT_PHIEDGE','THRIFT_PPRIME',\
-				'THRIFT_RHO','THRIFT_RHOFULL','THRIFT_RMAJOR','THRIFT_S','THRIFT_S11','THRIFT_S12','THRIFT_SNOB','THRIFT_T','\
-				THRIFT_UGRID','THRIFT_VP']:
+				'THRIFT_RHO','THRIFT_RHOFULL','THRIFT_RMAJOR','THRIFT_S','THRIFT_S11','THRIFT_S12','THRIFT_SNOB','THRIFT_T',\
+				'THRIFT_UGRID','THRIFT_VP']:
                 if temp in f:
                     setattr(self, temp, np.array(f[temp][:]))
                     
@@ -113,6 +113,23 @@ class THRIFT():
         else:
             print(f"{var} is not a numpy array.")
             exit(0)
+            
+    def get_vars(self,var,time=0.0):
+        # return an array with var(roa) at t=time
+        # var is any variable of the type THRIFT_## with dimension (ntimesteps,nssize)
+        
+        plot_var = getattr(self,var)
+        
+        idx = np.argmin(np.abs(self.THRIFT_T-time))
+        
+        real_time = self.THRIFT_T[idx]
+        
+        print(f'Returning variable {var} at t={real_time}s')
+        
+        return plot_var[idx,:]
+        
+        
+        
             
     def plot_vars_vs_iota(self,*vars,time_array=[0,1/4,1/2,3/4,1]):
         # plots var as a funciton of iota at different times


### PR DESCRIPTION
A restart mode to THRIFT is introduced, meaning that now we can do a long simulation in several runs. The code reads a restart file whose name is specified in `&THRIFT_INPUT` under `RESTART_FILENAME`. The restart file can be the results file of the previous run. The boolean `RESTART_FROM_FILE` should be set to `TRUE` in the input namelist  in case the restart file is to be read, otherwise the code will ignore the restart mode and start a simulation as usual.

I have tested this new functionality in the following way. I took the input files in `BENCHMARKS/THRIFT_TEST` and made a single run from `tstart=0.0` to `tend=80.0`. Then I made multiple runs using restart files in the intervals `t=[0,20]`, `t=[20.5,40]`, `t=[40.5,60]` and `t=[60.5,80]`. The variable `THRIFT_UGRID` is compared at different times for the two cases (single run vs multiple runs):

![image](https://github.com/user-attachments/assets/6f2cd45d-b4fd-4467-b565-b50878d2889e)
![image](https://github.com/user-attachments/assets/77a38415-16ff-43a5-bbf4-f4a6694770e8)
![image](https://github.com/user-attachments/assets/1bc3ef7a-647d-4131-b2ac-4bf4256ac1b5)


Note that for any `t` in the interval `[0,20]` , the difference between single run and multiple runs should be 0.0 since both cases are essentially starting from the beginning and doing the exact same thing. After `t=20`, the divergences are of order `1E-10` which is probably due to the way the restart file is being read.

Finally, I have also tested this using a SQUID wout file and the bootstrap computed with `BOOTSJ` . The comparison _single run vs multiple runs_ gives similar results, i.e., differences of order `1E-10`.