### PR TITLE
Bugfix/cleanup

### DIFF
--- a/STELLOPTV2/Sources/General/stellopt_bootsj.f90
+++ b/STELLOPTV2/Sources/General/stellopt_bootsj.f90
@@ -336,7 +336,7 @@
                WRITE(6,'(2X,A,F10.4,A)') 'NI0  =',densi(1),'x10^20 [m^-3]'
                IF (l_boot_all) WRITE(6,'(2X,A)') '<FULL CURRENT CALCULATTION>'
                WRITE(6,'(A)') '-------------------------------------------'
-               WRITE(6,'(A)') '   dex      rho      Te[keV]     Ti[keV]       Ne           Ni        BETA       J_BOOT     TOK_FRAC'
+               WRITE(6,'(A)') '   dex  flux(s)      Te[keV]     Ti[keV]       Ne           Ni        BETA       J_BOOT     TOK_FRAC'
                CALL FLUSH(6)             
             END IF
             bsnorm =0; capr = 0; caps = 0; ftrapped =0; h2 =0;

--- a/STELLOPTV2/Sources/General/stellopt_load_equil.f90
+++ b/STELLOPTV2/Sources/General/stellopt_load_equil.f90
@@ -377,10 +377,10 @@
          WRITE(6,'(A,F7.3,A)') '                    ',betap,'  (poloidal)'
          WRITE(6,'(A,F7.3,A)') '                    ',betat,'  (toroidal)'
          WRITE(6,'(A,E20.12)') '  TORIDAL CURRENT:  ',curtor
-         WRITE(6,'(A,F7.3)')   '     TORIDAL FLUX:  ',phiedge
-         WRITE(6,'(A,F7.3)')   '           VOLUME:  ',volume    
-         WRITE(6,'(A,F7.3)')   '     MAJOR RADIUS:  ',rmajor
-         WRITE(6,'(A,F7.3)')   '     MINOR RADIUS:  ',aminor
+         WRITE(6,'(A,F9.3)')   '     TORIDAL FLUX:  ',phiedge
+         WRITE(6,'(A,F9.3)')   '           VOLUME:  ',volume    
+         WRITE(6,'(A,F9.3)')   '     MAJOR RADIUS:  ',rmajor
+         WRITE(6,'(A,F9.3)')   '     MINOR RADIUS:  ',aminor
          WRITE(6,'(A,F7.3)')   '       AXIS FIELD:  ',Baxis
          WRITE(6,'(A,E20.12)')   '    STORED ENERGY:  ',wp
          CALL FLUSH(6)


### PR DESCRIPTION
This change fixes screen output for BOOTSJ when running in STELLOPT. The radial coordinate was labeled `rho` when it was in face the normalized toroidal flux `s`. Additionally, screen output of the plasma volume should now be correct.