### PR TITLE
VMEC2000: Now catch and handle TimeStepControl error.

### DIFF
--- a/VMEC2000/Sources/General/vmec_params.f
+++ b/VMEC2000/Sources/General/vmec_params.f
@@ -25,7 +25,8 @@ C-----------------------------------------------
      7                      bsub_bad_js1_flag=12,
      8                      r01_bad_value_flag=13,
      9                      arz_bad_value_flag=14,
-     1                      imas_read_flag=15
+     1                      time_control_flag=15,
+     2                      imas_read_flag=16
       INTEGER, PARAMETER :: restart_flag=1, readin_flag=2,
      1                      timestep_flag=4,output_flag=8, 
      2                      cleanup_flag=16, reset_jacdt_flag=32,

--- a/VMEC2000/Sources/Input_Output/fileout.f
+++ b/VMEC2000/Sources/Input_Output/fileout.f
@@ -163,7 +163,7 @@ C-----------------------------------------------
       INTEGER :: js, istat1=0, irst0, OFU
       REAL(dp), DIMENSION(:), POINTER :: lu, lv
       REAL(dp), ALLOCATABLE :: br_out(:), bz_out(:)
-      CHARACTER(LEN=*), PARAMETER, DIMENSION(0:14) :: werror = (/
+      CHARACTER(LEN=*), PARAMETER, DIMENSION(0:15) :: werror = (/
      &   'EXECUTION TERMINATED NORMALLY                            ', ! norm_term_flag
      &   'INITIAL JACOBIAN CHANGED SIGN (IMPROVE INITIAL GUESS)    ', ! bad_jacobian_flag
      &   'FORCE RESIDUALS EXCEED FTOL: MORE ITERATIONS REQUIRED    ', ! more_iter_flag
@@ -178,7 +178,8 @@ C-----------------------------------------------
      &   'SUCCESSFUL VMEC CONVERGENCE                              ', ! successful_term_flag
      &   'BSUBU OR BSUBV JS=1 COMPONENT NON-ZERO                   ', ! bsub_bad_js1_flag
      &   'RMNC N=0, M=1 IS ZERO                                    ', ! r01_bad_value_flag
-     &   'ARNORM OR AZNORM EQUAL ZERO IN BCOVAR                    '  ! arz_bad_value_flag
+     &   'ARNORM OR AZNORM EQUAL ZERO IN BCOVAR                    ',  ! arz_bad_value_flag
+     &   'LOGIC ERROR IN TIMESTEPCONTROL (IRST/=1 and 4)           '  ! time_control_flag
      &   /)
       CHARACTER(LEN=*), PARAMETER ::
      &    Warning = " Error deallocating global memory FILEOUT"

--- a/VMEC2000/Sources/TimeStep/evolve.f
+++ b/VMEC2000/Sources/TimeStep/evolve.f
@@ -243,7 +243,7 @@ C-----------------------------------------------
       SUBROUTINE TimeStepControl(ier_flag, PARVMEC)
       USE vmec_main, ONLY: res0, res1, fsq, fsqr, fsqz, fsql,
      &                     irst, iter1, iter2, delt0r, dp
-      USE vmec_params, ONLY: ns4
+      USE vmec_params, ONLY: ns4, time_control_flag
       USE vparams, ONLY: c1pm2
       USE vmec_input, ONLY: nstep
       USE precon2d, ONLY: ictrl_prec2d
@@ -258,6 +258,7 @@ C-----------------------------------------------
       INTEGER  :: ier_flag
       LOGICAL, INTENT(IN) :: PARVMEC
 
+      ier_flag = 0
       fsq0 = fsqr+fsqz+fsql
       IF (iter2.EQ.iter1 .OR. res0.EQ.-1) THEN
          res0 = fsq
@@ -295,7 +296,8 @@ C-----------------------------------------------
             CALL funct3d(.FALSE., ier_flag)
          END IF
          IF (irst .NE. 1 .and. irst .NE. 4) THEN
-            STOP 'Logic error in TimeStepControl!'
+            ier_flag = time_control_flag
+            !STOP 'Logic error in TimeStepControl!'
          END IF
       END IF
 


### PR DESCRIPTION
This modification catches the `TimeStepControl` error in VMEC and returns control instead of performing a `STOP`. Does not affect the VMEC BENCHMARK tests and should improve the robustness of STELLOPT.