### PR TITLE
STELLOPT: Fixed missing bootstrap from normalization.

### DIFF
--- a/STELLOPTV2/Sources/General/stellopt_renorm.f90
+++ b/STELLOPTV2/Sources/General/stellopt_renorm.f90
@@ -146,6 +146,8 @@
                WHERE(sigma_vaciota<bigno) sigma_vaciota = sigma_vaciota/temp
             CASE(jtarget_magwell)
                WHERE(sigma_magwell<bigno) sigma_magwell = sigma_magwell/temp
+            CASE(jtarget_bootstrap)
+               WHERE(sigma_bootstrap<bigno) sigma_bootstrap = sigma_bootstrap/temp
             CASE(jtarget_helicity)
                WHERE(ABS(sigma_helicity)<bigno) sigma_helicity = sigma_helicity/temp
             CASE(jtarget_quasiiso)


### PR DESCRIPTION
Fixed the missing renormalization of bootstrap when running STELLOPT with `-renorm`.