### PR TITLE
Feature/vmec rescale

### DIFF
--- a/LIBSTELL/LIBSTELL.dep
+++ b/LIBSTELL/LIBSTELL.dep
@@ -1242,6 +1242,7 @@ vf_coils.o : \
       
 
 vmec_input.o : \
+      stel_constants.o \
       vparams.o \
       vsvd0.o 
       

--- a/LIBSTELL/Sources/Modules/vmec_input.f
+++ b/LIBSTELL/Sources/Modules/vmec_input.f
@@ -700,20 +700,18 @@
       SUBROUTINE INDATA_VOLUME(volume)
       IMPLICIT NONE
       DOUBLE PRECISION,INTENT(INOUT) :: volume
-      INTEGER :: m, n, u, v, nu1, nv1
+      INTEGER :: m, n, u, v
       INTEGER, PARAMETER :: nu = 256
       INTEGER, PARAMETER :: nv = 256
       REAL(rprec) :: tcos, tsin, arg1
       REAL(rprec), DIMENSION(nu,nv) :: rreal, zreal, rureal
-      !nu1 = nu - 1; nv1 = nv - 1
-      nu1 = nu; nv1 = nv
       volume = zero; rreal = zero; zreal = zero; rureal = zero
       DO n = -ntord,ntord
          DO m = 0,mpol1d
             IF (rbc(n,m) == zero .and. zbs(n,m) == zero) CYCLE
             DO u = 1, nu
                DO v = 1, nv
-                  arg1 = (m*DBLE(u-1)/nu1-n*DBLE(v-1)/nv1)*twopi
+                  arg1 = (m*DBLE(u-1)/nu-n*DBLE(v-1)/nv)*twopi
                   tcos = COS(arg1)
                   tsin = SIN(arg1)
                   rreal(u,v)  = rreal(u,v) + rbc(n,m) * tcos
@@ -730,7 +728,7 @@
                IF (rbs(n,m) == zero .and. zbc(n,m) == zero) CYCLE
                DO u = 1, nu
                   DO v = 1, nv
-                     arg1 = (m*DBLE(u-1)/nu1-n*DBLE(v-1)/nv1)*twopi
+                     arg1 = (m*DBLE(u-1)/nu-n*DBLE(v-1)/nv)*twopi
                      tcos = COS(arg1)
                      tsin = SIN(arg1)
                      rreal(u,v)  = rreal(u,v) + rbs(n,m) * tsin
@@ -742,9 +740,54 @@
             END DO
          END DO
       END IF
-      volume = ABS(twopi*SUM(rreal*zreal*rureal)/DBLE(nu1*nv1))
+      volume = ABS(twopi*SUM(rreal*zreal*rureal)/DBLE(nu*nv))
       RETURN
       END SUBROUTINE INDATA_VOLUME
+
+      SUBROUTINE INDATA_AREA(area)
+      IMPLICIT NONE
+      DOUBLE PRECISION,INTENT(INOUT) :: area
+      INTEGER :: m, n, u, v
+      INTEGER, PARAMETER :: nu = 256
+      INTEGER, PARAMETER :: nv = 256
+      REAL(rprec) :: tcos, tsin, arg1
+      REAL(rprec), DIMENSION(nu,nv) :: zreal, rureal
+      area = zero; zreal = zero; rureal = zero
+      DO n = -ntord,ntord
+         DO m = 0,mpol1d
+            IF (rbc(n,m) == zero .and. zbs(n,m) == zero) CYCLE
+            DO u = 1, nu
+               DO v = 1, nv
+                  arg1 = (m*DBLE(u-1)/nu-n*DBLE(v-1)/nv)*twopi
+                  tcos = COS(arg1)
+                  tsin = SIN(arg1)
+                  zreal(u,v)  = zreal(u,v) + zbs(n,m) * tsin
+                  rureal(u,v) = rureal(u,v) 
+     1                          - m * rbc(n,m) * tsin * twopi
+               END DO
+            END DO
+         END DO
+      END DO
+      IF (lasym) THEN
+         DO n = -ntord,ntord
+            DO m = 0,mpol1d
+               IF (rbs(n,m) == zero .and. zbc(n,m) == zero) CYCLE
+               DO u = 1, nu
+                  DO v = 1, nv
+                     arg1 = (m*DBLE(u-1)/nu-n*DBLE(v-1)/nv)*twopi
+                     tcos = COS(arg1)
+                     tsin = SIN(arg1)
+                     zreal(u,v)  = zreal(u,v) + zbc(n,m) * tcos
+                     rureal(u,v) = rureal(u,v) 
+     1                             + m * rbs(n,m) * tcos * twopi
+                  END DO
+               END DO
+            END DO
+         END DO
+      END IF
+      area = ABS(SUM(zreal*rureal)/DBLE(nu*nv))
+      RETURN
+      END SUBROUTINE INDATA_AREA
 
       SUBROUTINE INIT_AXIS_MEAN
       IMPLICIT NONE

--- a/LIBSTELL/Sources/Modules/vmec_input.f
+++ b/LIBSTELL/Sources/Modules/vmec_input.f
@@ -71,6 +71,8 @@
       CHARACTER(len=120) :: arg1
       CHARACTER(len=100) :: input_extension
 
+      REAL(rprec) :: Tvolume ! SAL Total volume targeting
+
       LOGICAL :: lnyquist = .TRUE.    !=false, suppress nyquist stuff; CZHU 2021.03.31
 
       NAMELIST /indata/ mgrid_file, time_slice, nfp, ncurr, nsin,
@@ -98,7 +100,8 @@
      D   lgiveup,fgiveup,                                                  ! M.Drevlak 2012-05-10
      E   lbsubs,                                                           ! 2014-01-12 See jxbforce
      F   trip3d_file,                                                      ! SAL - TRIP3D
-     G   lnyquist
+     G   lnyquist,
+     H   tvolume
 
       NAMELIST /mseprofile/ mseprof
 
@@ -179,6 +182,9 @@
       am_aux_s(:) = -1
       ac_aux_s(:) = -1
       ai_aux_s(:) = -1
+
+!     Rescaling Parameters
+      tvolume = -1 ! No rescale if volume <= 0
       
 
 !

--- a/LIBSTELL/Sources/Modules/vmec_input.f
+++ b/LIBSTELL/Sources/Modules/vmec_input.f
@@ -1,5 +1,6 @@
       MODULE vmec_input
       USE vparams, ONLY: rprec, dp, mpol1d, ntord, ndatafmax
+      USE stel_constants, ONLY: zero,twopi
       USE vsvd0
       IMPLICIT NONE
 !-----------------------------------------------
@@ -71,7 +72,7 @@
       CHARACTER(len=120) :: arg1
       CHARACTER(len=100) :: input_extension
 
-      REAL(rprec) :: Tvolume ! SAL Total volume targeting
+      REAL(rprec) :: tvolume
 
       LOGICAL :: lnyquist = .TRUE.    !=false, suppress nyquist stuff; CZHU 2021.03.31
 
@@ -111,6 +112,7 @@
       INTEGER, INTENT(IN) :: iunit
       INTEGER, INTENT(OUT) :: istat
       ChARACTER(len=256) :: line
+      REAL(rprec) :: temp_volume
 
 !
 !     INITIALIZATIONS
@@ -183,8 +185,8 @@
       ac_aux_s(:) = -1
       ai_aux_s(:) = -1
 
-!     Rescaling Parameters
-      tvolume = -1 ! No rescale if volume <= 0
+!     Rescaling parameters
+      tvolume = -1
       
 
 !
@@ -366,7 +368,7 @@
       WRITE(iunit,outint) 'NCURR',ncurr
       WRITE (iunit, '(2x,3a)') "PIOTA_TYPE = '",TRIM(piota_type),"'"
       WRITE (iunit,'(a,(1p,4e22.14))') '  AI = ',(ai(n-1), n=1,SIZE(ai))
-      i	= minloc(ai_aux_s(2:),DIM=1)
+      i = minloc(ai_aux_s(2:),DIM=1)
       IF (i > 4) THEN
          WRITE (iunit,'(a,(1p,4ES22.12E3))') '  AI_AUX_S = ', 
      1         (ai_aux_s(n), n=1,i)
@@ -376,7 +378,7 @@
       WRITE (iunit, '(2x,3a)') "PCURR_TYPE = '",TRIM(pcurr_type),"'"
       WRITE (iunit,'(a,(1p,4ES22.12E3))')
      1 '  AC = ',(ac(n-1), n=1,SIZE(ac))
-      i	= minloc(ac_aux_s(2:),DIM=1)
+      i = minloc(ac_aux_s(2:),DIM=1)
       IF (i > 4) THEN
          WRITE (iunit,'(a,(1p,4ES22.12E3))') '  AC_AUX_S = ', 
      1         (ac_aux_s(n), n=1,i)
@@ -395,6 +397,7 @@
       WRITE (iunit,'(a,(1p,4ES22.12E3))') 
      1     '  ZAXIS_CS = ',(zaxis_cs(n), n=0,ntor)
       WRITE(iunit,'(A)') '!----- Boundary Parameters -----'
+      IF (tvolume > 0) WRITE(iunit,outexp) 'TVOLUME',tvolume
       DO m = 0, mpol - 1
          DO n = -ntor, ntor
             IF ((rbc(n,m).ne.0) .or. (zbs(n,m).ne.0)) THEN
@@ -568,6 +571,8 @@
      1               local_master, local_comm, iflag)
       CALL MPI_BCAST(fgiveup,          1, MPI_DOUBLE_PRECISION, 
      1               local_master, local_comm, iflag)
+      CALL MPI_BCAST(tvolume,          1, MPI_DOUBLE_PRECISION, 
+     1               local_master, local_comm, iflag)
       CALL MPI_BARRIER(local_comm,iflag)
       ! Real Arrays
       CALL MPI_BCAST(rbc,         (2*ntord+1)*(mpol1d+1),
@@ -684,6 +689,88 @@
       iflag = 0
       RETURN
       END SUBROUTINE bcast_indata_namelist
+
+      SUBROUTINE INDATA_VOLUME(volume)
+      IMPLICIT NONE
+      DOUBLE PRECISION,INTENT(INOUT) :: volume
+      INTEGER :: m, n, u, v, nu1, nv1
+      INTEGER, PARAMETER :: nu = 256
+      INTEGER, PARAMETER :: nv = 256
+      REAL(rprec) :: tcos, tsin, arg1
+      REAL(rprec), DIMENSION(nu,nv) :: rreal, zreal, rureal
+      !nu1 = nu - 1; nv1 = nv - 1
+      nu1 = nu; nv1 = nv
+      volume = zero; rreal = zero; zreal = zero; rureal = zero
+      DO n = -ntord,ntord
+         DO m = 0,mpol1d
+            IF (rbc(n,m) == zero .and. zbs(n,m) == zero) CYCLE
+            DO u = 1, nu
+               DO v = 1, nv
+                  arg1 = (m*DBLE(u-1)/nu1-n*DBLE(v-1)/nv1)*twopi
+                  tcos = COS(arg1)
+                  tsin = SIN(arg1)
+                  rreal(u,v)  = rreal(u,v) + rbc(n,m) * tcos
+                  zreal(u,v)  = zreal(u,v) + zbs(n,m) * tsin
+                  rureal(u,v) = rureal(u,v) 
+     1                          - m * rbc(n,m) * tsin * twopi
+               END DO
+            END DO
+         END DO
+      END DO
+      IF (lasym) THEN
+         DO n = -ntord,ntord
+            DO m = 0,mpol1d
+               IF (rbs(n,m) == zero .and. zbc(n,m) == zero) CYCLE
+               DO u = 1, nu
+                  DO v = 1, nv
+                     arg1 = (m*DBLE(u-1)/nu1-n*DBLE(v-1)/nv1)*twopi
+                     tcos = COS(arg1)
+                     tsin = SIN(arg1)
+                     rreal(u,v)  = rreal(u,v) + rbs(n,m) * tsin
+                     zreal(u,v)  = zreal(u,v) + zbc(n,m) * tcos
+                     rureal(u,v) = rureal(u,v) 
+     1                             + m * rbs(n,m) * tcos * twopi
+                  END DO
+               END DO
+            END DO
+         END DO
+      END IF
+      volume = ABS(twopi*SUM(rreal*zreal*rureal)/DBLE(nu1*nv1))
+      RETURN
+      END SUBROUTINE INDATA_VOLUME
+
+      SUBROUTINE INIT_AXIS_MEAN
+      IMPLICIT NONE
+      INTEGER :: n
+      raxis = zero; zaxis = zero
+      DO n = 0, ntord
+            raxis_cc(n) = rbc(n, 0)
+            zaxis_cc(n) = zbc(n, 0)
+            raxis_cs(n) = rbs(n, 0)
+            zaxis_cs(n) = zbs(n, 0)
+      END DO
+      RETURN
+      END SUBROUTINE INIT_AXIS_MEAN
+
+      SUBROUTINE INIT_AXIS_MIDPOINT
+      IMPLICIT NONE
+      INTEGER :: n, m
+      CALL INIT_AXIS_MEAN
+      DO m = 2, mpol1d, 2 ! Add even-m modes for m>0
+         ! Handle the n=0 modes:
+         raxis_cc(0) = raxis_cc(0) + rbc(0, m)
+         zaxis_cc(0) = zaxis_cc(0) + zbc(0, m)
+         ! No need to include the sin(n*phi) modes for n=0 here.
+         ! Handle the n.ne.0 modes:
+         DO n = 1, ntord
+            raxis_cc(n) = raxis_cc(n) + rbc(n, m) + rbc(-n, m)
+            zaxis_cc(n) = zaxis_cc(n) + zbc(n, m) + zbc(-n, m)
+            raxis_cs(n) = raxis_cs(n) + rbs(n, m) - rbs(-n, m)
+            zaxis_cs(n) = zaxis_cs(n) + zbs(n, m) - zbs(-n, m)
+         END DO
+      END DO
+      RETURN
+      END SUBROUTINE INIT_AXIS_MIDPOINT
 
       END MODULE vmec_input
 

--- a/LIBSTELL/Sources/Modules/vmec_input.f
+++ b/LIBSTELL/Sources/Modules/vmec_input.f
@@ -72,6 +72,7 @@
       CHARACTER(len=120) :: arg1
       CHARACTER(len=100) :: input_extension
 
+      LOGICAL :: lvolume_rfix
       REAL(rprec) :: tvolume
 
       LOGICAL :: lnyquist = .TRUE.    !=false, suppress nyquist stuff; CZHU 2021.03.31
@@ -102,7 +103,7 @@
      E   lbsubs,                                                           ! 2014-01-12 See jxbforce
      F   trip3d_file,                                                      ! SAL - TRIP3D
      G   lnyquist,
-     H   tvolume
+     H   tvolume, lvolume_rfix
 
       NAMELIST /mseprofile/ mseprof
 
@@ -187,6 +188,7 @@
 
 !     Rescaling parameters
       tvolume = -1
+      lvolume_rfix = .false.
       
 
 !
@@ -397,7 +399,10 @@
       WRITE (iunit,'(a,(1p,4ES22.12E3))') 
      1     '  ZAXIS_CS = ',(zaxis_cs(n), n=0,ntor)
       WRITE(iunit,'(A)') '!----- Boundary Parameters -----'
-      IF (tvolume > 0) WRITE(iunit,outexp) 'TVOLUME',tvolume
+      IF (tvolume > 0) THEN
+         WRITE(iunit,outexp) 'TVOLUME',tvolume
+         WRITE(iunit,outboo) 'LVOLUME_RFIX',lvolume_rfix
+      END IF
       DO m = 0, mpol - 1
          DO n = -ntor, ntor
             IF ((rbc(n,m).ne.0) .or. (zbs(n,m).ne.0)) THEN
@@ -466,6 +471,8 @@
       CALL MPI_BCAST(lgiveup,        1, MPI_LOGICAL, local_master, 
      1               local_comm, iflag)
       CALL MPI_BCAST(lbsubs,         1, MPI_LOGICAL, local_master, 
+     1               local_comm, iflag)
+      CALL MPI_BCAST(lvolume_rfix,   1, MPI_LOGICAL, local_master, 
      1               local_comm, iflag)
       CALL MPI_BARRIER(local_comm,iflag)
       ! Integers

--- a/VMEC2000/Sources/Input_Output/readin.f
+++ b/VMEC2000/Sources/Input_Output/readin.f
@@ -269,12 +269,29 @@ C-----------------------------------------------
 !
       IF (tvolume .gt. 0.0) THEN
          CALL INDATA_VOLUME(rtest)
-         rbc = rbc * (tvolume / rtest) ** (1.0/3.0)
-         zbs = zbs * (tvolume / rtest) ** (1.0/3.0)
-         IF (lasym) THEN
-            rbs = rbs * (tvolume / rtest) ** (1.0/3.0)
-            zbc = zbc * (tvolume / rtest) ** (1.0/3.0)
-         END IF
+         IF (lvolume_rfix) THEN
+            raxis_cc = rbc(0:ntord,0)
+            zaxis_cs = zbs(0:ntord,0)
+            rbc = rbc * (tvolume / rtest) ** (1.0/2.0)
+            zbs = zbs * (tvolume / rtest) ** (1.0/2.0)
+            rbc(0:ntord,0) = raxis_cc(0:ntord)
+            zbs(0:ntord,0) = zaxis_cs(0:ntord)
+            IF (lasym) THEN
+               raxis_cs = rbs(0:ntord,0)
+               zaxis_cc = zbc(0:ntord,0)
+               rbs = rbs * (tvolume / rtest) ** (1.0/2.0)
+               zbc = zbc * (tvolume / rtest) ** (1.0/2.0)
+               rbs(0:ntord,0) = raxis_cs(0:ntord)
+               zbc(0:ntord,0) = zaxis_cc(0:ntord)
+            END IF
+         ELSE
+            rbc = rbc * (tvolume / rtest) ** (1.0/3.0)
+            zbs = zbs * (tvolume / rtest) ** (1.0/3.0)
+            IF (lasym) THEN
+               rbs = rbs * (tvolume / rtest) ** (1.0/3.0)
+               zbc = zbc * (tvolume / rtest) ** (1.0/3.0)
+            END IF
+         ENDIF
          CALL INIT_AXIS_MIDPOINT
       END IF
 !

--- a/VMEC2000/Sources/Input_Output/readin.f
+++ b/VMEC2000/Sources/Input_Output/readin.f
@@ -25,7 +25,8 @@ C-----------------------------------------------
      &   NonZeroLen
       REAL(dp), DIMENSION(:,:), POINTER ::
      &  rbcc, rbss, rbcs, rbsc, zbcs, zbsc, zbcc, zbss
-      REAL(dp) :: rtest, ztest, tzc, trc, delta
+      REAL(dp) :: rtest, ztest, tzc, trc, delta, AVolume, AArea, TArea,
+     &            AR00
       REAL(dp), ALLOCATABLE :: temp(:)
       CHARACTER(LEN=100) :: line, line2
       CHARACTER(LEN=1)   :: ch1, ch2
@@ -268,28 +269,31 @@ C-----------------------------------------------
 !     Rescale the equilibria if asked
 !
       IF (tvolume .gt. 0.0) THEN
-         CALL INDATA_VOLUME(rtest)
+         CALL INDATA_VOLUME(AVolume)
          IF (lvolume_rfix) THEN
+            CALL INDATA_AREA(AArea)
+            AR00 = AVolume/(twopi * AArea)
+            TArea = TVolume/(twopi * AR00)
             raxis_cc = rbc(0:ntord,0)
             zaxis_cs = zbs(0:ntord,0)
-            rbc = rbc * (tvolume / rtest) ** (1.0/2.0)
-            zbs = zbs * (tvolume / rtest) ** (1.0/2.0)
+            rbc = rbc * (Tarea / Aarea) ** (1.0/2.0)
+            zbs = zbs * (Tarea / Aarea) ** (1.0/2.0)
             rbc(0:ntord,0) = raxis_cc(0:ntord)
             zbs(0:ntord,0) = zaxis_cs(0:ntord)
             IF (lasym) THEN
                raxis_cs = rbs(0:ntord,0)
                zaxis_cc = zbc(0:ntord,0)
-               rbs = rbs * (tvolume / rtest) ** (1.0/2.0)
-               zbc = zbc * (tvolume / rtest) ** (1.0/2.0)
+               rbs = rbs * (Tarea / Aarea) ** (1.0/2.0)
+               zbc = zbc * (Tarea / Aarea) ** (1.0/2.0)
                rbs(0:ntord,0) = raxis_cs(0:ntord)
                zbc(0:ntord,0) = zaxis_cc(0:ntord)
             END IF
          ELSE
-            rbc = rbc * (tvolume / rtest) ** (1.0/3.0)
-            zbs = zbs * (tvolume / rtest) ** (1.0/3.0)
+            rbc = rbc * (tvolume / AVolume) ** (1.0/3.0)
+            zbs = zbs * (tvolume / AVolume) ** (1.0/3.0)
             IF (lasym) THEN
-               rbs = rbs * (tvolume / rtest) ** (1.0/3.0)
-               zbc = zbc * (tvolume / rtest) ** (1.0/3.0)
+               rbs = rbs * (tvolume / AVolume) ** (1.0/3.0)
+               zbc = zbc * (tvolume / AVolume) ** (1.0/3.0)
             END IF
          ENDIF
          CALL INIT_AXIS_MIDPOINT
@@ -420,14 +424,17 @@ C-----------------------------------------------
      &   ns_array(1),nstep,nvacskip,
      &   ftol_array(multi_ns_grid),tcon0,lasym,lforbal,lmove_axis,
      &   lconm1,mfilter_fbdy,nfilter_fbdy,lfull3d1out,
-     &   max_main_iterations,lgiveup,fgiveup                                         ! M Drevlak 20130114
+     &   max_main_iterations,lgiveup,fgiveup,                                         ! M Drevlak 20130114
+     &   tvolume,lvolume_rfix
  110  FORMAT(' RUN CONTROL PARAMETERS:',/,1x,23('-'),/,
      &  '  ncurr  niter   nsin  nstep  nvacskip      ftol     tcon0',
      &  '    lasym  lforbal lmove_axis lconm1',/,
      &     4i7,i10,1p,2e10.2,4L9,/,
      &  '  mfilter_fbdy nfilter_fbdy lfull3d1out max_main_iterations', ! J Geiger 20120203
-     &  ' lgiveup fgiveup',/,               ! M Drevlak 20130114
-     &     2(6x,i7),L12,10x,i10,L8,e9.1,/)  ! M Drevlak 20130114
+     &  ' lgiveup fgiveup',               ! M Drevlak 20130114
+     &  '   tvolume lvolume_rfix',/,
+     &     2(6x,i7),L12,10x,i10,L8,e9.1,    ! M Drevlak 20130114
+     &     e10.2, L13 /)  ! S Lazerson 20250116
 
          WRITE (nthreed,120) precon_type, prec2d_threshold
  120  FORMAT(' PRECONDITIONER CONTROL PARAMETERS:',/,1x,34('-'),/,

--- a/VMEC2000/Sources/Input_Output/readin.f
+++ b/VMEC2000/Sources/Input_Output/readin.f
@@ -1,5 +1,6 @@
       SUBROUTINE readin(input_file, iseq_count, ier_flag, lscreen)
       USE vmec_main
+      USE vmec_input
       USE vmec_params
       USE vacmod
       USE vspline
@@ -263,7 +264,19 @@ C-----------------------------------------------
       IF (ier_flag .NE. norm_term_flag) RETURN
 
       IF (tensi2 .EQ. zero ) tensi2 = tensi
-
+!
+!     Rescale the equilibria if asked
+!
+      IF (tvolume .gt. 0.0) THEN
+         CALL INDATA_VOLUME(rtest)
+         rbc = rbc * (tvolume / rtest) ** (1.0/3.0)
+         zbs = zbs * (tvolume / rtest) ** (1.0/3.0)
+         IF (lasym) THEN
+            rbs = rbs * (tvolume / rtest) ** (1.0/3.0)
+            zbc = zbc * (tvolume / rtest) ** (1.0/3.0)
+         END IF
+         CALL INIT_AXIS_MIDPOINT
+      END IF
 !
 !     Open output files here, print out heading to threed1 file
 !


### PR DESCRIPTION
This modification adds two input variables to the VMEC `INDATA` namelist:

- TVOLUME
- LVOLUME_RFIX

The `TVOLUME` if set rescales the volume to the value which it is set to. This is done by multiplying all the boundary harmonics by a constant. If `LVOLUME_RFIX` is set to TRUE then the effective major radius is held fixed durring the rescaling.

These changes should not affect how VMEC is normally run.