### PR TITLE
BEAMS3D: made fidasim realspace axis grid-centers

### DIFF
--- a/BEAMS3D/Sources/beams3d_init.f90
+++ b/BEAMS3D/Sources/beams3d_init.f90
@@ -857,9 +857,9 @@
 
 
       IF (lfidasim) THEN
-         FORALL(i = 1:nr_fida) raxis_fida(i) = (i-1)*(rmax_fida-rmin_fida)/(nr_fida) + rmin_fida !Lower grid edges
-         FORALL(i = 1:nz_fida) zaxis_fida(i) = (i-1)*(zmax_fida-zmin_fida)/(nz_fida) + zmin_fida
-         FORALL(i = 1:nphi_fida) phiaxis_fida(i) = (i-1)*(phimax_fida-phimin_fida)/(nphi_fida) + phimin_fida
+         FORALL(i = 1:nr_fida) raxis_fida(i) = (i-0.5)/r_h + rmin_fida !Centered grid as expected by FIDASIM
+         FORALL(i = 1:nz_fida) zaxis_fida(i) = (i-0.5)/z_h+ zmin_fida
+         FORALL(i = 1:nphi_fida) phiaxis_fida(i) = (i-0.5)/p_h + phimin_fida
          FORALL(i = 1:nenergy_fida) energy_fida(i) = REAL(i-0.5) / REAL(nenergy_fida) * 0.5 * MAXVAL(mass) * partvmax * partvmax /1.60217662E-19 / 1000.0
          FORALL(i = 1:npitch_fida) pitch_fida(i) = REAL(i-0.5) / REAL(npitch_fida) * 2.0 - 1.0
          IF (nenergy_fida .eq. 1) THEN


### PR DESCRIPTION
FIDASIM expects its axis values to be on the grid centers, however the FIDASIM interface to NUBEAM outputs the axis from X_min to X_max-dX, which was also the behavior before this bugfix. As we still binned the markers on the grid centeres, this shifted the FIDASIM distribution inwards (to lower major radius values) by dr/2, also altering the spectra. Now we assign the correct and more meaningful centered axis values from X_min+dr/2 to X_max-dr/2.