### PR TITLE
Feature/sopt bootprox

### DIFF
--- a/LIBSTELL/Sources/STELLOPT/stellopt_input_mod.f90
+++ b/LIBSTELL/Sources/STELLOPT/stellopt_input_mod.f90
@@ -352,6 +352,7 @@
                          delta_min, delta_max, &
                          target_balloon, sigma_balloon, balloon_theta, balloon_zeta,&
                          target_bootstrap,sigma_bootstrap, target_neo, sigma_neo,&
+                         target_b10b11, sigma_b10b11, &
                          target_Jstar, sigma_Jstar, NumJstar,&
                          target_helicity, sigma_helicity, helicity,&
                          target_helicity_old, sigma_helicity_old, &
@@ -911,6 +912,8 @@
       balloon_zeta(:) = -1.0
       target_bootstrap(:) = 0.0
       sigma_bootstrap(:) = bigno
+      target_b10b11(:) = 0.0
+      sigma_b10b11(:) = bigno
       target_neo(:)   = 0.0
       sigma_neo(:)    = bigno
       target_Jstar(:) = 0.0
@@ -1097,6 +1100,7 @@
       lbooz(1) = .FALSE.
       target_balloon(1)   = 0.0;  sigma_balloon(1)   = bigno
       target_bootstrap(1) = 0.0;  sigma_bootstrap(1) = bigno
+      target_b10b11(1)    = 0.0;  sigma_b10b11(1)    = bigno
       target_neo(1)       = 0.0;  sigma_neo(1)       = bigno
       target_dkes(1)      = 0.0;  sigma_dkes(1)      = bigno
       target_dkes(2)      = 0.0;  sigma_dkes(2)      = bigno
@@ -1757,6 +1761,20 @@
            IF (sigma_bootstrap(ik) < bigno)  WRITE(iunit,"(2(2X,A,I3.3,A,ES22.12E3))") &
                           'TARGET_BOOTSTRAP(',ik,') = ',target_bootstrap(ik), &
                           'SIGMA_BOOTSTRAP(',ik,') = ',sigma_bootstrap(ik)
+         END DO
+      END IF
+      IF (ANY(sigma_b10b11 < bigno)) THEN
+         WRITE(iunit,'(A)') '!----------------------------------------------------------------------'
+         WRITE(iunit,'(A)') '!          B10/B11 (BOOTSTRAP PROXY)'  
+         WRITE(iunit,'(A)') '!----------------------------------------------------------------------'
+         n=0
+         DO ik = 1,UBOUND(sigma_b10b11,DIM=1)
+            IF(sigma_b10b11(ik) < bigno) n=ik
+         END DO
+         DO ik = 1, n
+           IF (sigma_b10b11(ik) < bigno)  WRITE(iunit,"(2(2X,A,I3.3,A,ES22.12E3))") &
+                          'TARGET_B10B11(',ik,') = ',target_b10b11(ik), &
+                          'SIGMA_B10B11(',ik,') = ',sigma_b10b11(ik)
          END DO
       END IF
       IF (ANY(sigma_neo < bigno)) THEN

--- a/LIBSTELL/Sources/STELLOPT/stellopt_targets.f90
+++ b/LIBSTELL/Sources/STELLOPT/stellopt_targets.f90
@@ -153,6 +153,7 @@
       REAL(rprec), DIMENSION(nsd)   ::  target_jdotb, sigma_jdotb
       REAL(rprec), DIMENSION(nsd)   ::  target_balloon, sigma_balloon
       REAL(rprec), DIMENSION(nsd)   ::  target_bootstrap, sigma_bootstrap
+      REAL(rprec), DIMENSION(nsd)   ::  target_b10b11, sigma_b10b11
       REAL(rprec), DIMENSION(nsd)   ::  target_neo, sigma_neo
       REAL(rprec), DIMENSION(nsd)   ::  target_Jstar, sigma_Jstar
       REAL(rprec), DIMENSION(nsd)   ::  target_magwell, sigma_magwell
@@ -272,6 +273,7 @@
       INTEGER, PARAMETER :: jtarget_balloon    = 601
       INTEGER, PARAMETER :: jtarget_kink       = 6011
       INTEGER, PARAMETER :: jtarget_bootstrap  = 602
+      INTEGER, PARAMETER :: jtarget_b10b11     = 6021
       INTEGER, PARAMETER :: jtarget_neo        = 603
       INTEGER, PARAMETER :: jtarget_Jstar      = 604
       INTEGER, PARAMETER :: jtarget_helicity   = 605
@@ -417,6 +419,8 @@
             WRITE(iunit, out_format) 'Kink Stability'
          CASE(jtarget_bootstrap)
             WRITE(iunit, out_format) 'Bootstrap Current'
+         CASE(jtarget_b10b11)
+            WRITE(iunit, out_format) 'B10/B11 (Bootstrap Proxy)'
          CASE(jtarget_neo)
             WRITE(iunit, out_format) 'Neoclassical Transport'
          CASE(jtarget_Jstar)

--- a/STELLOPTV2/ObjectList
+++ b/STELLOPTV2/ObjectList
@@ -1,4 +1,5 @@
 ObjectFiles = \
+chisq_b10b11.o \
 chisq_rosenbrock2d.o \
 chisq_quasiiso.o \
 stellopt_read_cws.o \

--- a/STELLOPTV2/STELLOPTV2.dep
+++ b/STELLOPTV2/STELLOPTV2.dep
@@ -239,6 +239,14 @@ chisq_magwell.o : \
       stellopt_runtime.o \
       $(LIB_DIR)/$(LOCTYPE)/stellopt_targets.o \
       equil_utils.o
+
+
+chisq_b10b11.o : \
+      stellopt_runtime.o \
+      $(LIB_DIR)/$(LOCTYPE)/stellopt_targets.o \
+      equil_vals.o \
+      $(LIB_DIR)/$(LOCTYPE)/read_boozer_mod.o \
+      $(LIB_DIR)/$(LOCTYPE)/vmec_input.o
       
 
 chisq_bprobes.o : \
@@ -277,14 +285,16 @@ chisq_helicity.o : \
       stellopt_runtime.o \
       $(LIB_DIR)/$(LOCTYPE)/stellopt_targets.o \
       equil_vals.o \
-      $(LIB_DIR)/$(LOCTYPE)/read_boozer_mod.o
+      $(LIB_DIR)/$(LOCTYPE)/read_boozer_mod.o \
+      $(LIB_DIR)/$(LOCTYPE)/vmec_input.o
 
 
 chisq_helicity_ornl.o : \
       stellopt_runtime.o \
       $(LIB_DIR)/$(LOCTYPE)/stellopt_targets.o \
       equil_vals.o \
-      $(LIB_DIR)/$(LOCTYPE)/read_boozer_mod.o
+      $(LIB_DIR)/$(LOCTYPE)/read_boozer_mod.o \
+      $(LIB_DIR)/$(LOCTYPE)/vmec_input.o
 
 
 chisq_quasiiso.o : \

--- a/STELLOPTV2/Sources/Chisq/chisq_b10b11.f90
+++ b/STELLOPTV2/Sources/Chisq/chisq_b10b11.f90
@@ -1,0 +1,76 @@
+!-----------------------------------------------------------------------
+!     Subroutine:    chisq_b10b11
+!     Authors:       S. Lazerson (samuel.lazerson@gauss-fusion.com)
+!     Date:          02/15/2025
+!     Description:   Calculate the Boozer B10/B11 ratio (Bmn) which is a
+!                    proxy for bootstrap current.
+!                    http://aip.scitation.org/doi/10.1063/1.860843
+!-----------------------------------------------------------------------
+      SUBROUTINE chisq_b10b11(target,sigma,niter,iflag)
+!-----------------------------------------------------------------------
+!     Libraries
+!-----------------------------------------------------------------------
+      USE stellopt_runtime
+      USE stellopt_targets
+      USE equil_vals
+      USE read_boozer_mod
+      USE vmec_input, ONLY: mpol, ntor
+      
+!-----------------------------------------------------------------------
+!     Input/Output Variables
+!
+!-----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL(rprec), INTENT(in)    ::  target(nsd)
+      REAL(rprec), INTENT(in)    ::  sigma(nsd)
+      INTEGER,     INTENT(in)    ::  niter
+      INTEGER,     INTENT(inout) ::  iflag
+      
+!-----------------------------------------------------------------------
+!     Local Variables
+!
+!-----------------------------------------------------------------------
+      INTEGER :: ik, mn
+      REAL(rprec) :: b00,b01,b11,b10
+!----------------------------------------------------------------------
+!     BEGIN SUBROUTINE
+!----------------------------------------------------------------------
+      IF (iflag < 0) RETURN
+      ik   = COUNT(sigma < bigno)
+      IF (iflag == 1) WRITE(iunit_out,'(A,2(2X,I3.3))') 'B10B11 ',ik,7
+      IF (iflag == 1) WRITE(iunit_out,'(A)') 'TARGET  SIGMA  VAL  B00  B01  B10  B11'
+      IF (niter >= 0) THEN
+         DO ik = 1, nsd
+            IF (sigma(ik) >= bigno) CYCLE
+            b00 = 0.0; b10 = 0.0; b01 = 0.0; b11 = 1.0
+            DO mn = 1, mnboz_b
+               IF ((ixn_b(mn)/nfp_b == 0) .and. (ixm_b(mn) == 0)) b00 = bmnc_b(mn,ik)
+               IF ((ixn_b(mn)/nfp_b == 1) .and. (ixm_b(mn) == 0)) b01 = bmnc_b(mn,ik)
+               IF ((ixn_b(mn)/nfp_b == 0) .and. (ixm_b(mn) == 1)) b10 = bmnc_b(mn,ik)
+               IF ((ixn_b(mn)/nfp_b == 1) .and. (ixm_b(mn) == 1)) b11 = bmnc_b(mn,ik)
+            END DO
+            mtargets = mtargets + 1
+            targets(mtargets) = target(ik)
+            sigmas(mtargets)  = sigma(ik)
+            vals(mtargets) = b10/b11
+            IF (iflag == 1) WRITE(iunit_out,'(7ES22.12E3)') target(ik),sigmas(mtargets),vals(mtargets),b00,b01,b10,b11
+         END DO
+      ELSE
+         ! Consistency check
+         mboz = MAX(6*mpol, 2, mboz)             
+         nboz = MAX(2*ntor-1, 0, nboz)  
+         ! CALCULATE mnboz_b becasue we don't know it yet (setup_booz.f)
+         mnboz_b = (2*nboz+1)*(mboz-1) + (nboz + 1)   
+         DO ik = 1, nsd
+            IF (sigma(ik) < bigno) THEN
+               lbooz(ik) = .TRUE.
+               mtargets = mtargets + 1
+               IF (niter == -2) target_dex(mtargets)=jtarget_b10b11
+            END IF
+         END DO
+      END IF
+      RETURN
+!----------------------------------------------------------------------
+!     END SUBROUTINE
+!----------------------------------------------------------------------
+      END SUBROUTINE chisq_b10b11

--- a/STELLOPTV2/Sources/General/stellopt_load_targets.f90
+++ b/STELLOPTV2/Sources/General/stellopt_load_targets.f90
@@ -251,6 +251,9 @@
       ! Boostrap
       IF (ANY(sigma_bootstrap < bigno)) &
          CALL chisq_bootstrap(target_bootstrap, sigma_bootstrap, ncnt,iflag)
+      ! B10B11
+      IF (ANY(sigma_b10b11 < bigno)) &
+         CALL chisq_b10b11(target_b10b11, sigma_b10b11, ncnt,iflag)
       ! NEO
       IF (ANY(sigma_neo < bigno)) &
          CALL chisq_neo(target_neo, sigma_neo, ncnt,iflag)

--- a/pySTEL/STELLOPT.py
+++ b/pySTEL/STELLOPT.py
@@ -883,7 +883,7 @@ class MyApp(QMainWindow):
 					'NE','NELINE','TE','TELINE','TI','TILINE','ZEFFLINE',\
 					'XICS','XICS_BRIGHT','XICS_W3','XICS_V','SXR','VPHI','VACIOTA',\
 					'IOTA','BALLOON','BOOTSTRAP','DKES','DKES_ERDIFF','DKES_ALPHA',\
-					'HELICITY','HELICITY_FULL','QUASIISO','GAMMA_C', \
+					'B10B11','HELICITY','HELICITY_FULL','QUASIISO','GAMMA_C', \
 					'KINK','ORBIT','JDOTB','J_STAR','NEO','TXPORT','ECEREFLECT',\
 					'S11','S12','S21','S22','MAGWELL',\
 					'CURVATURE_KERT','CURVATURE_P2']
@@ -901,7 +901,7 @@ class MyApp(QMainWindow):
 		# Handle Special Plots
 		self.ui.ComboBoxOPTplot_type.addItem('-----SPECIAL-----')
 		for name in ['BALLOON','KINK','ORBIT','NEO','HELICITY','HELICITY_FULL',\
-					'TXPORT','B_PROBES','FLUXLOOPS','SEGROG',\
+					'B10B11','BOOTSTRAP','TXPORT','B_PROBES','FLUXLOOPS','SEGROG',\
 					'NELINE','TELINE','TILINE','ZEFFLINE',\
 					'XICS','XICS_BRIGHT','XICS_W3','XICS_V',\
 					'S11','S12','S21','S22','MAGWELL','VACIOTA',\
@@ -942,6 +942,7 @@ class MyApp(QMainWindow):
 			self.ui.ComboBoxOPTplot_type.addItem('----- Boozer Coordinates -----')
 			self.ui.ComboBoxOPTplot_type.addItem('Boozer Spectrum')
 			self.ui.ComboBoxOPTplot_type.addItem('Boozer |B|')
+			self.ui.ComboBoxOPTplot_type.addItem('B10/B11')
 			self.ui.ComboBoxOPTplot_type.addItem('|B|_MAX')
 			self.ui.ComboBoxOPTplot_type.addItem('QAS_ERROR')
 			self.ui.ComboBoxOPTplot_type.addItem('QPS_ERROR')
@@ -1123,6 +1124,20 @@ class MyApp(QMainWindow):
 			self.ax2.set_xlabel('Radial Grid')
 			self.ax2.set_ylabel('Epsilon Effective')
 			self.ax2.set_title('Neoclassical Helical Ripple (NEO)')
+			self.ax2.legend()
+		elif (plot_name == 'BOOTSTRAP_evolution'):
+			x = self.stel_data.BOOTSTRAP_RHO # actually flux
+			y = self.stel_data.BOOTSTRAP_VAL #
+			t = self.stel_data.BOOTSTRAP_TARGET
+			d = self.stel_data.BOOTSTRAP_SIGMA
+			self.ax2.errorbar(x[0,:],t[0,:],yerr=d[0,:],fmt='ok',fillstyle='none',label='Target')
+			self.ax2.plot(x[0,:],y[0,:],'o',fillstyle='none',label='Initial',color='red')
+			for i in range(1,niter-1,1):
+				self.ax2.plot(x[i,:],y[i,:],'.k',fillstyle='none')
+			self.ax2.plot(x[niter-1,:],y[niter-1,:],'o',fillstyle='none',label='Final',color='green')
+			self.ax2.set_xlabel('Radial Grid')
+			self.ax2.set_ylabel('Bootstrap Current')
+			self.ax2.set_title('Bootstrap Current (BOOTSJ)')
 			self.ax2.legend()
 		elif ('DKES_L' in plot_name):
 			# Get L type

--- a/pySTEL/libstell/stellopt.py
+++ b/pySTEL/libstell/stellopt.py
@@ -33,7 +33,7 @@ class STELLOPT():
 			'NEO', 'DKES', 'DKES_ERDIFF', 'DKES_ALPHA', 'TXPORT',      \
 			'ORBIT', 'HELICITY', 'HELICITY_FULL', 'JSTAR', 'RESJAC',   \
 			'COIL_BNORM', 'REGCOIL_CHI2_B', 'CURVATURE_P2', 'GAMMA_C', \
-			'KINK', 'QUASIISO']
+			'KINK', 'QUASIISO', 'B10B11']
 
 	def read_stellopt_map(self,filename='map.dat'):
 		"""Reads a STELLOPT MAP output file


### PR DESCRIPTION
This pull request adds the B(m=1,n=0)/B(m=1,n=1) target to STELLOPT. This target is a proxy for the bootstrap current. The proxy is based on findings in the development of W7-X where B10/B11~0.5 minimized the bootstrap current [Phys. Fluids B 5, 3728–3736 (1993)](http://aip.scitation.org/doi/10.1063/1.860843). It should be noted that there is also an orthagonal dependence on B(m=0,n=1) which controls the mirror term. The user is free to specify the target B10/B11 ratio.