### PR TITLE
Bugfix/vmec badstart

### DIFF
--- a/VMEC2000/Sources/General/vmec_params.f
+++ b/VMEC2000/Sources/General/vmec_params.f
@@ -26,7 +26,8 @@ C-----------------------------------------------
      8                      r01_bad_value_flag=13,
      9                      arz_bad_value_flag=14,
      1                      time_control_flag=15,
-     2                      imas_read_flag=16
+     1                      really_bad_flag=16,
+     2                      imas_read_flag=17
       INTEGER, PARAMETER :: restart_flag=1, readin_flag=2,
      1                      timestep_flag=4,output_flag=8, 
      2                      cleanup_flag=16, reset_jacdt_flag=32,

--- a/VMEC2000/Sources/Input_Output/fileout.f
+++ b/VMEC2000/Sources/Input_Output/fileout.f
@@ -163,7 +163,7 @@ C-----------------------------------------------
       INTEGER :: js, istat1=0, irst0, OFU
       REAL(dp), DIMENSION(:), POINTER :: lu, lv
       REAL(dp), ALLOCATABLE :: br_out(:), bz_out(:)
-      CHARACTER(LEN=*), PARAMETER, DIMENSION(0:15) :: werror = (/
+      CHARACTER(LEN=*), PARAMETER, DIMENSION(0:16) :: werror = (/
      &   'EXECUTION TERMINATED NORMALLY                            ', ! norm_term_flag
      &   'INITIAL JACOBIAN CHANGED SIGN (IMPROVE INITIAL GUESS)    ', ! bad_jacobian_flag
      &   'FORCE RESIDUALS EXCEED FTOL: MORE ITERATIONS REQUIRED    ', ! more_iter_flag
@@ -178,8 +178,9 @@ C-----------------------------------------------
      &   'SUCCESSFUL VMEC CONVERGENCE                              ', ! successful_term_flag
      &   'BSUBU OR BSUBV JS=1 COMPONENT NON-ZERO                   ', ! bsub_bad_js1_flag
      &   'RMNC N=0, M=1 IS ZERO                                    ', ! r01_bad_value_flag
-     &   'ARNORM OR AZNORM EQUAL ZERO IN BCOVAR                    ',  ! arz_bad_value_flag
-     &   'LOGIC ERROR IN TIMESTEPCONTROL (IRST/=1 and 4)           '  ! time_control_flag
+     &   'ARNORM OR AZNORM EQUAL ZERO IN BCOVAR                    ', ! arz_bad_value_flag
+     &   'LOGIC ERROR IN TIMESTEPCONTROL (IRST/=1 and 4)           ', ! time_control_flag
+     &   'THE EQUILIBRIUM BOUNDARY FAILED TO CONVERGE              '  ! really_bad_flag
      &   /)
       CHARACTER(LEN=*), PARAMETER ::
      &    Warning = " Error deallocating global memory FILEOUT"

--- a/VMEC2000/Sources/TimeStep/runvmec.f
+++ b/VMEC2000/Sources/TimeStep/runvmec.f
@@ -6,7 +6,7 @@
      &                       restart_flag, readin_flag,
      &                       timestep_flag, ns_error_flag,
      &                       reset_jacdt_flag, lamscale, imasrun_flag,
-     &                       imas_read_flag
+     &                       imas_read_flag, really_bad_flag
       USE realspace
       USE vmec_params, ONLY: ntmax
       USE vacmod, ONLY: nuv, nuv3
@@ -402,6 +402,17 @@ C-----------------------------------------------
             END IF
          END IF
          grid_id = grid_id + 1
+
+         ! This is hear to catch and issue with indexing
+         IF (igrid .lt. igrid0) THEN
+            NS_RESLTN = 0
+            grid_id = 1
+            IF (ier_flag .eq. more_iter_flag) THEN
+                ier_flag = really_bad_flag
+                EXIT
+            END IF
+         END IF
+
       END DO
       !END - Main loop that will be parallelized - SKS
 
@@ -409,6 +420,7 @@ C-----------------------------------------------
 
       IF (ier_flag .eq. bad_jacobian_flag .and. jacob_off .eq. 0) THEN
          jacob_off = 1
+         NS_RESLTN = NS_RESLTN - 1
          GO TO 50
       END IF
 

--- a/pySTEL/libstell/stellopt.py
+++ b/pySTEL/libstell/stellopt.py
@@ -195,7 +195,10 @@ class STELLOPT():
 				if 'ITER' not in temp_dict.keys():
 					temp_dict['ITER'] = np.zeros((self.niter,1))
 				iter_val = iter_val + 1
-				temp_dict['ITER'][iter_val] = int(iter_txt)
+				if iter_txt == 'MIN':
+					temp_dict['ITER'][iter_val] = temp_dict['ITER'][iter_val]+1
+				else:
+					temp_dict['ITER'][iter_val] = int(iter_txt)
 				i = i +1
 				continue
 			elif 'TARGETS' in lines[i]:


### PR DESCRIPTION
This bugfix closes #302 by addressing the issue where a poor initial boundary can cause VMEC to walk off the end of a helper array.