### PR TITLE
STELLOPT: ONE_ITER mode now possible by command line option.

### DIFF
--- a/STELLOPTV2/Sources/General/stellopt_init.f90
+++ b/STELLOPTV2/Sources/General/stellopt_init.f90
@@ -58,8 +58,9 @@
       CALL read_stellopt_input(TRIM(id_string),ier)
       CALL stellopt_read_cws
       CALL stellopt_write_header
-      !CALL bcast_vars(master,MPI_COMM_STEL,ierr_mpi)
-      !IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'stellot_init:bcast_vars',ierr_mpi)
+
+      ! Handle a one_iter_run
+      IF (loneiter) opt_type = 'one_iter'
 
       ! Handle coil geometry
       IF (lcoil_geom) CALL namelist_input_makegrid(id_string)

--- a/STELLOPTV2/Sources/General/stellopt_main.f90
+++ b/STELLOPTV2/Sources/General/stellopt_main.f90
@@ -68,6 +68,7 @@
       lno_restart = .false.
       lauto_domain = .false.
       lrenorm      = .false.
+      loneiter     = .false.
       pct_domain = 0.05
       xvec_file = 'xvec.dat'
       INQUIRE(UNIT=6,NAME=screen_str) ! Store STDOUT
@@ -119,6 +120,8 @@
                   i=i+1
                   call GETCARG(i,args(i),numargs)
                   xvec_file = args(i)
+               case ("-oneiter","-one_iter")
+                  loneiter = .true.
                case ("-help","-h") ! Output Help message
                   write(6,*)' STELLOPT Optimizer '
                   WRITE(6,'(a,f5.2)') '  Version: ',STELLOPT_VERSION
@@ -129,6 +132,7 @@
                   write(6,*)'     -autodomain pct   Automatically calculate min-max domain'
                   write(6,*)'     -noverb           Supress all screen output'
                   write(6,*)'     -log              Output screen to log file'
+                  write(6,*)'     -one_iter         Force single iteration operation'
                   write(6,*)'     -tri file1 file2  Triangulation files'
                   write(6,*)'     -xvec_file file   X_VEC filename (OPT_TYPE: EVAL_XVEC)'
                   write(6,*)'     -help:            Output help message'
@@ -163,12 +167,14 @@
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'stellopt_main_3',ierr_mpi)
       CALL MPI_BCAST(lauto_domain,1,MPI_LOGICAL, master, MPI_COMM_STEL,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'stellopt_main_4',ierr_mpi)
-      CALL MPI_BCAST(pct_domain,1,MPI_REAL8, master, MPI_COMM_STEL,ierr_mpi)
+      CALL MPI_BCAST(loneiter,1,MPI_LOGICAL, master, MPI_COMM_STEL,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'stellopt_main_5',ierr_mpi)
-      CALL MPI_BCAST(id_string,256,MPI_CHARACTER, master, MPI_COMM_STEL,ierr_mpi)
+      CALL MPI_BCAST(pct_domain,1,MPI_REAL8, master, MPI_COMM_STEL,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'stellopt_main_6',ierr_mpi)
-      CALL MPI_BCAST(id_tag,256,MPI_CHARACTER, master, MPI_COMM_STEL,ierr_mpi)
+      CALL MPI_BCAST(id_string,256,MPI_CHARACTER, master, MPI_COMM_STEL,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'stellopt_main_7',ierr_mpi)
+      CALL MPI_BCAST(id_tag,256,MPI_CHARACTER, master, MPI_COMM_STEL,ierr_mpi)
+      IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'stellopt_main_8',ierr_mpi)
       CALL MPI_BARRIER( MPI_COMM_STEL, ierr_mpi )
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BARRIER_ERR,'stellopt_main',ierr_mpi)
 !DEC$ ENDIF

--- a/STELLOPTV2/Sources/Modules/stellopt_runtime.f90
+++ b/STELLOPTV2/Sources/Modules/stellopt_runtime.f90
@@ -209,7 +209,7 @@
 !                                  lrefit, lno_restart, lauto_domain, lparallel,&
 !                                  ltriangulate, lcoil_geom, lrenorm     
       LOGICAL                  :: lverb, lneed_output, lrestart,&
-                                  lauto_domain, lparallel,lrenorm
+                                  lauto_domain, lparallel,lrenorm, loneiter
 !      INTEGER                  :: nvars, mtargets, iter, mode, iunit_out,&
 !                                  cr_strategy, rho_exp, npopulation, noptimizers,&
 !                                  ier_paraexe


### PR DESCRIPTION
This allows the user to specify `-one_iter` or `-oneiter` on the command line to STELLOPT and the will default to the single iteration mode of operation.