### PR TITLE
STELLOPT: 2D Rosenbrock test feature

### DIFF
--- a/LIBSTELL/Sources/Optimization/DE2_Evolve.f
+++ b/LIBSTELL/Sources/Optimization/DE2_Evolve.f
@@ -409,7 +409,7 @@
             END IF
             IF( strategy == 5) THEN
                a5 = a1
-               DO WHILE (ANY(a4==a1))
+               DO WHILE (ANY(a5==a1))
                   DO i =1, NP
                      CALL random_number(rand_C1)
                      IF (a5(i) == a1(i)) a5(i) = 1 + rand_C1*(NP-1)

--- a/LIBSTELL/Sources/STELLOPT/stellopt_input_mod.f90
+++ b/LIBSTELL/Sources/STELLOPT/stellopt_input_mod.f90
@@ -411,7 +411,8 @@
                          target_gamma_c, sigma_gamma_c, &
                          lRosenbrock_X_opt, dRosenbrock_X_opt, &
                          Rosenbrock_X, Rosenbrock_X_min, Rosenbrock_X_max, &
-                         target_Rosenbrock_F, sigma_Rosenbrock_F
+                         target_Rosenbrock_F, sigma_Rosenbrock_F, &
+                         target_Rosenbrock2D, sigma_Rosenbrock2D
        
 !-----------------------------------------------------------------------
 !     Subroutines
@@ -549,6 +550,8 @@
       Rosenbrock_X_max(1:ROSENBROCK_DIM)  = bigno
       target_Rosenbrock_F(1:ROSENBROCK_DIM) = 0
       sigma_Rosenbrock_F(1:ROSENBROCK_DIM)  = bigno
+      target_Rosenbrock2D = 0.0
+      sigma_Rosenbrock2D = bigno
 
       IF (.not.ltriangulate) THEN  ! This is done because values may be set by trinagulate
          phiedge_min     = -bigno;  phiedge_max     = bigno
@@ -2585,6 +2588,13 @@
             END DO
          END DO
       END IF
+      WRITE(iunit,'(A)') '!----------------------------------------------------------------------'
+      WRITE(iunit,'(A)') '!         Rosenbrock 2D TEST FUNCTION' 
+      WRITE(iunit,'(A)') '!----------------------------------------------------------------------'
+      IF (sigma_Rosenbrock2D < bigno) THEN
+         WRITE(iunit,outflt) 'TARGET_ROSENBROCK2D',target_Rosenbrock2D
+         WRITE(iunit,outflt) 'sigma_ROSENBROCK2D',sigma_Rosenbrock2D
+      END IF 
       WRITE(iunit,'(A)') '/'
 
       RETURN

--- a/LIBSTELL/Sources/STELLOPT/stellopt_input_mod.f90
+++ b/LIBSTELL/Sources/STELLOPT/stellopt_input_mod.f90
@@ -1102,6 +1102,7 @@
       target_dkes(2)      = 0.0;  sigma_dkes(2)      = bigno
       target_helicity(1)  = 0.0;  sigma_helicity(1)  = bigno
       target_quasiiso(1)  = 0.0;  sigma_quasiiso(1)  = bigno
+      target_gamma_c(1)   = 0.0;  sigma_gamma_c(1)   = bigno
       target_Jstar(1)     = 0.0;  sigma_Jstar(1)     = bigno
       target_dkes_Erdiff(1) = 0.0; sigma_dkes_Erdiff(1) = bigno
       target_dkes_alpha(1) = 0.0; sigma_dkes_alpha(1) = bigno

--- a/LIBSTELL/Sources/STELLOPT/stellopt_targets.f90
+++ b/LIBSTELL/Sources/STELLOPT/stellopt_targets.f90
@@ -84,6 +84,7 @@
       REAL(rprec) ::  target_kappa_avg, sigma_kappa_avg
       REAL(rprec) ::  target_x, sigma_x
       REAL(rprec) ::  target_y, sigma_y
+      REAL(rprec) ::  target_rosenbrock2d, sigma_rosenbrock2d
       REAL(rprec), DIMENSION(rosenbrock_dim) ::  target_Rosenbrock_F, &
                                                  sigma_Rosenbrock_F
       REAL(rprec), PARAMETER ::  bigno_ne = 1.0E27
@@ -297,6 +298,7 @@
       INTEGER, PARAMETER :: jtarget_x          = 900
       INTEGER, PARAMETER :: jtarget_y          = 901
       INTEGER, PARAMETER :: jtarget_Rosenbrock_F   = 902
+      INTEGER, PARAMETER :: jtarget_Rosenbrock2D   = 903
       
 
       CONTAINS
@@ -313,6 +315,8 @@
             WRITE(iunit, out_format) 'Y'
          CASE(jtarget_Rosenbrock_F)
             WRITE(iunit, out_format) 'Rosenbrock Test Function'
+         CASE(jtarget_Rosenbrock2D)
+            WRITE(iunit, out_format) 'Rosenbrock (2D) Test Function'
          CASE(jtarget_aspect)
             WRITE(iunit, out_format) 'Aspect Ratio'
          CASE(jtarget_aspect_max)

--- a/STELLOPTV2/ObjectList
+++ b/STELLOPTV2/ObjectList
@@ -1,4 +1,5 @@
 ObjectFiles = \
+chisq_rosenbrock2d.o \
 chisq_quasiiso.o \
 stellopt_read_cws.o \
 stellopt_write_header.o \

--- a/STELLOPTV2/STELLOPTV2.dep
+++ b/STELLOPTV2/STELLOPTV2.dep
@@ -169,6 +169,13 @@ chisq_rosenbrock.o : \
       $(LIB_DIR)/$(LOCTYPE)/stellopt_vars.o
 
       
+chisq_rosenbrock2d.o : \
+      stellopt_runtime.o \
+      $(LIB_DIR)/$(LOCTYPE)/stellopt_targets.o \
+      $(LIB_DIR)/$(LOCTYPE)/stellopt_input_mod.o \
+      $(LIB_DIR)/$(LOCTYPE)/stellopt_vars.o
+
+      
 chisq_rbtor.o : \
       stellopt_runtime.o \
       $(LIB_DIR)/$(LOCTYPE)/stellopt_targets.o \

--- a/STELLOPTV2/Sources/Chisq/chisq_rosenbrock2d.f90
+++ b/STELLOPTV2/Sources/Chisq/chisq_rosenbrock2d.f90
@@ -1,0 +1,57 @@
+!-----------------------------------------------------------------------
+!     Subroutine:    chisq_rosenbrock2D
+!     Authors:       S. Lazerson (samuel.lazerson@gauss-fusion.com)
+!     Date:          2023
+!     Description:   This is a 2D Rosenbrock function see:
+!                    https://en.wikipedia.org/wiki/Rosenbrock_function
+!-----------------------------------------------------------------------
+      SUBROUTINE chisq_rosenbrock2d(target,sigma,niter,iflag)
+!-----------------------------------------------------------------------
+!     Libraries
+!-----------------------------------------------------------------------
+      USE stellopt_runtime
+      USE stellopt_targets
+      USE stellopt_vars
+      
+!-----------------------------------------------------------------------
+!     Input/Output Variables
+!
+!-----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL(rprec), INTENT(in)    ::  target
+      REAL(rprec), INTENT(in)    ::  sigma
+      INTEGER,     INTENT(in)    ::  niter
+      INTEGER,     INTENT(inout) ::  iflag
+      
+!-----------------------------------------------------------------------
+!     Local Variables
+!
+!-----------------------------------------------------------------------
+      INTEGER :: ii
+      REAL(rprec)  :: F
+      REAL(rprec),PARAMETER  ::  A = 1.0
+      REAL(rprec),PARAMETER  ::  B = 100.0 
+!----------------------------------------------------------------------
+!     BEGIN SUBROUTINE
+!----------------------------------------------------------------------
+      IF (iflag < 0) RETURN
+      IF (iflag == 1) WRITE(iunit_out,'(A,2(2X,I3.3))') 'ROSENBROCK2D',1,5
+      IF (iflag == 1) WRITE(iunit_out,'(A)') 'TARGET  SIGMA  XVAL  A  B'
+      IF (niter >= 0) THEN
+         F = (A - xval)**2 + B*(yval - xval**2)**2
+         mtargets = mtargets + 1
+         targets(mtargets) = target
+         sigmas(mtargets)  = sigma
+         vals(mtargets)    = F
+         IF (iflag == 1) WRITE(iunit_out,'(5ES22.12E3)') target,sigma,vals(mtargets),A,B
+      ELSE
+         IF (sigma < bigno) THEN
+            mtargets = mtargets + 1
+            IF (niter == -2) target_dex(mtargets)=jtarget_Rosenbrock2D
+         END IF
+      END IF
+      RETURN
+!----------------------------------------------------------------------
+!     END SUBROUTINE
+!----------------------------------------------------------------------
+      END SUBROUTINE chisq_rosenbrock2d

--- a/STELLOPTV2/Sources/General/stellopt_fcn.f90
+++ b/STELLOPTV2/Sources/General/stellopt_fcn.f90
@@ -398,6 +398,8 @@
             CASE('spec')
             CASE('test')
                !Do Nothing
+               iflag = 0
+               ier_paraexe = 0
          END SELECT
          ! Check profiles for negative values of pressure
          dex = MINLOC(am_aux_s(2:),DIM=1)

--- a/STELLOPTV2/Sources/General/stellopt_load_targets.f90
+++ b/STELLOPTV2/Sources/General/stellopt_load_targets.f90
@@ -48,6 +48,9 @@
       ! Rosenbrock test function
       IF (ANY(sigma_Rosenbrock_F < bigno)) &
          CALL chisq_Rosenbrock(target_Rosenbrock_F,sigma_Rosenbrock_F,ncnt,iflag)
+      ! Rosenbrock2D test function
+      IF (sigma_Rosenbrock2D < bigno)  &
+         CALL chisq_rosenbrock2d(target_Rosenbrock2D,sigma_Rosenbrock2D,ncnt,iflag)
       !------------- SCALAR TARGETS ----------------------------
       ! PHIEDGE
       IF (sigma_phiedge < bigno)  &

--- a/STELLOPTV2/Sources/General/stellopt_renorm.f90
+++ b/STELLOPTV2/Sources/General/stellopt_renorm.f90
@@ -92,6 +92,8 @@
                sigma_r0 = sigma_r0/temp
             CASE(jtarget_b0)
                sigma_b0 = sigma_b0/temp
+            CASE(jtarget_rosenbrock2d)
+               sigma_rosenbrock2d = sigma_rosenbrock2d/temp
             CASE(jtarget_balloon)
                WHERE(sigma_balloon < bigno) sigma_balloon = sigma_balloon/temp
             CASE(jtarget_separatrix)


### PR DESCRIPTION
This pull request adds a 2D Rosenbrock test function target to the optimizer for testing. Additionally, the `EQUIL_TYPE='test'` option was slightly broken and now corrected. Finally, a bug in the differential evolution algorithm when using `MODE=5` has been corrected.