### PR TITLE
Feature/thrift_improve

### DIFF
--- a/THRIFT/Sources/thrift_boozer.f90
+++ b/THRIFT/Sources/thrift_boozer.f90
@@ -157,7 +157,7 @@
          irun_setup_booz = 0
          CALL boozer_coords(ik,irun_setup_booz)
          IF (myend<=ik) mystart = myend + 1 ! we did it
-         IF (myworkid /= master) THEN
+         IF (myworkid /= master .and. mystart <= myend) THEN
             rmncb = 0
             zmnsb = 0
             pmnsb = 0

--- a/THRIFT/Sources/thrift_penta.f90
+++ b/THRIFT/Sources/thrift_penta.f90
@@ -35,7 +35,7 @@
                         te, ne, dtedrho, dnedrho, EparB, JBS_PENTA, etapar_PENTA, rho_temp, J_temp, eta_temp
       REAL(rprec), DIMENSION(:,:), ALLOCATABLE :: ni,ti, dtidrho, dnidrho
       REAL(rprec), DIMENSION(:,:), ALLOCATABLE :: D11, D13, D33
-      TYPE(EZspline1_r8) :: J_spl, eta_spl
+      TYPE(EZspline1_r8) :: EparB_spl, J_spl, eta_spl
       INTEGER :: bcs0(2)
 !-----------------------------------------------------------------------
 !     BEGIN SUBROUTINE
@@ -62,6 +62,17 @@
          JBS_PENTA = 0.0; etapar_PENTA = 0.0
 
          IF (myworkid == master) THEN
+            
+            ! EparB Spline
+            bcs1=(/ 0, 0/)
+            CALL EZspline_init(EparB_spl,nsj,bcs1,ier)
+            IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'thrift_penta: eparb',ier)
+            EparB_spl%isHermite   = 0
+            EparB_spl%x1 = SQRT(THRIFT_S)
+            CALL EZspline_setup(EparB_spl,THRIFT_EPARB(:,mytimestep),ier,EXACT_DIM=.true.)
+            IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'thrift_penta: eparb',ier)
+            !
+
             DO k = 1, ns_dkes
                   mysurf = DKES_K(k)
                   s = DBLE(mysurf-1) / DBLE(ns_eq-1)
@@ -99,14 +110,14 @@
                         CALL get_prof_tiprime(rho, THRIFT_T(mytimestep), j, dtidrho(k,j))
                         CALL get_prof_niprime(rho, THRIFT_T(mytimestep), j, dnidrho(k,j))
                   END DO
-
-                  !EparB
-                  EparB(k) = 0.0_rprec !! temporary... cannot do THRIFT_EPARB(mysurf,mytimestep) since this is defined in thrift grid, not vmec... interpolation?
+                  
+                  ! EparB
+                  ier = 0
+                  CALL EZSpline_interp(EparB_spl, rho, EparB(k), ier)
             END DO
-
-
-            ! print *, 'master_thrift_penta: dkes_d11', DKES_D11
+            CALL EZspline_free(EparB_spl,ier)
          END IF
+         
 #if defined(MPI_OPT)
          CALL MPI_BCAST(rho_k,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
          CALL MPI_BCAST(iota,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)

--- a/pySTEL/libstell/plasma.py
+++ b/pySTEL/libstell/plasma.py
@@ -484,6 +484,33 @@ class PLASMA:
         
         print(f'{filename} created with success!')
         
+    def plot_nustar(self,R0=1.0,iota=1.0):
+        # plots nu_star = (nu(vth)/vth)*() as a function of 
+        
+        import matplotlib.pyplot as plt
+        
+        plt.rc('font', size=18)
+        
+        roa = np.linspace(0,1,100)
+        
+        _, ax = plt.subplots(figsize=(11,8))
+
+        for species in self.list_of_species:
+            vth = self.get_thermal_speed(species,roa)
+            nu = self.get_collisionality(species,roa,vtest=vth)
+            
+            nu_star = (nu/vth)*(R0/iota) 
+            
+            ax.plot(roa,nu_star,'-',label=f'{species}')
+        
+        ax.grid()
+        ax.set_xlabel('r/a')
+        ax.set_ylabel(r'$\nu^*$')
+        ax.set_yscale('log')
+        ax.set_title(r'plasma collisionality $\nu^*=(\nu/v_{th})(R_0/\iota)$')
+        plt.legend()
+        plt.show()
+        
     def get_pressure_polynomial_coefficients(self,deg_fit=10):
         # this computes the AM coefficients and the PRES_SCALE scalar for a VMEC input
         # assuming that PMASS_TYPE = 'power_series'
@@ -540,75 +567,7 @@ class PLASMA:
         print(f'AM_AUX_S = {s_VMEC}')
         print(f'AM_AUX_F = {pres}')
         
-        return AM,PRES_SCALE
-
-        
-    def print_SFINCS_namelist(self,roa):
-        # prints in the command line physics and species parameters namelist of for SFINCS
-        
-        n_species = np.array( [self.get_density(species,rho=roa) for species in self.list_of_species] )
-        T_species = np.array( [self.get_temperature(species,rho=roa) for species in self.list_of_species] )
-        m_species = np.array( [self.mass[species] for species in self.list_of_species] )
-        Z_species = np.array( [self.Zcharge[species] for species in self.list_of_species] )
-        
-        nder_species = np.array( [self.get_density_der(species,rho=roa) for species in self.list_of_species] )
-        Tder_species = np.array( [self.get_temperature_der(species,rho=roa) for species in self.list_of_species] )
-
-        ## reference values
-        nBar = np.max(n_species) # pick largest value. must be in m^-3
-        mBar = MP # must be in kg 
-        TBar = np.max(T_species) # must be in eV
-        
-        vBar = np.sqrt(2*TBar*EC/mBar)
-        
-        print(f'nBar = {nBar}')
-        print(f'vBar = {vBar}')
-        
-        # mandatory values -- these values (BBar=1 and RBar=1) are mandatory when mag field is read from VMEC wout file (see SFINCS documentation)
-        BBar = 1.0
-        RBar = 1.0
-        
-        # print(f'jbs.B = {-1.2e-4*EC*nBar*vBar*BBar}')
-        
-        # compute loglambda as in PENTA
-        Te = self.get_temperature('electrons',rho=roa)
-        ne = self.get_density('electrons',rho=roa)
-        if(Te>50):
-            loglambda = 25.3 - 1.15*np.log10(ne/1e6) + 2.3*np.log10(Te)
-        else:
-            loglambda = 23.4 - 1.15*np.log10(ne/1e6) + 3.45*np.log10(Te)
-        
-        nuHat = 4*np.sqrt(2*np.pi)*nBar*EC**4*loglambda / ( 3*(4*np.pi*EPS0)**2 * np.sqrt(mBar) * (EC*TBar)**1.5 )
-        
-        # compute physics parameters
-        Delta = mBar*vBar / (EC*BBar*RBar)
-        alpha = 1.0
-        nu_n = nuHat * RBar/vBar
-        
-        mHats = m_species/mBar
-        nHats = n_species/nBar
-        THats = T_species/TBar
-        dNHatdrNs = nder_species/nBar
-        dTHatdrNs = Tder_species/TBar
-        
-        # print output
-        
-        print('&speciesParameters')
-        print(f"Zs = {' '.join(map(str, Z_species))}")
-        print(f"mHats = {' '.join(map(str, mHats))}")
-        print(f"nHats = {' '.join(map(str, nHats))}")
-        print(f"THats = {' '.join(map(str, THats))}")
-        print(f"dNHatdrNs = {' '.join(map(str, dNHatdrNs))}")
-        print(f"dTHatdrNs = {' '.join(map(str, dTHatdrNs))}")
-        print('/')
-
-        print('&physicsParameters')
-        print(f'Delta = {Delta}')
-        print(f'alpha = {alpha}')
-        print(f'nu_n = {nu_n}')
-
-        print('dont forget the rest of the parameters...')
-        
+        return AM,PRES_SCALE       
         
     def print_SFINCS_list_namelist(self,roa_list,folder_path):
         # saves input.namlist inside folder_path/surface_k
@@ -731,15 +690,14 @@ solverTolerance = 1d-6
 """
             
              # Define the file path
-            file_path = os.path.join(folder_path+'/'+folder_name, 'input.namelist')
+            file_path = os.path.join(folder_path+'/'+folder_name, f'input.namelist_{k+1}')
             
             # Write the content to the file
             with open(file_path, 'w') as f:
                 f.write(file_content)
 
             print(f"Created {file_path}")
-        
-
+            
 # Main routine
 if __name__=="__main__":
 	import sys

--- a/pySTEL/libstell/thrift.py
+++ b/pySTEL/libstell/thrift.py
@@ -34,7 +34,7 @@ class THRIFT():
 		"""
 
         import h5py
-        import numpy as np
+        # import numpy as np
 
 		#read file
         with h5py.File(file,'r') as f:
@@ -127,6 +127,64 @@ class THRIFT():
         print(f'Returning variable {var} at t={real_time}s')
         
         return plot_var[idx,:]
+    
+
+    def plot_plasma_profile(self,plasma_file):
+        
+        import h5py
+        
+        hf = h5py.File(plasma_file, 'r')
+
+        #read taxis and raxis
+        nt = np.array( hf['nt'] )
+        raxis = np.array( hf['raxis_prof'][:] )
+        taxis = np.array( hf['taxis_prof'][:] )
+        
+        ne = np.array( hf['ne_prof'][:] )
+        Te = np.array( hf['te_prof'][:] )
+        
+        ni = np.array( hf['ni_prof'][:] )
+        Ti = np.array( hf['ti_prof'][:] )
+        
+        nion = np.int64( hf['nion'] )
+        
+        hf.close()
+        
+        _, ax_n = plt.subplots(figsize=(11,8))
+        _, ax_T = plt.subplots(figsize=(11,8))    
+        
+        ax_n.plot(raxis,ne)
+        ax_n.set_xlabel('r/a') 
+        ax_n.set_title('ne')   
+        ax_n.grid()   
+        
+        ax_T.plot(raxis,Te)
+        ax_T.set_xlabel('r/a') 
+        ax_T.set_title('Te')   
+        ax_T.grid()  
+        
+        plt.show()
+        
+        _, ax_n = plt.subplots(figsize=(11,8))
+        _, ax_T = plt.subplots(figsize=(11,8))
+        
+        for i in range(nion):
+            
+            ax_n.plot(raxis,ni[:,:,i])
+            ax_n.set_xlabel('r/a') 
+            ax_n.set_title(f'ni, ion={i+1}')   
+            ax_n.grid()
+            
+            ax_T.plot(raxis,Ti[:,:,i])
+            ax_T.set_xlabel('r/a') 
+            ax_T.set_title(f'Ti, ion={i+1}')   
+            ax_T.grid()
+            
+            plt.show()
+            
+        
+        
+        
         
         
         


### PR DESCRIPTION
Two main changes:

1. Fixed a bug in `thrift_boozer` which was preventing the code to run with a number of processes larger than the total number of surfaces

2. `THRIFT_EPARB` is interpolated and given as input to `PENTA` within the `DKES+PENTA+THRIFT` integration

There were also some minor changes in the `plasma` and `thrift` classes of `pySTEL`.