### PR TITLE
Feature/coulomb logs

### DIFF
--- a/LIBSTELL/Sources/Modules/collision_operators.f90
+++ b/LIBSTELL/Sources/Modules/collision_operators.f90
@@ -121,6 +121,31 @@
          RETURN
       END FUNCTION COULOMB_LOG_NRL_IEC
 
+      FUNCTION COULOMB_LOG_NRL_IE(ne,te,mi,Z,ni,ti) RESULT(result)
+         !--------------------------------------------------------------
+         !   NE      Electron density [m^-3]
+         !   TE      Electron temperature [eV]
+         !   MI      Ion mass [kg]
+         !   Z       Ion Charge number [-]
+         !   NI      Ion density [m^-3]
+         !   TI      Ion temperature [eV]
+         !   RESULT  Coulomb Logarithm Thermal ion-electron
+         !--------------------------------------------------------------
+         IMPLICIT NONE
+         DOUBLE PRECISION, INTENT(in) :: ne,te,mi,Z,ni,ti
+         DOUBLE PRECISION :: result
+         IF (ti/mi < (te/electron_mass)) THEN
+            IF (te < (10 * Z * Z)) THEN
+               result = COULOMB_LOG_NRL_IEA(Z,ne,te)
+            ELSE
+               result = COULOMB_LOG_NRL_IEB(ne,te)
+            END IF
+         ELSE
+            result = COULOMB_LOG_NRL_IEC(mi,Z,ni,ti)
+         END IF
+         RETURN
+      END FUNCTION COULOMB_LOG_NRL_IE
+
       FUNCTION COULOMB_LOG_NRL_II(mass1,z1,ni1,ti1,mass2,z2,ni2,ti2) RESULT(result)
          !--------------------------------------------------------------
          !   MASS1   First Ion mass [kg]

--- a/LIBSTELL/Sources/Modules/collision_operators.f90
+++ b/LIBSTELL/Sources/Modules/collision_operators.f90
@@ -108,7 +108,7 @@
       FUNCTION COULOMB_LOG_NRL_IEC(mass,Z,ni,ti) RESULT(result)
          !--------------------------------------------------------------
          !           For Te < Ti*me/mi
-         !   Z       Ion mass [kg]
+         !   mass    Ion mass [kg]
          !   Z       Ion charge number [e]
          !   NI      Ion Density [m^-3]
          !   TI      Ion Temperature [eV]

--- a/LIBSTELL/Sources/Modules/collision_operators.f90
+++ b/LIBSTELL/Sources/Modules/collision_operators.f90
@@ -138,8 +138,8 @@
          DOUBLE PRECISION, INTENT(in) :: mass2,z2,ni2,ti2
          DOUBLE PRECISION :: result
          result = 23.0 - LOG( ( z1 * z2 * ( mass1 + mass2 ) ) * &
-                    ( ni1 * z1 * z1 / ti1 + ni2 * z2 * z2 / ti2) * &
-                    1.0E-6 / ( mass1 * ti2 + mass2 * ti1 ) )
+                    SQRT( ni1 * z1 * z1 / ti1 + ni2 * z2 * z2 / ti2) * &
+                    SQRT(1.0E-6) / ( mass1 * ti2 + mass2 * ti1 ) )
          RETURN
       END FUNCTION COULOMB_LOG_NRL_II
 

--- a/pySTEL/libstell/collisions.py
+++ b/pySTEL/libstell/collisions.py
@@ -87,15 +87,6 @@ class COLLISIONS():
 		mu = mi/self.MP
 		# No need to convert masses from kg to g
   
-		# if ti/mi < (te/self.ME):
-		# 	if (te < (10 * Z * Z)):
-		# 		clog = 23 - np.log(np.sqrt(ne_cm)*Z*te**(-1.5))
-		# 	else:
-		# 		clog = 24 - np.log(np.sqrt(ne_cm)/te)
-		# else:
-		# 	mu = (self.ME*mi)/(self.ME+mi)
-		# 	clog  = 16 - np.log(mu*Z*Z*np.sqrt(ni)*ti**-1.5)
-  
 		# Convert to numpy arrays if they aren't already
 		ti = np.asarray(ti)
 		te = np.asarray(te)
@@ -106,19 +97,18 @@ class COLLISIONS():
 		condition = (ti / mi) < (te / self.ME)
 
 		# Compute mu for cases where the condition is False
-		mu = (self.ME * mi) / (self.ME + mi)
+		mu = mi / DA
   
 		# Compute clog based on condition
 		clog = np.where(
 			condition,
 			np.where(
 				te < (10 * Z * Z),
-				23 - np.log(np.sqrt(ne_cm) * Z * te**(-1.5)),  # First nested condition
-				24 - np.log(np.sqrt(ne_cm) / te)  # Second nested condition
+				23 - np.log(np.sqrt(ne_cm) * Z * te**(-1.5)),
+				24 - np.log(np.sqrt(ne_cm) / te) 
 			),
-			16 - np.log(mu * Z * Z * np.sqrt(ni) * ti**-1.5)  # Else case
+			16 - np.log(mu * Z * Z * np.sqrt(ni) * ti**-1.5) 
 		)
-  
   
 		return clog
 


### PR DESCRIPTION
There was a square root missing in `COULOMB_LOG_NRL_II`. 

I have also introduced the function `COULOMB_LOG_NRL_IE`, which makes calls to the appropriate functions depending on the input parameters.

In `pySTEL`, the variable `mu` was not correctly defined in `coullog_ei`. According to NRL, `mu=mi/mp`. Now both `pySTEL` and `LIBSTELL` agree.