### PR TITLE
Feature/collision refactor

### DIFF
--- a/BEAMS3D/BEAMS3D.dep
+++ b/BEAMS3D/BEAMS3D.dep
@@ -84,6 +84,7 @@ beams3d_follow.o: \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
       ../../LIBSTELL/$(LOCTYPE)/safe_open_mod.o \
       ../../LIBSTELL/$(LOCTYPE)/wall_mod.o \
+      ../../LIBSTELL/$(LOCTYPE)/collision_operators.o \
       ../../LIBSTELL/$(LOCTYPE)/mpi_inc.o \
       beams3d_runtime.o \
       beams3d_lines.o \
@@ -96,6 +97,7 @@ beams3d_follow.o: \
 beams3d_follow_gc.o: \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
       ../../LIBSTELL/$(LOCTYPE)/safe_open_mod.o \
+      ../../LIBSTELL/$(LOCTYPE)/collision_operators.o \
       ../../LIBSTELL/$(LOCTYPE)/mpi_inc.o \
       beams3d_runtime.o \
       beams3d_lines.o \
@@ -107,6 +109,7 @@ beams3d_follow_gc.o: \
 beams3d_follow_fo.o: \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
       ../../LIBSTELL/$(LOCTYPE)/safe_open_mod.o \
+      ../../LIBSTELL/$(LOCTYPE)/collision_operators.o \
       ../../LIBSTELL/$(LOCTYPE)/mpi_inc.o \
       beams3d_runtime.o \
       beams3d_lines.o \
@@ -276,6 +279,7 @@ beams3d_physics_mod.o: \
       ../../LIBSTELL/$(LOCTYPE)/mpi_params.o \
       ../../LIBSTELL/$(LOCTYPE)/ezspline.o \
       ../../LIBSTELL/$(LOCTYPE)/ezspline_obj.o \
+      ../../LIBSTELL/$(LOCTYPE)/collision_operators.o \
       beams3d_runtime.o \
       beams3d_lines.o \
       beams3d_grid.o

--- a/BEAMS3D/Sources/beams3d_follow.f90
+++ b/BEAMS3D/Sources/beams3d_follow.f90
@@ -22,6 +22,7 @@ SUBROUTINE beams3d_follow
     USE beams3d_write_par
     USE safe_open_mod, ONLY: safe_open
     USE wall_mod, ONLY: wall_free, ihit_array, nface
+    USE collision_operators, ONLY: SET_CRIT_FACTOR, SET_COULOMB_FACTOR
     USE mpi_inc
     !-----------------------------------------------------------------------
     !     Local Variables
@@ -125,11 +126,7 @@ SUBROUTINE beams3d_follow
 
     ! Some helpers
     fact_vsound = 1.5*sqrt(e_charge/plasma_mass)*therm_factor
-    fact_crit= SQRT(2.0*e_charge/electron_mass)*(0.75*sqrt_pi*electron_mass*plasma_Zmean/plasma_mass)**(1.0/3.0) ! Wesson pg 226 5.4.9
-    fact_crit_legacy = SQRT(2*e_charge/plasma_mass)*(0.75*sqrt_pi*sqrt(plasma_mass/electron_mass))**(1.0/3.0)
-    !fact_crit=fact_crit_pro*(plasma_Zmean/plasma_mass)**(1.0/3.0)
-    !fact_kick = pi2*2*SQRT(pi*1E-7*plasma_mass)*E_kick*freq_kick !old
-    !fact_kick = 2*freq_kick*E_kick
+    CALL SET_CRIT_FACTOR(plasma_Zmean,plasma_mass)
 
     ! Handle the Beam defaults
     IF (lbeam) THEN
@@ -158,8 +155,7 @@ SUBROUTINE beams3d_follow
        mybeam = Beam(i)
        moment = mu_start(i)
        fact_pa   = plasma_mass/(mymass*plasma_Zmean)
-       fact_coul = myZ*(mymass+plasma_mass)/(mymass*plasma_mass*6.02214076208E+26)
-       
+       CALL SET_COULOMB_FACTOR(mymass,myZ,plasma_mass)
        ! Save the IC of the neutral
        my_end = t_end(i)
        myline = i
@@ -193,8 +189,7 @@ SUBROUTINE beams3d_follow
           myline = i
           mytdex = 1
           fact_pa   = plasma_mass/(mymass*plasma_Zmean)
-          fact_coul = myZ*(mymass+plasma_mass)/(mymass*plasma_mass*6.02214076208E+26)
-          
+          CALL SET_COULOMB_FACTOR(mymass,myZ,plasma_mass)
           ! Define neutral trajectory
           myv_neut(1) = vr_start(i)*cos(phi_start(i)) - vphi_start(i)*sin(phi_start(i))
           myv_neut(2) = vr_start(i)*sin(phi_start(i)) + vphi_start(i)*cos(phi_start(i))

--- a/BEAMS3D/Sources/beams3d_follow_fo.f90
+++ b/BEAMS3D/Sources/beams3d_follow_fo.f90
@@ -25,6 +25,7 @@ SUBROUTINE beams3d_follow_fo
     USE beams3d_write_par
     USE beams3d_physics_mod, ONLY: beams3d_gc2fo, beams3d_calc_dt
     USE safe_open_mod, ONLY: safe_open
+    USE collision_operators, ONLY: SET_COULOMB_FACTOR
     USE mpi_inc
     !-----------------------------------------------------------------------
     !     Local Variables
@@ -149,8 +150,7 @@ SUBROUTINE beams3d_follow_fo
                     lneut  = .false.
                     ! Collision parameters
                     fact_pa   = plasma_mass/(mymass*plasma_Zmean)
-                    fact_coul = myZ*(mymass+plasma_mass)/(mymass*plasma_mass*6.02214076208E+26)
-					
+                    CALL SET_COULOMB_FACTOR(mymass,myZ,plasma_mass)
                     DO ! Must do it this way becasue lbeam changes q(4) values
 #if defined(NAG)
                        CALL D02CJF(t_nag,tf_nag,neqs_nag,q,fpart_eom,tol_nag,relab,out_beams3d_part,D02CJW,w,ier)
@@ -195,8 +195,7 @@ SUBROUTINE beams3d_follow_fo
                     lneut  = .false.
                     ! Collision parameters
                     fact_pa   = plasma_mass/(mymass*plasma_Zmean)
-                    fact_coul = myZ*(mymass+plasma_mass)/(mymass*plasma_mass*6.02214076208E+26)
-					
+                    CALL SET_COULOMB_FACTOR(mymass,myZ,plasma_mass)
                     ! Setup DRKHVG parameters
                     iopt = 0 
                     DO
@@ -252,8 +251,7 @@ SUBROUTINE beams3d_follow_fo
                     lneut  = .false.
                     ! Collision parameters
                     fact_pa   = plasma_mass/(mymass*plasma_Zmean)
-                    fact_coul = myZ*(mymass+plasma_mass)/(mymass*plasma_mass*6.02214076208E+26)
-					
+                    CALL SET_COULOMB_FACTOR(mymass,myZ,plasma_mass)
                     ! Now handle Coordinate conversion
                     IF (lbeam .and. mytdex == 3) mytdex = 2 ! BEAM -> FO Run
                     IF (lboxsim)  mytdex = 1

--- a/BEAMS3D/Sources/beams3d_follow_gc.f90
+++ b/BEAMS3D/Sources/beams3d_follow_gc.f90
@@ -26,6 +26,7 @@ SUBROUTINE beams3d_follow_gc
     USE mpi_params ! MPI
     USE beams3d_write_par
     USE beams3d_physics_mod, ONLY: beams3d_calc_dt
+    USE collision_operators, ONLY: SET_COULOMB_FACTOR
     USE safe_open_mod, ONLY: safe_open
     USE mpi_inc
     !-----------------------------------------------------------------------
@@ -142,8 +143,7 @@ SUBROUTINE beams3d_follow_gc
                     ! Collision parameters
                     fact_kick = 2*E_kick*mycharge/(mymass*pi2*pi2*freq_kick*freq_kick*SQRT(pi*1E-7*plasma_mass))
                     fact_pa   = plasma_mass/(mymass*plasma_Zmean)
-                    fact_coul = myZ*(mymass+plasma_mass)/(mymass*plasma_mass*6.02214076208E+26)
-
+                    CALL SET_COULOMB_FACTOR(mymass,myZ,plasma_mass)
                     ! Now calc dt
                     CALL beams3d_calc_dt(1,q(1),q(2),q(3),dt)
                     tf_nag = t_nag+dt
@@ -192,8 +192,7 @@ SUBROUTINE beams3d_follow_gc
                     ! Collision parameters
                     fact_kick = 2*E_kick*mycharge/(mymass*pi2*pi2*freq_kick*freq_kick*SQRT(pi*1E-7*plasma_mass))
                     fact_pa   = plasma_mass/(mymass*plasma_Zmean)
-                    fact_coul = myZ*(mymass+plasma_mass)/(mymass*plasma_mass*6.02214076208E+26)
-					
+                    CALL SET_COULOMB_FACTOR(mymass,myZ,plasma_mass)
                     ! Now calc dt
                     CALL beams3d_calc_dt(1,q(1),q(2),q(3),dt)
                     tf_nag = t_nag+dt
@@ -265,8 +264,7 @@ SUBROUTINE beams3d_follow_gc
                     ! Collision parameters
                     fact_kick = 2*E_kick*mycharge/(mymass*pi2*pi2*freq_kick*freq_kick*SQRT(pi*1E-7*plasma_mass))
                     fact_pa   = plasma_mass/(mymass*plasma_Zmean)
-                    fact_coul = myZ*(mymass+plasma_mass)/(mymass*plasma_mass*6.02214076208E+26)
-					
+                    CALL SET_COULOMB_FACTOR(mymass,myZ,plasma_mass)
                     ! Now calc dt
                     CALL beams3d_calc_dt(1,q(1),q(2),q(3),dt)
                     tf_nag = t_nag+dt

--- a/BEAMS3D/Sources/beams3d_physics_mod.f90
+++ b/BEAMS3D/Sources/beams3d_physics_mod.f90
@@ -395,10 +395,10 @@ MODULE beams3d_physics_mod
             !-----------------------------------------------------------
             dve   = factor_electron*speed*tau_spit_inv
             dvi   = factor_ion*vc3_tauinv/(speed*speed)
-            reduction = dve + dvi
-            newspeed = speed - reduction*dt+sigma*zeta
             dve=dve+ddve
             dvi=dvi+ddvi
+            reduction = (dve + dvi)*dt+sigma*zeta
+            newspeed = speed - reduction            
             vfrac = newspeed/speed
             !-----------------------------------------------------------
             !  Thermalize particle or adjust vll and moment

--- a/BEAMS3D/Sources/beams3d_physics_mod.f90
+++ b/BEAMS3D/Sources/beams3d_physics_mod.f90
@@ -240,7 +240,7 @@ MODULE beams3d_physics_mod
                           rho_temp, omeg_temp, binv, vrot_para, vrot_perp, &
                           vc3_tauinv, vbeta, zeff_temp,&
                           sm,omega2,vrel2,bmax,bmincl,bminqu,bmin,&
-                          zdelth,zrang, factor_ion, factor_electron, speed2inv
+                          zdelth,zrang, factor_ion, factor_electron, speed3inv, speed2inv
          DOUBLE PRECISION :: Ebench  ! for ASCOT Benchmark
          DOUBLE PRECISION :: slow_par(3), ni_temp(NION)
          ! For splines
@@ -324,6 +324,7 @@ MODULE beams3d_physics_mod
             !  Apply toroidal rotation
             !     vrot_para: Parallel rotation velocity [m/s]
             !     vrot_perp: Perpendicular rotation velocity [m/s]
+            !     speed      Total particle speed [m/s]
             !-----------------------------------------------------------
             inv_mymass = one/mymass
             vrot_para = omeg_temp*r_temp*bphi_temp*binv
@@ -361,25 +362,30 @@ MODULE beams3d_physics_mod
 
             !------------------------------------------------------------
             !  Velocity diffusion 
+            !   https://doi.org/10.1103/PhysRev.107.1
+            !   https://doi.org/10.1063/1.1694943
+            !   https://doi.org/10.1016/0021-9991(81)90111-X
+            !   https://doi.org/10.1016/j.cpc.2014.01.014
+            !     speed3inv    v**-3 [m^3/s^3]
+            !     speed2inv    v**-2 [m^3/s^3]
+            !     ddve
             !------------------------------------------------------------
             ddve = zero; ddvi = zero; sigma = zero; zeta = zero;
             factor_ion = one; factor_electron = one
 #if defined(B3D_VEL_DIFFUSION)
-            speed_cube = (speed*speed*speed)
-            CALL gauss_rand(1,zeta)  ! A random from a standard normal (1,1)
+            speed3inv = 1.0/(speed*speed*speed)
+            speed2inv = speed*speed3inv
             ddve=ABS(2*e_charge*dt*te_temp*inv_mymass*tau_spit_inv)
-            ddvi=ABS(2*e_charge*dt*(ti_temp*vcrit_cube*inv_mymass/speed_cube)*tau_spit_inv)
+            ddvi=ABS(2*e_charge*dt*ti_temp*vcrit_cube*inv_mymass*speed3inv*tau_spit_inv)
+            CALL gauss_rand(1,zeta)  ! A random from a standard normal (1,1)
             sigma = sqrt( ddve+ddvi) ! The standard deviation.
             ddve=zeta*ddve/sigma
             ddvi=zeta*ddvi/sigma
-            speed2inv = 1.0/(speed*speed)
             factor_electron = ( 1.0 - 2.0*te_temp*inv_mymass*e_charge*speed2inv)
             factor_ion      = ( 1.0 +     ti_temp*inv_mymass*e_charge*speed2inv)
 #endif
             !-----------------------------------------------------------
             !  Viscouse Velocity Reduction
-            !     v_s       Local Sound Speed
-            !     speed     Total particle speed
             !     dve       Speed change due to electron slowing down 
             !     dvi       Speed change due to ion slowing down 
             !     reduction Total change in speed

--- a/BEAMS3D/Sources/beams3d_physics_mod.f90
+++ b/BEAMS3D/Sources/beams3d_physics_mod.f90
@@ -357,7 +357,7 @@ MODULE beams3d_physics_mod
                tau_spit_inv = one/slow_par(2)
                vc3_tauinv = vcrit_cube*tau_spit_inv
             ELSE !Dont evaluate collisions
-               q(4) = vll + vrot_para
+               !q(4) = vll + vrot_para
                RETURN
             END IF
 
@@ -395,10 +395,10 @@ MODULE beams3d_physics_mod
             !-----------------------------------------------------------
             dve   = factor_electron*speed*tau_spit_inv
             dvi   = factor_ion*vc3_tauinv/(speed*speed)
+            reduction = (dve + dvi)*dt+sigma*zeta
+            newspeed = speed - reduction                
             dve=dve+ddve
             dvi=dvi+ddvi
-            reduction = (dve + dvi)*dt+sigma*zeta
-            newspeed = speed - reduction            
             vfrac = newspeed/speed
             !-----------------------------------------------------------
             !  Thermalize particle or adjust vll and moment

--- a/BEAMS3D/Sources/beams3d_physics_mod.f90
+++ b/BEAMS3D/Sources/beams3d_physics_mod.f90
@@ -40,6 +40,9 @@ MODULE beams3d_physics_mod
       USE EZspline_obj
       USE EZspline
       USE adas_mod_parallel
+      USE collision_operators, ONLY: COULOMB_LOG_NRL_COUNTERSTREAM,&
+                                     V_CRITICAL, V_CRITICAL_WEILAND, &
+                                     TAU_SPITZER
       USE mpi_params 
 
       !-----------------------------------------------------------------
@@ -91,12 +94,10 @@ MODULE beams3d_physics_mod
          DOUBLE PRECISION :: slow_par(3)
          DOUBLE PRECISION, INTENT(in) :: ne_in, te_in, vbeta_in, Zeff_in
          DOUBLE PRECISION :: ne_cm,coulomb_log
-         ne_cm = ne_in * 1E-6
-         coulomb_log = 43 - log(Zeff_in*fact_coul*sqrt(ne_cm/te_in)/(vbeta_in*vbeta_in))
-         !fact_crit_legacy = SQRT(2*e_charge/plasma_mass)*(0.75*sqrt_pi*sqrt(plasma_mass/electron_mass))**(1.0/3.0)
-         slow_par(1) = fact_crit_legacy*SQRT(te_in) 
-         slow_par(2) = 3.777183D41*mymass*SQRT(te_in*te_in*te_in)/(ne_in*myZ*myZ*coulomb_log)  ! note ne should be in m^-3 here, tau_spit
-         slow_par(3) =Zeff_in*fact_pa         
+         coulomb_log = COULOMB_LOG_NRL_COUNTERSTREAM(ne_in,te_in,vbeta_in,Zeff_in)
+         slow_par(1) = V_CRITICAL(te_in)
+         slow_par(2) = TAU_SPITZER(mymass,ne_in,te_in,myZ,coulomb_log)
+         slow_par(3) = Zeff_in*fact_pa  
       END FUNCTION coll_op_nrl19
 
       !-----------------------------------------------------------------
@@ -123,14 +124,11 @@ MODULE beams3d_physics_mod
          DOUBLE PRECISION :: slow_par(3)
          DOUBLE PRECISION, INTENT(in) :: ne_in, te_in, vbeta_in, Zeff_in
          DOUBLE PRECISION :: ne_cm, coulomb_loge, coulomb_logi
-         ne_cm = ne_in * 1E-6
-         coulomb_logi = 43 - log(Zeff_in*fact_coul*sqrt(ne_cm/te_in)/(vbeta_in*vbeta_in))
-         coulomb_loge=log(1.09d11 * te_in/Zeff_in/sqrt(ne_cm))
-      !WRITE(6,*) coulomb_loge, coulomb_logi
-      ! Callen Ch2 pg41 eq2.135 (fact*Vtherm; Vtherm = SQRT(2*E/mass) so E in J not eV)
-         slow_par(1) = fact_crit*SQRT(te_in)*(coulomb_logi/coulomb_loge)**(1.0/3.0) !vcrit, the coulomb ratio is from Weiland (2018) eq.11
-         slow_par(2) = 3.777183D41*mymass*SQRT(te_in*te_in*te_in)/(ne_in*myZ*myZ*coulomb_loge)  ! note ne should be in m^-3 here, tau_spit
-         slow_par(3) =Zeff_in*fact_pa
+         coulomb_logi = COULOMB_LOG_NRL_COUNTERSTREAM(ne_in,te_in,vbeta_in,Zeff_in)
+         coulomb_loge = log(1.09d11 * te_in/Zeff_in/sqrt(ne_cm))
+         slow_par(1) = V_CRITICAL_WEILAND(te_in,coulomb_logi,coulomb_loge)
+         slow_par(2) = TAU_SPITZER(mymass,ne_in,te_in,myZ,coulomb_loge)
+         slow_par(3) = Zeff_in*fact_pa  
          RETURN
       END FUNCTION coll_op_nrl19_ie
 

--- a/BEAMS3D/Sources/beams3d_physics_mod.f90
+++ b/BEAMS3D/Sources/beams3d_physics_mod.f90
@@ -240,7 +240,7 @@ MODULE beams3d_physics_mod
                           rho_temp, omeg_temp, binv, vrot_para, vrot_perp, &
                           vc3_tauinv, vbeta, zeff_temp,&
                           sm,omega2,vrel2,bmax,bmincl,bminqu,bmin,&
-                          zdelth,zrang
+                          zdelth,zrang, factor_ion, factor_electron, speed2inv
          DOUBLE PRECISION :: Ebench  ! for ASCOT Benchmark
          DOUBLE PRECISION :: slow_par(3), ni_temp(NION)
          ! For splines
@@ -362,7 +362,8 @@ MODULE beams3d_physics_mod
             !------------------------------------------------------------
             !  Velocity diffusion 
             !------------------------------------------------------------
-            ddve = zero; ddvi = zero
+            ddve = zero; ddvi = zero; sigma = zero; zeta = zero;
+            factor_ion = one; factor_electron = one
 #if defined(B3D_VEL_DIFFUSION)
             speed_cube = (speed*speed*speed)
             CALL gauss_rand(1,zeta)  ! A random from a standard normal (1,1)
@@ -371,6 +372,9 @@ MODULE beams3d_physics_mod
             sigma = sqrt( ddve+ddvi) ! The standard deviation.
             ddve=zeta*ddve/sigma
             ddvi=zeta*ddvi/sigma
+            speed2inv = 1.0/(speed*speed)
+            factor_electron = ( 1.0 - 2.0*te_temp*inv_mymass*e_charge*speed2inv)
+            factor_ion      = ( 1.0 +     ti_temp*inv_mymass*e_charge*speed2inv)
 #endif
             !-----------------------------------------------------------
             !  Viscouse Velocity Reduction
@@ -382,8 +386,8 @@ MODULE beams3d_physics_mod
             !     newspeed  New total speed
             !     vfrac     Ratio between new and old speed (helper) 
             !-----------------------------------------------------------
-            dve   = speed*tau_spit_inv*(1-2*te_temp*inv_mymass*e_charge/speed**2.0)
-            dvi   = vc3_tauinv/(speed*speed)*(1+ti_temp*inv_mymass*e_charge/speed**2.0)
+            dve   = factor_electron*speed*tau_spit_inv
+            dvi   = factor_ion*vc3_tauinv/(speed*speed)
             reduction = dve + dvi
             newspeed = speed - reduction*dt+sigma*zeta
             dve=dve+ddve

--- a/LIBSTELL/LIBSTELL.dep
+++ b/LIBSTELL/LIBSTELL.dep
@@ -1,5 +1,7 @@
 # Microsoft Developer Studio Generated Dependency File, included by LIBSTELL.mak      
 
+collision_operators.o : 
+
 read_nescoil_mod.o : \
       safe_open_mod.o \
       stel_kinds.o \
@@ -7,7 +9,6 @@ read_nescoil_mod.o : \
       ezspline_obj.o \
       mpi_sharmem.o \
       mpi_inc.o
-
 
 stellopt_globals.o : \
       stel_kinds.o 

--- a/LIBSTELL/ObjectList
+++ b/LIBSTELL/ObjectList
@@ -1,4 +1,5 @@
 ObjectFiles = \
+collision_operators.o \
 thrift_input_mod.o \
 thrift_globals.o \
 read_nescoil_mod.o \

--- a/LIBSTELL/Sources/Modules/collision_operators.f90
+++ b/LIBSTELL/Sources/Modules/collision_operators.f90
@@ -56,12 +56,9 @@
          !--------------------------------------------------------------
          IMPLICIT NONE
          DOUBLE PRECISION, INTENT(in) :: z_plasma,mass_plasma
-         fact_crit = SQRT( 2.0 * electron_charge )
-         ! WESSON PG 226 5.4.9
-         fact_crit_weiland = fact_crit/sqrt(electron_mass) * ( 0.75 * sqrt_pi * &
-                            electron_mass * z_plasma / mass_plasma) ** (1.0/3.0)
-         fact_crit = fact_crit/sqrt(mass_plasma) * ( 0.75 * sqrt_pi * &
+         fact_crit = SQRT( 2.0 * electron_charge /mass_plasma) * ( 0.75 * sqrt_pi * &
                             SQRT( mass_plasma / electron_mass ) )**(1.0/3.0)
+         fact_crit_weiland=fact_crit*z_plasma** (1.0/3.0) ! WESSON PG 226 5.4.9
          RETURN
       END SUBROUTINE SET_CRIT_FACTOR
 

--- a/LIBSTELL/Sources/Modules/collision_operators.f90
+++ b/LIBSTELL/Sources/Modules/collision_operators.f90
@@ -1,0 +1,230 @@
+!-----------------------------------------------------------------------
+!     Module:        collision_operators
+!     Authors:       S. Lazerson (samuel.lazerson@gauss-fusion.com)
+!     Date:          12/18/2024
+!     Description:   This module contains routines for calculating
+!                    various collision based quantities.
+!-----------------------------------------------------------------------
+      MODULE collision_operators
+!-----------------------------------------------------------------------
+!     Libraries
+!-----------------------------------------------------------------------
+      
+!-----------------------------------------------------------------------
+!     Module Variables
+!-----------------------------------------------------------------------
+      IMPLICIT NONE
+      DOUBLE PRECISION, PRIVATE, PARAMETER :: &
+                              electron_mass   = 9.1093837139D-31 !m_e
+      DOUBLE PRECISION, PRIVATE, PARAMETER :: &
+                              electron_charge = 1.602176634D-19 !e_c
+      DOUBLE PRECISION, PRIVATE, PARAMETER :: &
+                              sqrt_pi         = SQRT(4.0 * ATAN(1.0))   !pi^(1/2)
+      DOUBLE PRECISION, PRIVATE, PARAMETER :: &
+                              inv_dalton      = 6.02214076208E+26 ! 1./AMU [1/kg]
+      DOUBLE PRECISION, PRIVATE, PARAMETER :: &
+                              hbar            = 1.054571817E+34 ! hbar [J.s]
+      DOUBLE PRECISION, PRIVATE :: coulomb_factor, fact_crit, &
+                                   fact_crit_weiland
+      
+!-----------------------------------------------------------------------
+!     Function Interfaces
+!-----------------------------------------------------------------------
+      
+!-----------------------------------------------------------------------
+!     Subroutines and Functions
+!-----------------------------------------------------------------------
+      CONTAINS
+
+      SUBROUTINE SET_COULOMB_FACTOR(mass,z,mass_plasma)
+         !--------------------------------------------------------------
+         !   MASS         Particle mass [kg]
+         !   Z            Particle charge number [e]
+         !   MASS_PLASMA  Plasma effective mass [kg]
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: mass,z,mass_plasma
+         coulomb_factor = z * ( mass + mass_plasma ) / &
+                              ( mass * mass_plasma * 6.02214076208D+26 )
+         RETURN
+      END SUBROUTINE SET_COULOMB_FACTOR
+
+      SUBROUTINE SET_CRIT_FACTOR(z_plasma,mass_plasma)
+         !--------------------------------------------------------------
+         !   Z_PLASMA     Particle charge number [e]
+         !   MASS_PLASMA  Plasma effective mass [kg]
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: z_plasma,mass_plasma
+         fact_crit = SQRT( 2.0 * electron_charge / electron_mass)
+         ! WESSON PG 226 5.4.9
+         fact_crit_weiland = fact_crit * ( 0.75 * sqrt_pi * &
+                            electron_mass * z_plasma / mass_plasma) ** (1.0/3.0)
+         fact_crit = fact_crit * ( 0.75 * sqrt_pi * &
+                            SQRT( mass_plasma / electron_mass ) )**(1.0/3.0)
+         RETURN
+      END SUBROUTINE SET_CRIT_FACTOR
+
+      FUNCTION COULOMB_LOG_NRL_EE(ne,te) RESULT(result)
+         !--------------------------------------------------------------
+         !   NE      Electron Density [m^-3]
+         !   TE      Electron Temperature [eV]
+         !   RESULT  Coulomb Logarithm Thermal electron-electron
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: ne,te
+         DOUBLE PRECISION :: result
+         result = 23.5 - LOG( SQRT( te * 1D-6 ) * te**-1.25 ) &
+                - SQRT( 1D-5 + 0.0625 * ( LOG(te) - 2.0 )**2.0 )
+         RETURN
+      END FUNCTION COULOMB_LOG_NRL_EE
+
+      FUNCTION COULOMB_LOG_NRL_IEA(Z,ne,te) RESULT(result)
+         !--------------------------------------------------------------
+         !           For Ti*me/mi < Te < 10*Z*Z [eV]
+         !   Z       Ion charge number [e]
+         !   NE      Electron Density [m^-3]
+         !   TE      Electron Temperature [eV]
+         !   RESULT  Coulomb Logarithm Thermal ion-electron
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: Z,ne,te
+         DOUBLE PRECISION :: result
+         result = 23.0 - LOG( SQRT( ne * 1.0E-6 ) * Z * te**(-1.50))
+         RETURN
+      END FUNCTION COULOMB_LOG_NRL_IEA
+
+      FUNCTION COULOMB_LOG_NRL_IEB(ne,te) RESULT(result)
+         !--------------------------------------------------------------
+         !           For Ti*me/mi < 10*Z*Z [eV] < Te
+         !   NE      Electron Density [m^-3]
+         !   TE      Electron Temperature [eV]
+         !   RESULT  Coulomb Logarithm Thermal ion-electron
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: ne,te
+         DOUBLE PRECISION :: result
+         result = 24.0 - LOG( SQRT( ne * 1.0E-6 ) / te)
+         RETURN
+      END FUNCTION COULOMB_LOG_NRL_IEB
+
+      FUNCTION COULOMB_LOG_NRL_IEC(mass,Z,ni,ti) RESULT(result)
+         !--------------------------------------------------------------
+         !           For Te < Ti*me/mi
+         !   Z       Ion mass [kg]
+         !   Z       Ion charge number [e]
+         !   NI      Ion Density [m^-3]
+         !   TI      Ion Temperature [eV]
+         !   RESULT  Coulomb Logarithm Thermal ion-electron
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: mass,Z,ni,ti
+         DOUBLE PRECISION :: result
+         result = 16.0 - LOG( SQRT( ni * 1.0E-6 ) * Ti**(-1.5) * Z * Z * mass * inv_dalton)
+         RETURN
+      END FUNCTION COULOMB_LOG_NRL_IEC
+
+      FUNCTION COULOMB_LOG_NRL_II(mass1,z1,ni1,ti1,mass2,z2,ni2,ti2) RESULT(result)
+         !--------------------------------------------------------------
+         !   MASS1   First Ion mass [kg]
+         !   Z1      First Ion charge number [e]
+         !   NI1     First Ion Density [m^-3]
+         !   TI1     First Ion Temperature [eV]
+         !   MASS2   Second Ion mass [kg]
+         !   Z2      Second Ion charge number [e]
+         !   NI2     Second Ion Density [m^-3]
+         !   TI2     Second Ion Temperature [eV]
+         !   RESULT  Coulomb Logarithm Thermal ion-ion
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: mass1,z1,ni1,ti1
+         DOUBLE PRECISION, INTENT(in) :: mass2,z2,ni2,ti2
+         DOUBLE PRECISION :: result
+         result = 23.0 - LOG( ( z1 * z2 * ( mass1 + mass2 ) ) * &
+                    ( ni1 * z1 * z1 / ti1 + ni2 * z2 * z2 / ti2) * &
+                    1.0E-6 / ( mass1 * ti2 + mass2 * ti1 ) )
+         RETURN
+      END FUNCTION COULOMB_LOG_NRL_II
+
+      FUNCTION COULOMB_LOG_NRL_GENERAL(mass1,Z1,mass2,Z2,ld,u) RESULT(result)
+         !--------------------------------------------------------------
+         !   MASS1   First Species mass [kg]
+         !   Z1      First Species charge number [e]
+         !   MASS2   Second Species mass [kg]
+         !   Z2      Second Species charge number [e]
+         !   LD      Plasma Debye Length [m]
+         !   U       Relative velocities (|v1-v2|)
+         !   RESULT  Coulomb Logarithm species-species
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: mass1,z1,mass2,z2,ld,u
+         DOUBLE PRECISION :: result
+         DOUBLE PRECISION :: rmina,rminb
+         rmina   =  1.0 / mass2 + 1.0 / mass1
+         rminb   =  0.5 * hbar * rmina / u
+         rmina   =  rmina*electron_charge*electron_charge*Z1*Z2/( u * u )
+         result  = LOG( LD / MAX(rmina,rminb) )
+      END FUNCTION COULOMB_LOG_NRL_GENERAL
+
+      FUNCTION COULOMB_LOG_NRL_COUNTERSTREAM(ne,te,vbeta,Zeff) RESULT(result)
+         !--------------------------------------------------------------
+         !   NE      Electron Density [m^-3]
+         !   TE      Electron Temperature [eV]
+         !   VBETA   Normalized Particle Velocity (v/c)
+         !   ZEFF    Plasma Effective Charge [arb]
+         !   RESULT  Coulomb Logarithm Counterstreaming ions
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: ne,te,vbeta,Zeff
+         DOUBLE PRECISION :: result
+         result = 43.0 - log(Zeff*coulomb_factor*sqrt(ne*1D-6/te)/(vbeta*vbeta))
+         RETURN
+      END FUNCTION COULOMB_LOG_NRL_COUNTERSTREAM
+
+      FUNCTION V_CRITICAL(te) RESULT(result)
+         !--------------------------------------------------------------
+         !   TE      Electron Temperature [eV]
+         !   RESULT  Critical Velocity [m/s]
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: te
+         DOUBLE PRECISION :: result
+         result = fact_crit*SQRT(te)
+         RETURN
+      END FUNCTION V_CRITICAL
+
+      FUNCTION V_CRITICAL_WEILAND(te,ion_coulomb_log,electron_coulomb_log) RESULT(result)
+         !--------------------------------------------------------------
+         !   TE                    Electron Temperature [eV]
+         !   ION_COULOMB_LOG       Ion Coulomb Logarithm [arb]
+         !   ELECTRON_COULOMB_LOG  Eelctron Coulomb Logarithm [arb]
+         !   RESULT                Critical Velocity [m/s]
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: te,ion_coulomb_log,electron_coulomb_log
+         DOUBLE PRECISION :: result
+         !The coulomb ratio is from Weiland (2018) eq.11
+         result = fact_crit_weiland*SQRT(te)*(ion_coulomb_log/electron_coulomb_log)**(1.0/3.0)
+         RETURN
+      END FUNCTION V_CRITICAL_WEILAND
+
+      FUNCTION TAU_SPITZER(mass,ne,te,Z,coulomb_log) RESULT(result)
+         !--------------------------------------------------------------
+         !   MASS         Particle mass [kg]
+         !   Z            Particle charge number [e]
+         !   NE           Electron Density [m^-3]
+         !   TE           Electron Temperature [eV]
+         !   COULOMB_LOG  Coulomb Logarithm
+         !   RESULT       Spitzer Collisional Timescale [s]
+         !--------------------------------------------------------------
+         DOUBLE PRECISION, INTENT(in) :: mass,ne,te,Z,coulomb_log
+         DOUBLE PRECISION :: result
+         result = 3.777183D41 * mass * SQRT( te * te * te ) / &
+                    (ne * Z * Z * coulomb_log)
+         RETURN
+      END FUNCTION TAU_SPITZER
+      
+!-----------------------------------------------------------------------
+!     End Module
+!-----------------------------------------------------------------------
+      END MODULE collision_operators

--- a/LIBSTELL/Sources/Modules/collision_operators.f90
+++ b/LIBSTELL/Sources/Modules/collision_operators.f90
@@ -56,11 +56,11 @@
          !--------------------------------------------------------------
          IMPLICIT NONE
          DOUBLE PRECISION, INTENT(in) :: z_plasma,mass_plasma
-         fact_crit = SQRT( 2.0 * electron_charge / electron_mass)
+         fact_crit = SQRT( 2.0 * electron_charge )
          ! WESSON PG 226 5.4.9
-         fact_crit_weiland = fact_crit * ( 0.75 * sqrt_pi * &
+         fact_crit_weiland = fact_crit/sqrt(electron_mass) * ( 0.75 * sqrt_pi * &
                             electron_mass * z_plasma / mass_plasma) ** (1.0/3.0)
-         fact_crit = fact_crit * ( 0.75 * sqrt_pi * &
+         fact_crit = fact_crit/sqrt(mass_plasma) * ( 0.75 * sqrt_pi * &
                             SQRT( mass_plasma / electron_mass ) )**(1.0/3.0)
          RETURN
       END SUBROUTINE SET_CRIT_FACTOR


### PR DESCRIPTION
This pull requests moves the computation of various coulomb logarithms and Spitzer collisional time to a LIBSTELL based module so that both BEAMS3D and THRIFT can refernece a common database.  The BEAMS3D regression tests all pass so there should be no chage BEASM3D performance.

@ajchcoelho will handle interfacing the new module into THRIFT.