### PR TITLE
LIBSTEL: Fixed header issue in Map files regarding large int.

### DIFF
--- a/LIBSTELL/Sources/Optimization/MAP.f90
+++ b/LIBSTELL/Sources/Optimization/MAP.f90
@@ -199,7 +199,7 @@
          CALL FLUSH(6)
          map_file = 'map.dat'
          CALL safe_open(iunit,ierr,TRIM(map_file),'new','formatted')
-         WRITE(iunit,'(4(2X,i6))') m,n,ndiv,num_search
+         WRITE(iunit,'(4(2X,i8))') m,n,ndiv,num_search
          DO i = 1, num_search
             WRITE(iunit,'(1p,4ES22.12E3)') (grid(i,j), j=1,n)
          END DO

--- a/LIBSTELL/Sources/Optimization/MAP_HYPERS.f90
+++ b/LIBSTELL/Sources/Optimization/MAP_HYPERS.f90
@@ -141,7 +141,7 @@
          map_file = 'map_hypers.dat'
          istat = 0
          CALL safe_open(iunit,istat,TRIM(map_file),'new','formatted')
-         WRITE(iunit,'(4(2X,i6))') m,n,ntot+1
+         WRITE(iunit,'(4(2X,i8))') m,n,ntot+1
          DO i = 0, ntot
             WRITE(iunit,'(1p,4ES22.12E3)') (x_global(j,i), j=1,n)
          END DO

--- a/LIBSTELL/Sources/Optimization/MAP_LINEAR.f90
+++ b/LIBSTELL/Sources/Optimization/MAP_LINEAR.f90
@@ -186,7 +186,7 @@
       IF (myid .eq. master) THEN
          map_file = 'map_linear.dat'
          CALL safe_open(iunit,ierr,TRIM(map_file),'new','formatted')
-         WRITE(iunit,'(4(2X,i6))') m,n,num_search
+         WRITE(iunit,'(4(2X,i8))') m,n,num_search
          DO i = 1, num_search
             WRITE(iunit,'(1p,4ES22.12E3)') (grid(i,j), j=1,n)
          END DO

--- a/LIBSTELL/Sources/Optimization/MAP_PLANE.f90
+++ b/LIBSTELL/Sources/Optimization/MAP_PLANE.f90
@@ -233,7 +233,7 @@
          WRITE(6,'(A)') '------- Outputing to map_plane.dat --------'
          CALL FLUSH(6)
          CALL safe_open(iunit,ierr,TRIM(map_file),'new','formatted')
-         WRITE(iunit,'(4(2X,i6))') m,n,ndiv,num_search
+         WRITE(iunit,'(4(2X,i8))') m,n,ndiv,num_search
          DO i = 1, num_search
             WRITE(iunit,'(1p,4ES22.12E3)') (grid(i,j), j=1,n)
          END DO


### PR DESCRIPTION
Fixes an issue where the `MAP` type optimizations had a bad integer write for very large integers.