### PR TITLE
BEAMS3D: Bugfix for uninitialized variable in beams3d_physics_mod.

### DIFF
--- a/BEAMS3D/Sources/beams3d_physics_mod.f90
+++ b/BEAMS3D/Sources/beams3d_physics_mod.f90
@@ -364,7 +364,7 @@ MODULE beams3d_physics_mod
             !------------------------------------------------------------
             !  Velocity diffusion 
             !------------------------------------------------------------
-            ddve = zero; ddvi = zero
+            ddve = zero; ddvi = zero; sigma = zero; zeta = zero
 #if defined(B3D_VEL_DIFFUSION)
             speed_cube = (speed*speed*speed)
             CALL gauss_rand(1,zeta)  ! A random from a standard normal (1,1)


### PR DESCRIPTION
This bugfix fixes an un-initilized sigma and zeta value in the GC collision operator for BEAMS3D.