### PR TITLE
Bugfix for BEAMS3D VMEC field lookup

### DIFF
--- a/BEAMS3D/Sources/beams3d_init_fusion.f90
+++ b/BEAMS3D/Sources/beams3d_init_fusion.f90
@@ -84,7 +84,7 @@
       CALL init_random_seed
       IF (lverb) THEN
          WRITE(6, '(A)') '----- INITIALIZING FUSION REACTIONS -----'
-         WRITE(6, '(A,I6)') '      nparticles_start: ', nparticles_start
+         WRITE(6, '(A,I8)') '      nparticles_start: ', nparticles_start
          CALL FLUSH(6)
       END IF
 

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -331,7 +331,7 @@
          j = MOD(s-1,nr*nphi)
          j = FLOOR(REAL(j) / REAL(nr))+1
          k = CEILING(REAL(s) / REAL(nr*nphi))
-         if (sflx > 1.0) sflx = 0.9
+         sflx = MAX(0.001,MIN(0.999,sflx))
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                       br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
          ! GetBcyl will return ier = 0,-1,or-3
@@ -341,6 +341,7 @@
          ! Try again
          IF (ier .eq. -1) THEN
             sflx = MIN(sflx - 0.01,0.99)
+            uflx = uflx-0.1
             CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                         br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
          END IF
@@ -359,7 +360,6 @@
                B_R(i,j,k)   = br
                B_PHI(i,j,k) = bphi
                B_Z(i,j,k)   = bz
-               !sflx = 1.5 ! Assume s=1 for lplasma_only
             END IF
          END IF
          lsmooth(s) = (ier < 0) .and. (i > 1) .and. (i < nr) .and. (k > 1) .and. (k < nz)
@@ -390,12 +390,14 @@
          j = FLOOR(REAL(j) / REAL(nr))+1
          k = CEILING(REAL(s) / REAL(nr*nphi))
          if (.not. lsmooth(s)) CYCLE
+         ! Try a really good guess for S and U
          sflx =   S_ARR(i+1,j  ,k  ) + S_ARR(i-1,j  ,k  ) &
                 + S_ARR(i  ,j  ,k+1) + S_ARR(i  ,j  ,k-1)
          uflx =   U_ARR(i+1,j  ,k  ) + U_ARR(i-1,j  ,k  ) &
                 + U_ARR(i  ,j  ,k+1) + U_ARR(i  ,j  ,k-1)
          sflx = MIN(sflx*0.25,0.99)
          uflx = uflx*0.25
+         sflx = MAX(0.001,MIN(0.999,sflx))
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                       br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
          ! GetBcyl will return ier = 0,-1,or-3
@@ -413,13 +415,29 @@
                B_PHI(i,j,k) = bphi
                B_Z(i,j,k)   = bz
             END IF
-         ELSE IF (.not. luse_vc) THEN
-            B_R(i,j,k)   =   B_R(i+1,j  ,k  ) + B_R(i-1,j  ,k  ) &
-                           + B_R(i  ,j  ,k+1) + B_R(i  ,j  ,k-1)
-            B_PHI(i,j,k) =   B_PHI(i+1,j  ,k  ) + B_PHI(i-1,j  ,k  ) &
-                           + B_PHI(i  ,j  ,k+1) + B_PHI(i  ,j  ,k-1)
-            B_Z(i,j,k)   =   B_Z(i+1,j  ,k  ) + B_Z(i-1,j  ,k  ) &
-                           + B_Z(i  ,j  ,k+1) + B_Z(i  ,j  ,k-1)
+         ELSE IF (ier == -1) THEN
+            ! PRINT *,">>>> USING APPROXIMATE SOLUTION >>>>>",i,j,k,sflx,uflx,br,bphi,bz,ier
+            ! ! Save Grid data
+            ! S_ARR(i,j,k) = MAX(sflx,0.0)
+            ! IF (uflx<0)  uflx = uflx+pi2
+            ! U_ARR(i,j,k) = uflx
+            ! ! Handle equilibrium data
+            ! IF (sflx <=1.0) THEN ! Inside equilibrium
+            !    B_R(i,j,k)   = br
+            !    B_PHI(i,j,k) = bphi
+            !    B_Z(i,j,k)   = bz
+            ! END IF
+            ! We average because using the returned fields introduces spikes.
+            S_ARR(i,j,k) =   (S_ARR(i+1,j  ,k  ) + S_ARR(i-1,j  ,k  ) &
+                            + S_ARR(i  ,j  ,k+1) + S_ARR(i  ,j  ,k-1))*0.25
+            U_ARR(i,j,k) =   (U_ARR(i+1,j  ,k  ) + U_ARR(i-1,j  ,k  ) &
+                           + U_ARR(i  ,j  ,k+1) + U_ARR(i  ,j  ,k-1))*0.25
+            B_R(i,j,k)   =   (B_R(i+1,j  ,k  ) + B_R(i-1,j  ,k  ) &
+                           + B_R(i  ,j  ,k+1) + B_R(i  ,j  ,k-1))*0.25
+            B_PHI(i,j,k) =   (B_PHI(i+1,j  ,k  ) + B_PHI(i-1,j  ,k  ) &
+                           + B_PHI(i  ,j  ,k+1) + B_PHI(i  ,j  ,k-1))*0.25
+            B_Z(i,j,k)   =   (B_Z(i+1,j  ,k  ) + B_Z(i-1,j  ,k  ) &
+                           + B_Z(i  ,j  ,k+1) + B_Z(i  ,j  ,k-1))*0.25
          END IF
          IF (MOD(s,nr) == 0) THEN
             IF (lverb) THEN

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -186,7 +186,7 @@
          i = 120
          j = 180
          lverb_wall=.false.
-         IF (lverb) WRITE(6,'(A)')        '   CREATING WALL FROM HARMONICS'
+         IF (lverb) WRITE(6,'(A)')        '   GENERATING WALL FROM BOUNDARY HARMONICS'
          IF (lasym) THEN
             CALL wall_load_mn(DBLE(rmnc(1:mnmax,k)),DBLE(zmns(1:mnmax,k)), &
                DBLE(xm),-DBLE(xn),mnmax,i,j,lverb_wall,MPI_COMM_LOCAL, &
@@ -298,7 +298,6 @@
       
       IF (lverb) THEN
          IF (luse_vc) CALL virtual_casing_info(6)
-         WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Plasma Field Calculation [',0,']%'
          CALL FLUSH(6)
       END IF
       
@@ -310,26 +309,43 @@
       uflx = 0.0
 
       IF (mylocalid == mylocalmaster) THEN
+         IF (.not. luse_vc) THEN
+            B_R = 0.0; B_PHI=1.0; B_Z=0.0
+         END IF
          TE = 0; NE = 0; TI=0; S_ARR=scaleup*scaleup; U_ARR=0; POT_ARR=0; ZEFF_ARR = 1; OMEG_ARR=0;
       END IF
+
 #if defined(MPI_OPT)
       CALL MPI_BARRIER(MPI_COMM_LOCAL,ierr_mpi)
 #endif
+
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      !! Perform the lookup of VMEC B-field and S,U grid data
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      IF (lverb) THEN
+         WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Plasma Field Lookup [',0,']%'
+      END IF
+      CALL FLUSH(6)
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
          j = MOD(s-1,nr*nphi)
          j = FLOOR(REAL(j) / REAL(nr))+1
          k = CEILING(REAL(s) / REAL(nr*nphi))
-         sflx = 0.0
-         ! The GetBcyl Routine returns -3 if cyl2flx thinks s>1
-         ! however, if cyl2flx fails to converge then s may be
-         ! greater than 1 but cyl2flux will not throw the -3 code.
-         ! In this case GetBcyl returns br,bphi,bz = 0.  So
-         ! bphi == 0 or ier ==-3 indicate that a point is
-         ! outside the VMEC domain.
+         if (sflx > 1.0) sflx = 0.9
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                       br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
-         IF (ier == 0 .and. bphi /= 0) THEN ! We have field data
+         ! GetBcyl will return ier = 0,-1,or-3
+         !   0 : Success
+         !  -1 : Success but at reduced tolerance
+         !  -3 : Failure (no B returned)
+         ! Try again
+         IF (ier .eq. -1) THEN
+            sflx = MIN(sflx - 0.01,0.99)
+            CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
+                        br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
+         END IF
+         ! If sucessfull save the data
+         IF (ier .eq. 0) THEN
             ! Save Grid data
             S_ARR(i,j,k) = MAX(sflx,0.0)
             IF (uflx<0)  uflx = uflx+pi2
@@ -343,31 +359,135 @@
                B_R(i,j,k)   = br
                B_PHI(i,j,k) = bphi
                B_Z(i,j,k)   = bz
-               sflx = 1.5 ! Assume s=1 for lplasma_only
+               !sflx = 1.5 ! Assume s=1 for lplasma_only
             END IF
-            IF (sflx <= s_max) THEN
-               IF (nte > 0) CALL EZspline_interp(TE_spl_s,MIN(sflx,s_max_te),TE(i,j,k),ier)
-               IF (nne > 0) CALL EZspline_interp(NE_spl_s,MIN(sflx,s_max_ne),NE(i,j,k),ier)
-               IF (nti > 0) CALL EZspline_interp(TI_spl_s,MIN(sflx,s_max_ti),TI(i,j,k),ier)
-               IF (npot > 0) CALL EZspline_interp(POT_spl_s,MIN(sflx,s_max_pot),POT_ARR(i,j,k),ier)
-               IF (nomeg > 0) CALL EZspline_interp(OMEG_spl_s,MIN(sflx,s_max_omeg),OMEG_ARR(i,j,k),ier)
-               IF (nzeff > 0) THEN
-                  CALL EZspline_interp(ZEFF_spl_s,MIN(sflx,s_max_zeff),ZEFF_ARR(i,j,k),ier)
-                  DO u=1, NION
-                     CALL EZspline_interp(NI_spl_s(u),MIN(sflx,s_max_zeff),NI(u,i,j,k),ier)
-                  END DO
-               END IF
-            ELSE
-               br = 1
-               IF (npot > 0) CALL EZspline_interp(POT_spl_s,br,POT_ARR(i,j,k),ier)
+         END IF
+         lsmooth(s) = (ier < 0) .and. (i > 1) .and. (i < nr) .and. (k > 1) .and. (k < nz)
+         IF (MOD(s,nr) == 0) THEN
+            IF (lverb) THEN
+               CALL backspace_out(6,6)
+               WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
+               CALL FLUSH(6)
+            END IF
+         END IF
+      END DO
+
+#if defined(MPI_OPT)
+      CALL MPI_BARRIER(MPI_COMM_LOCAL,ierr_mpi)
+#endif
+
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      !! Perform the 2nd Pass only inside domain
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      IF (lverb) THEN
+         WRITE(6,*)
+         WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Plasma Field 2nd Pass [',0,']%'
+      END IF
+      CALL FLUSH(6)
+      DO s = mystart, myend
+         i = MOD(s-1,nr)+1
+         j = MOD(s-1,nr*nphi)
+         j = FLOOR(REAL(j) / REAL(nr))+1
+         k = CEILING(REAL(s) / REAL(nr*nphi))
+         if (.not. lsmooth(s)) CYCLE
+         sflx =   S_ARR(i+1,j  ,k  ) + S_ARR(i-1,j  ,k  ) &
+                + S_ARR(i  ,j  ,k+1) + S_ARR(i  ,j  ,k-1)
+         uflx =   U_ARR(i+1,j  ,k  ) + U_ARR(i-1,j  ,k  ) &
+                + U_ARR(i  ,j  ,k+1) + U_ARR(i  ,j  ,k-1)
+         sflx = MIN(sflx*0.25,0.99)
+         uflx = uflx*0.25
+         CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
+                      br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
+         ! GetBcyl will return ier = 0,-1,or-3
+         !   0 : Success
+         !  -1 : Success but at reduced tolerance
+         !  -3 : Failure (no B returned)
+         IF (ier .eq. 0) THEN
+            ! Save Grid data
+            S_ARR(i,j,k) = MAX(sflx,0.0)
+            IF (uflx<0)  uflx = uflx+pi2
+            U_ARR(i,j,k) = uflx
+            ! Handle equilibrium data
+            IF (sflx <=1.0) THEN ! Inside equilibrium
+               B_R(i,j,k)   = br
+               B_PHI(i,j,k) = bphi
+               B_Z(i,j,k)   = bz
             END IF
          ELSE IF (.not. luse_vc) THEN
-            B_R(i,j,k)   = 0
-            B_PHI(i,j,k) = 1
-            B_Z(i,j,k)   = 0
+            B_R(i,j,k)   =   B_R(i+1,j  ,k  ) + B_R(i-1,j  ,k  ) &
+                           + B_R(i  ,j  ,k+1) + B_R(i  ,j  ,k-1)
+            B_PHI(i,j,k) =   B_PHI(i+1,j  ,k  ) + B_PHI(i-1,j  ,k  ) &
+                           + B_PHI(i  ,j  ,k+1) + B_PHI(i  ,j  ,k-1)
+            B_Z(i,j,k)   =   B_Z(i+1,j  ,k  ) + B_Z(i-1,j  ,k  ) &
+                           + B_Z(i  ,j  ,k+1) + B_Z(i  ,j  ,k-1)
          END IF
-         ! Virtual Casing
-         IF (luse_vc .and. sflx > 1) THEN
+         IF (MOD(s,nr) == 0) THEN
+            IF (lverb) THEN
+               CALL backspace_out(6,6)
+               WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
+               CALL FLUSH(6)
+            END IF
+         END IF
+      END DO
+      
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      !! Evaluate the profile quantities on the background grid
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      IF (lverb) THEN
+         WRITE(6,*)
+         WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Profile Lookup [',0,']%'
+      END IF
+      CALL FLUSH(6)
+      DO s = mystart, myend
+         i = MOD(s-1,nr)+1
+         j = MOD(s-1,nr*nphi)
+         j = FLOOR(REAL(j) / REAL(nr))+1
+         k = CEILING(REAL(s) / REAL(nr*nphi))
+         sflx = S_ARR(i,j,k)
+         sflx = MAX(sflx,0.0)
+         ! Do the potential everwhere
+         IF (npot > 0) CALL EZspline_interp(POT_spl_s,MIN(sflx,s_max_pot),POT_ARR(i,j,k),ier)
+         IF (sflx <= s_max) THEN
+            IF (nte > 0) CALL EZspline_interp(TE_spl_s,MIN(sflx,s_max_te),TE(i,j,k),ier)
+            IF (nne > 0) CALL EZspline_interp(NE_spl_s,MIN(sflx,s_max_ne),NE(i,j,k),ier)
+            IF (nti > 0) CALL EZspline_interp(TI_spl_s,MIN(sflx,s_max_ti),TI(i,j,k),ier)
+            IF (nomeg > 0) CALL EZspline_interp(OMEG_spl_s,MIN(sflx,s_max_omeg),OMEG_ARR(i,j,k),ier)
+            IF (nzeff > 0) THEN
+               CALL EZspline_interp(ZEFF_spl_s,MIN(sflx,s_max_zeff),ZEFF_ARR(i,j,k),ier)
+               DO u=1, NION
+                  CALL EZspline_interp(NI_spl_s(u),MIN(sflx,s_max_zeff),NI(u,i,j,k),ier)
+               END DO
+            END IF
+         END IF
+         IF (MOD(s,nr) == 0) THEN
+            IF (lverb) THEN
+               CALL backspace_out(6,6)
+               WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
+               CALL FLUSH(6)
+            END IF
+         END IF
+      END DO
+
+      ! Fix ZEFF
+      IF (mylocalid == mylocalmaster) WHERE(ZEFF_ARR < 1) ZEFF_ARR = 1
+
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      !! Virtual casing if requested.
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      IF (luse_vc) THEN
+         IF (lverb) THEN
+            WRITE(6,*)
+            WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Virtual Casing [',0,']%'
+         END IF
+         CALL FLUSH(6)
+         DO s = mystart, myend
+            i = MOD(s-1,nr)+1
+            j = MOD(s-1,nr*nphi)
+            j = FLOOR(REAL(j) / REAL(nr))+1
+            k = CEILING(REAL(s) / REAL(nr*nphi))
+            sflx = S_ARR(i,j,k)
+            sflx = MAX(sflx,0.0)
+            IF (sflx <= 1.0) CYCLE
             xaxis_vc = raxis_g(i)*cos(phiaxis(j))
             yaxis_vc = raxis_g(i)*sin(phiaxis(j))
             zaxis_vc = zaxis_g(k)
@@ -384,22 +504,15 @@
             ELSE IF (ier > 1) THEN ! Only report real errors not failure to find tolerance errors
                WRITE(6,*) myworkid,mylocalid,i,j,k,ier
             END IF
-         !ELSE
-            ! This is an error code check
-            !PRINT *,'ERROR in GetBcyl Detected'
-            !PRINT *,'R,PHI,Z',raxis_g(i),phiaxis(j),zaxis_g(k)
-            !print *,'br,bphi,bz,myworkid',br,bphi,bz,mylocalid
-            !CALL FLUSH(6)
-            !stop 'ERROR in GetBcyl'
-         END IF
-         IF (MOD(s,nr) == 0) THEN
-            IF (lverb) THEN
-               CALL backspace_out(6,6)
-               WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
-               CALL FLUSH(6)
+            IF (MOD(s,nr) == 0) THEN
+               IF (lverb) THEN
+                  CALL backspace_out(6,6)
+                  WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
+                  CALL FLUSH(6)
+               END IF
             END IF
-         END IF
-      END DO
+         END DO
+      END IF
       
 #if defined(MPI_OPT)
       CALL MPI_BARRIER(MPI_COMM_LOCAL,ierr_mpi)
@@ -414,110 +527,128 @@
          ALLOCATE(Gfactor(ns_prof1))
          DO s = 1, ns_prof1
             sflx = MIN(REAL(s-0.5)/h1_prof,1.0)
-            !sflx = REAL(s-1 + 0.5)/ns_prof1 ! Half grid rho
             sflx = sflx*sflx
             CALL EZspline_interp(ZEFF_spl_s,sflx,uflx,ier)
-            ! sflx=s uflx=Zeff
             CALL vmec_ohkawa(sflx,uflx,Gfactor(s)) ! (1-l31)/Zeff
          END DO
       ENDIF
 
-      ! Expand the VMEC geometric grid for s>1
-      ALLOCATE(rmnc_temp(mnmax,ns*scaleup),zmns_temp(mnmax,ns*scaleup))
-      rmnc_temp(:,1:ns) = rmnc(:,1:ns)
-      zmns_temp(:,1:ns) = zmns(:,1:ns)
-      nv = ntor + 1
-      DO s = 2,ns ! Remove magnetic axis from geometric axis
-         rmnc_temp(1:nv,s) = rmnc_temp(1:nv,s) - rmnc(1:nv,1)
-         zmns_temp(1:nv,s) = zmns_temp(1:nv,s) - zmns(1:nv,1)
-      END DO
-      DO s = ns+1,ns*scaleup
-         sflx = REAL(s)/REAL(ns)
-         uflx = SQRT(REAL(s)/REAL(ns*scaleup))
-         WHERE (MOD(NINT(xm),2)==1)
-            rmnc_temp(:,s) = rmnc_temp(:,ns)*sflx**1.5
-            zmns_temp(:,s) = zmns_temp(:,ns)*sflx**1.5
-         ELSEWHERE
-            rmnc_temp(:,s) = rmnc_temp(:,ns)*sflx
-            zmns_temp(:,s) = zmns_temp(:,ns)*sflx
-         END WHERE
-      END DO
-      DO s = 2,ns*scaleup ! Add magnetic axis from geometric axis
-         rmnc_temp(1:nv,s) = rmnc_temp(1:nv,s) + rmnc(1:nv,1)
-         zmns_temp(1:nv,s) = zmns_temp(1:nv,s) + zmns(1:nv,1)
-      END DO
-      IF (lasym) THEN
-         ALLOCATE(rmns_temp(mnmax,ns*scaleup),zmnc_temp(mnmax,ns*scaleup))
-         rmns_temp(:,1:ns) = rmns(:,1:ns)
-         zmnc_temp(:,1:ns) = zmnc(:,1:ns)
-         DO s = 2,ns ! Remove magnetic axis from geometric axis
-            rmns_temp(1:nv,s) = rmns_temp(1:nv,s) - rmns(1:nv,1)
-            zmnc_temp(1:nv,s) = zmnc_temp(1:nv,s) - zmnc(1:nv,1)
-         END DO
-         DO s = ns+1,ns*scaleup
-            sflx = REAL(s)/REAL(ns)
-            uflx = SQRT(REAL(s)/REAL(ns*scaleup))
-            WHERE (MOD(NINT(xm),2)==1)
-               rmns_temp(:,s) = rmns_temp(:,ns)*sflx**1.5
-               zmnc_temp(:,s) = zmnc_temp(:,ns)*sflx**1.5
-            ELSEWHERE
-               rmns_temp(:,s) = rmns_temp(:,ns)*sflx
-               zmnc_temp(:,s) = zmnc_temp(:,ns)*sflx
-            END WHERE
-         END DO
-         DO s = 2,ns*scaleup ! Add magnetic axis from geometric axis
-            rmns_temp(1:nv,s) = rmns_temp(1:nv,s) + rmns(1:nv,1)
-            zmnc_temp(1:nv,s) = zmnc_temp(1:nv,s) + zmnc(1:nv,1)
-         END DO
-      END IF
-      DEALLOCATE(iotaf,phipf,rmnc,zmns,lmns,bsupumnc,bsupvmnc)
-      ns = ns*scaleup
-      ALLOCATE(iotaf(1:ns),phipf(1:ns))
-      ALLOCATE(rmnc(1:mnmax,1:ns),zmns(1:mnmax,1:ns), &
-         lmns(1:mnmax,1:ns), &
-         bsupumnc(1:mnmax_nyq,1:ns),bsupvmnc(1:mnmax_nyq,1:ns))
-      rmnc=rmnc_temp; zmns=zmns_temp; bsupumnc=0; bsupvmnc=0; lmns=0
-      DEALLOCATE(rmnc_temp,zmns_temp,rzl_local)
-      IF (lasym) THEN
-         DEALLOCATE(rmns,zmnc,lmnc,bsupumns,bsupvmns)
-         ALLOCATE(rmns(1:mnmax,1:ns),zmnc(1:mnmax,1:ns), &
-            lmnc(1:mnmax,1:ns), &
-            bsupumns(1:mnmax_nyq,1:ns),bsupvmns(1:mnmax_nyq,1:ns))
-         rmns=rmns_temp; zmnc=zmnc_temp; bsupumns=0; bsupvmns=0; lmnc=0
-         DEALLOCATE(rmns_temp,zmnc_temp)
-      END IF
-      DO s = mystart, myend ! Now fill in grid
-         i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
-         sflx = 0.0
-         IF (S_ARR(i,j,k)<=1.0) CYCLE
-         CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
-                      br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
-         ! note that s in now rho since we grid different in the outer region
-         IF (ier .ne. 0) THEN
-            lsmooth(s) = .true.
-            CYCLE
-         END IF
-         sflx = sflx*sflx*scaleup*scaleup
-         S_ARR(i,j,k) = MAX(sflx,1.01)
-         IF (uflx<0)  uflx = uflx+pi2
-         U_ARR(i,j,k) = uflx
-      END DO
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      !!  This doesn't really do anything more than what
+      !!  is done above so for now we turn it off.
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      ! ! Expand the VMEC geometric grid for s>1
+      ! ALLOCATE(rmnc_temp(mnmax,ns*scaleup),zmns_temp(mnmax,ns*scaleup))
+      ! rmnc_temp(:,1:ns) = rmnc(:,1:ns)
+      ! zmns_temp(:,1:ns) = zmns(:,1:ns)
+      ! nv = ntor + 1
+      ! DO s = 2,ns ! Remove magnetic axis from geometric axis
+      !    rmnc_temp(1:nv,s) = rmnc_temp(1:nv,s) - rmnc(1:nv,1)
+      !    zmns_temp(1:nv,s) = zmns_temp(1:nv,s) - zmns(1:nv,1)
+      ! END DO
+      ! DO s = ns+1,ns*scaleup
+      !    sflx = REAL(s)/REAL(ns)
+      !    uflx = SQRT(REAL(s)/REAL(ns*scaleup))
+      !    WHERE (MOD(NINT(xm),2)==1)
+      !       rmnc_temp(:,s) = rmnc_temp(:,ns)*sflx**1.5
+      !       zmns_temp(:,s) = zmns_temp(:,ns)*sflx**1.5
+      !    ELSEWHERE
+      !       rmnc_temp(:,s) = rmnc_temp(:,ns)*sflx
+      !       zmns_temp(:,s) = zmns_temp(:,ns)*sflx
+      !    END WHERE
+      ! END DO
+      ! DO s = 2,ns*scaleup ! Add magnetic axis from geometric axis
+      !    rmnc_temp(1:nv,s) = rmnc_temp(1:nv,s) + rmnc(1:nv,1)
+      !    zmns_temp(1:nv,s) = zmns_temp(1:nv,s) + zmns(1:nv,1)
+      ! END DO
+      ! IF (lasym) THEN
+      !    ALLOCATE(rmns_temp(mnmax,ns*scaleup),zmnc_temp(mnmax,ns*scaleup))
+      !    rmns_temp(:,1:ns) = rmns(:,1:ns)
+      !    zmnc_temp(:,1:ns) = zmnc(:,1:ns)
+      !    DO s = 2,ns ! Remove magnetic axis from geometric axis
+      !       rmns_temp(1:nv,s) = rmns_temp(1:nv,s) - rmns(1:nv,1)
+      !       zmnc_temp(1:nv,s) = zmnc_temp(1:nv,s) - zmnc(1:nv,1)
+      !    END DO
+      !    DO s = ns+1,ns*scaleup
+      !       sflx = REAL(s)/REAL(ns)
+      !       uflx = SQRT(REAL(s)/REAL(ns*scaleup))
+      !       WHERE (MOD(NINT(xm),2)==1)
+      !          rmns_temp(:,s) = rmns_temp(:,ns)*sflx**1.5
+      !          zmnc_temp(:,s) = zmnc_temp(:,ns)*sflx**1.5
+      !       ELSEWHERE
+      !          rmns_temp(:,s) = rmns_temp(:,ns)*sflx
+      !          zmnc_temp(:,s) = zmnc_temp(:,ns)*sflx
+      !       END WHERE
+      !    END DO
+      !    DO s = 2,ns*scaleup ! Add magnetic axis from geometric axis
+      !       rmns_temp(1:nv,s) = rmns_temp(1:nv,s) + rmns(1:nv,1)
+      !       zmnc_temp(1:nv,s) = zmnc_temp(1:nv,s) + zmnc(1:nv,1)
+      !    END DO
+      ! END IF
+      ! DEALLOCATE(iotaf,phipf,rmnc,zmns,lmns,bsupumnc,bsupvmnc)
+      ! ns = ns*scaleup
+      ! ALLOCATE(iotaf(1:ns),phipf(1:ns))
+      ! ALLOCATE(rmnc(1:mnmax,1:ns),zmns(1:mnmax,1:ns), &
+      !    lmns(1:mnmax,1:ns), &
+      !    bsupumnc(1:mnmax_nyq,1:ns),bsupvmnc(1:mnmax_nyq,1:ns))
+      ! rmnc=rmnc_temp; zmns=zmns_temp; bsupumnc=0; bsupvmnc=0; lmns=0
+      ! DEALLOCATE(rmnc_temp,zmns_temp,rzl_local)
+      ! IF (lasym) THEN
+      !    DEALLOCATE(rmns,zmnc,lmnc,bsupumns,bsupvmns)
+      !    ALLOCATE(rmns(1:mnmax,1:ns),zmnc(1:mnmax,1:ns), &
+      !       lmnc(1:mnmax,1:ns), &
+      !       bsupumns(1:mnmax_nyq,1:ns),bsupvmns(1:mnmax_nyq,1:ns))
+      !    rmns=rmns_temp; zmnc=zmnc_temp; bsupumns=0; bsupvmns=0; lmnc=0
+      !    DEALLOCATE(rmns_temp,zmnc_temp)
+      ! END IF
+      ! IF (lverb) THEN
+      !    WRITE(6,*)
+      !    WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Expanding S-Grid [',0,']%'
+      ! END IF
+      ! DO s = mystart, myend ! Now fill in grid
+      !    i = MOD(s-1,nr)+1
+      !    j = MOD(s-1,nr*nphi)
+      !    j = FLOOR(REAL(j) / REAL(nr))+1
+      !    k = CEILING(REAL(s) / REAL(nr*nphi))
+      !    lsmooth(s) = .FALSE.
+      !    if (sflx > 1.0) sflx = 0.9
+      !    IF (S_ARR(i,j,k)<=1.0) CYCLE
+      !    CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
+      !                 br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
+      !    ! note that s in now rho since we grid different in the outer region
+      !    IF ((ier < 0) .and. (i > 1) .and. (i < nr) .and. (k > 1) .and. (k < nz)) THEN
+      !       lsmooth(s) = .true.
+      !       CYCLE
+      !    END IF
+      !    sflx = sflx*sflx*scaleup*scaleup
+      !    S_ARR(i,j,k) = MAX(sflx,1.01)
+      !    !IF (uflx<0)  uflx = uflx+pi2
+      !    U_ARR(i,j,k) = uflx
+      !    IF (MOD(s,nr) == 0) THEN
+      !       IF (lverb) THEN
+      !          CALL backspace_out(6,6)
+      !          WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
+      !          CALL FLUSH(6)
+      !       END IF
+      !    END IF
+      ! END DO
 
-      ! Smooth
-      DO s = mystart, myend ! Now fill in grid
-         IF (.not.lsmooth(s)) CYCLE
-         i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
-         IF (i==1 .or. i==nr) CYCLE
-         IF (k==1 .or. k==nz) CYCLE
-         S_ARR(i,j,k) = (MAX(S_ARR(i-1,j,k),S_ARR(i+1,j,k)) &
-                  + MAX(S_ARR(i,j,k-1),S_ARR(i,j,k+1)))*0.5 
-      END DO
+      ! ! Smooth
+      ! IF (lverb) THEN
+      !    WRITE(6,*)
+      !    WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Smoothing S-Grid [',0,']%'
+      ! END IF
+      ! DO s = mystart, myend ! Now fill in grid
+      !    IF (.not.lsmooth(s)) CYCLE
+      !    i = MOD(s-1,nr)+1
+      !    j = MOD(s-1,nr*nphi)
+      !    j = FLOOR(REAL(j) / REAL(nr))+1
+      !    k = CEILING(REAL(s) / REAL(nr*nphi))
+      !    !IF (i==1 .or. i==nr) CYCLE
+      !    !IF (k==1 .or. k==nz) CYCLE
+      !    S_ARR(i,j,k) = (MAX(S_ARR(i-1,j,k),S_ARR(i+1,j,k)) &
+      !             + MAX(S_ARR(i,j,k-1),S_ARR(i,j,k+1)))*0.5 
+      ! END DO
 
       ! Deallocations
       IF (myworkid == master) THEN
@@ -533,17 +664,14 @@
       DEALLOCATE(lsmooth)
       
       IF (lverb) THEN
-         CALL backspace_out(6,36)
-         CALL FLUSH(6)
-         WRITE(6,'(36X)',ADVANCE='no')
-         CALL FLUSH(6)
-         CALL backspace_out(6,36)
+         !CALL backspace_out(6,36)
+         !CALL FLUSH(6)
+         !WRITE(6,'(36X)',ADVANCE='no')
+         !CALL FLUSH(6)
+         !CALL backspace_out(6,36)
          WRITE(6,*)
          CALL FLUSH(6)
       END IF    
-
-      ! Fix ZEFF
-      IF (mylocalid == mylocalmaster) WHERE(ZEFF_ARR < 1) ZEFF_ARR = 1
 
 #if defined(MPI_OPT)
       CALL MPI_BARRIER(MPI_COMM_LOCAL,ierr_mpi)

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -52,8 +52,6 @@
                            bumnc_temp(:,:),bvmnc_temp(:,:),&
                            rmns_temp(:,:),zmnc_temp(:,:),&
                            bumns_temp(:,:),bvmns_temp(:,:)
-      INTEGER, PARAMETER :: scaleup=2
-      LOGICAL, ALLOCATABLE, DIMENSION(:) :: lsmooth
 !-----------------------------------------------------------------------
 !     Begin Subroutine
 !-----------------------------------------------------------------------
@@ -303,16 +301,13 @@
       
       ! Break up the Work
       CALL MPI_CALC_MYRANGE(MPI_COMM_LOCAL, 1, nr*nphi*nz, mystart, myend)
-      ALLOCATE(lsmooth(mystart:myend))
-      lsmooth = .false.
-      
-      uflx = 0.0
 
+      ! Initialize the grids
       IF (mylocalid == mylocalmaster) THEN
          IF (.not. luse_vc) THEN
             B_R = 0.0; B_PHI=1.0; B_Z=0.0
          END IF
-         TE = 0; NE = 0; TI=0; S_ARR=scaleup*scaleup; U_ARR=0; POT_ARR=0; ZEFF_ARR = 1; OMEG_ARR=0;
+         TE = 0; NE = 0; TI=0; S_ARR=4.0; U_ARR=0; POT_ARR=0; ZEFF_ARR = 1; OMEG_ARR=0;
       END IF
 
 #if defined(MPI_OPT)
@@ -334,17 +329,11 @@
          sflx = MAX(0.001,MIN(0.999,sflx))
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                       br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
+         !PRINT *,i,j,k,raxis_g(i),phiaxis(j),zaxis_g(k), br, bphi, bz, sflx,uflx,ier
          ! GetBcyl will return ier = 0,-1,or-3
          !   0 : Success
          !  -1 : Success but at reduced tolerance
          !  -3 : Failure (no B returned)
-         ! Try again
-         IF (ier .eq. -1) THEN
-            sflx = MIN(sflx - 0.01,0.99)
-            uflx = uflx-0.1
-            CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
-                        br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
-         END IF
          ! If sucessfull save the data
          IF (ier .eq. 0) THEN
             ! Save Grid data
@@ -356,20 +345,21 @@
                B_R(i,j,k)   = br
                B_PHI(i,j,k) = bphi
                B_Z(i,j,k)   = bz
-            ELSE IF (.not. luse_vc) THEN  ! Overwrite data outside
+            ELSE IF (.not. luse_vc) THEN  ! Overwrite data outside if not VC
                B_R(i,j,k)   = br
                B_PHI(i,j,k) = bphi
                B_Z(i,j,k)   = bz
             END IF
+         ELSE IF (ier == -1) THEN
+            S_ARR(i,j,k) = -1
          END IF
-         lsmooth(s) = (ier < 0) .and. (i > 1) .and. (i < nr) .and. (k > 1) .and. (k < nz)
          IF (MOD(s,nr) == 0) THEN
             IF (lverb) THEN
                CALL backspace_out(6,6)
                WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
-               CALL FLUSH(6)
             END IF
          END IF
+         CALL FLUSH(6)
       END DO
 
 #if defined(MPI_OPT)
@@ -389,63 +379,58 @@
          j = MOD(s-1,nr*nphi)
          j = FLOOR(REAL(j) / REAL(nr))+1
          k = CEILING(REAL(s) / REAL(nr*nphi))
-         if (.not. lsmooth(s)) CYCLE
-         ! Try a really good guess for S and U
-         sflx =   S_ARR(i+1,j  ,k  ) + S_ARR(i-1,j  ,k  ) &
-                + S_ARR(i  ,j  ,k+1) + S_ARR(i  ,j  ,k-1)
-         uflx =   U_ARR(i+1,j  ,k  ) + U_ARR(i-1,j  ,k  ) &
-                + U_ARR(i  ,j  ,k+1) + U_ARR(i  ,j  ,k-1)
-         sflx = MIN(sflx*0.25,0.99)
-         uflx = uflx*0.25
-         sflx = MAX(0.001,MIN(0.999,sflx))
-         CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
-                      br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
-         ! GetBcyl will return ier = 0,-1,or-3
-         !   0 : Success
-         !  -1 : Success but at reduced tolerance
-         !  -3 : Failure (no B returned)
-         IF (ier .eq. 0) THEN
-            ! Save Grid data
-            S_ARR(i,j,k) = MAX(sflx,0.0)
-            IF (uflx<0)  uflx = uflx+pi2
-            U_ARR(i,j,k) = uflx
-            ! Handle equilibrium data
-            IF (sflx <=1.0) THEN ! Inside equilibrium
-               B_R(i,j,k)   = br
-               B_PHI(i,j,k) = bphi
-               B_Z(i,j,k)   = bz
-            END IF
-         ELSE IF (ier == -1) THEN
-            ! PRINT *,">>>> USING APPROXIMATE SOLUTION >>>>>",i,j,k,sflx,uflx,br,bphi,bz,ier
-            ! ! Save Grid data
-            ! S_ARR(i,j,k) = MAX(sflx,0.0)
-            ! IF (uflx<0)  uflx = uflx+pi2
-            ! U_ARR(i,j,k) = uflx
-            ! ! Handle equilibrium data
-            ! IF (sflx <=1.0) THEN ! Inside equilibrium
-            !    B_R(i,j,k)   = br
-            !    B_PHI(i,j,k) = bphi
-            !    B_Z(i,j,k)   = bz
-            ! END IF
-            ! We average because using the returned fields introduces spikes.
-            S_ARR(i,j,k) =   (S_ARR(i+1,j  ,k  ) + S_ARR(i-1,j  ,k  ) &
-                            + S_ARR(i  ,j  ,k+1) + S_ARR(i  ,j  ,k-1))*0.25
-            U_ARR(i,j,k) =   (U_ARR(i+1,j  ,k  ) + U_ARR(i-1,j  ,k  ) &
-                           + U_ARR(i  ,j  ,k+1) + U_ARR(i  ,j  ,k-1))*0.25
-            B_R(i,j,k)   =   (B_R(i+1,j  ,k  ) + B_R(i-1,j  ,k  ) &
-                           + B_R(i  ,j  ,k+1) + B_R(i  ,j  ,k-1))*0.25
-            B_PHI(i,j,k) =   (B_PHI(i+1,j  ,k  ) + B_PHI(i-1,j  ,k  ) &
-                           + B_PHI(i  ,j  ,k+1) + B_PHI(i  ,j  ,k-1))*0.25
-            B_Z(i,j,k)   =   (B_Z(i+1,j  ,k  ) + B_Z(i-1,j  ,k  ) &
-                           + B_Z(i  ,j  ,k+1) + B_Z(i  ,j  ,k-1))*0.25
-         END IF
+         ! First update progress
          IF (MOD(s,nr) == 0) THEN
             IF (lverb) THEN
                CALL backspace_out(6,6)
                WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
-               CALL FLUSH(6)
             END IF
          END IF
+         CALL FLUSH(6)
+         ! Don't do edge points
+         IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
+         ! Now do the problematic parts
+         IF (S_ARR(i,j,k) < 0.0) THEN
+            sflx = 0; uflx = 0; br = 0; bphi = 0; bz = 0; u = 0
+            IF (S_ARR(i+1,j  ,k  )>=0.0) THEN
+               sflx = sflx + S_ARR(i+1,j  ,k  )
+               uflx = uflx + U_ARR(i+1,j  ,k  )
+               br   = br   +   B_R(i+1,j  ,k  )
+               bphi = bphi + B_PHI(i+1,j  ,k  )
+               bz   = bz   +   B_Z(i+1,j  ,k  )
+               u = u + 1
+            ENDIF
+            IF (S_ARR(i-1,j  ,k  )>=0.0) THEN
+               sflx = sflx + S_ARR(i-1,j  ,k  )
+               uflx = uflx + U_ARR(i-1,j  ,k  )
+               br   = br   +   B_R(i-1,j  ,k  )
+               bphi = bphi + B_PHI(i-1,j  ,k  )
+               bz   = bz   +   B_Z(i-1,j  ,k  )
+               u = u + 1
+            ENDIF
+            IF (S_ARR(i  ,j  ,k+1)>=0.0) THEN
+               sflx = sflx + S_ARR(i  ,j  ,k+1)
+               uflx = uflx + U_ARR(i  ,j  ,k+1)
+               br   = br   +   B_R(i  ,j  ,k+1)
+               bphi = bphi + B_PHI(i  ,j  ,k+1)
+               bz   = bz   +   B_Z(i  ,j  ,k+1)
+               u = u + 1
+            ENDIF
+            IF (S_ARR(i  ,j  ,k-1)>=0.0) THEN
+               sflx = sflx + S_ARR(i  ,j  ,k-1)
+               uflx = uflx + U_ARR(i  ,j  ,k-1)
+               br   = br   +   B_R(i  ,j  ,k-1)
+               bphi = bphi + B_PHI(i  ,j  ,k-1)
+               bz   = bz   +   B_Z(i  ,j  ,k-1)
+               u = u + 1
+            ENDIF
+            S_ARR(i,j,k) = sflx/DBLE(u)
+            U_ARR(i,j,k) = uflx/DBLE(u)
+            B_R(i,j,k)   =   br/DBLE(u)
+            B_PHI(i,j,k) = bphi/DBLE(u)
+            B_Z(i,j,k)   =   bz/DBLE(u)
+         ENDIF
+         CALL FLUSH(6)
       END DO
       
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -481,9 +466,9 @@
             IF (lverb) THEN
                CALL backspace_out(6,6)
                WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
-               CALL FLUSH(6)
             END IF
          END IF
+         CALL FLUSH(6)
       END DO
 
       ! Fix ZEFF
@@ -551,123 +536,6 @@
          END DO
       ENDIF
 
-      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      !!  This doesn't really do anything more than what
-      !!  is done above so for now we turn it off.
-      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      ! ! Expand the VMEC geometric grid for s>1
-      ! ALLOCATE(rmnc_temp(mnmax,ns*scaleup),zmns_temp(mnmax,ns*scaleup))
-      ! rmnc_temp(:,1:ns) = rmnc(:,1:ns)
-      ! zmns_temp(:,1:ns) = zmns(:,1:ns)
-      ! nv = ntor + 1
-      ! DO s = 2,ns ! Remove magnetic axis from geometric axis
-      !    rmnc_temp(1:nv,s) = rmnc_temp(1:nv,s) - rmnc(1:nv,1)
-      !    zmns_temp(1:nv,s) = zmns_temp(1:nv,s) - zmns(1:nv,1)
-      ! END DO
-      ! DO s = ns+1,ns*scaleup
-      !    sflx = REAL(s)/REAL(ns)
-      !    uflx = SQRT(REAL(s)/REAL(ns*scaleup))
-      !    WHERE (MOD(NINT(xm),2)==1)
-      !       rmnc_temp(:,s) = rmnc_temp(:,ns)*sflx**1.5
-      !       zmns_temp(:,s) = zmns_temp(:,ns)*sflx**1.5
-      !    ELSEWHERE
-      !       rmnc_temp(:,s) = rmnc_temp(:,ns)*sflx
-      !       zmns_temp(:,s) = zmns_temp(:,ns)*sflx
-      !    END WHERE
-      ! END DO
-      ! DO s = 2,ns*scaleup ! Add magnetic axis from geometric axis
-      !    rmnc_temp(1:nv,s) = rmnc_temp(1:nv,s) + rmnc(1:nv,1)
-      !    zmns_temp(1:nv,s) = zmns_temp(1:nv,s) + zmns(1:nv,1)
-      ! END DO
-      ! IF (lasym) THEN
-      !    ALLOCATE(rmns_temp(mnmax,ns*scaleup),zmnc_temp(mnmax,ns*scaleup))
-      !    rmns_temp(:,1:ns) = rmns(:,1:ns)
-      !    zmnc_temp(:,1:ns) = zmnc(:,1:ns)
-      !    DO s = 2,ns ! Remove magnetic axis from geometric axis
-      !       rmns_temp(1:nv,s) = rmns_temp(1:nv,s) - rmns(1:nv,1)
-      !       zmnc_temp(1:nv,s) = zmnc_temp(1:nv,s) - zmnc(1:nv,1)
-      !    END DO
-      !    DO s = ns+1,ns*scaleup
-      !       sflx = REAL(s)/REAL(ns)
-      !       uflx = SQRT(REAL(s)/REAL(ns*scaleup))
-      !       WHERE (MOD(NINT(xm),2)==1)
-      !          rmns_temp(:,s) = rmns_temp(:,ns)*sflx**1.5
-      !          zmnc_temp(:,s) = zmnc_temp(:,ns)*sflx**1.5
-      !       ELSEWHERE
-      !          rmns_temp(:,s) = rmns_temp(:,ns)*sflx
-      !          zmnc_temp(:,s) = zmnc_temp(:,ns)*sflx
-      !       END WHERE
-      !    END DO
-      !    DO s = 2,ns*scaleup ! Add magnetic axis from geometric axis
-      !       rmns_temp(1:nv,s) = rmns_temp(1:nv,s) + rmns(1:nv,1)
-      !       zmnc_temp(1:nv,s) = zmnc_temp(1:nv,s) + zmnc(1:nv,1)
-      !    END DO
-      ! END IF
-      ! DEALLOCATE(iotaf,phipf,rmnc,zmns,lmns,bsupumnc,bsupvmnc)
-      ! ns = ns*scaleup
-      ! ALLOCATE(iotaf(1:ns),phipf(1:ns))
-      ! ALLOCATE(rmnc(1:mnmax,1:ns),zmns(1:mnmax,1:ns), &
-      !    lmns(1:mnmax,1:ns), &
-      !    bsupumnc(1:mnmax_nyq,1:ns),bsupvmnc(1:mnmax_nyq,1:ns))
-      ! rmnc=rmnc_temp; zmns=zmns_temp; bsupumnc=0; bsupvmnc=0; lmns=0
-      ! DEALLOCATE(rmnc_temp,zmns_temp,rzl_local)
-      ! IF (lasym) THEN
-      !    DEALLOCATE(rmns,zmnc,lmnc,bsupumns,bsupvmns)
-      !    ALLOCATE(rmns(1:mnmax,1:ns),zmnc(1:mnmax,1:ns), &
-      !       lmnc(1:mnmax,1:ns), &
-      !       bsupumns(1:mnmax_nyq,1:ns),bsupvmns(1:mnmax_nyq,1:ns))
-      !    rmns=rmns_temp; zmnc=zmnc_temp; bsupumns=0; bsupvmns=0; lmnc=0
-      !    DEALLOCATE(rmns_temp,zmnc_temp)
-      ! END IF
-      ! IF (lverb) THEN
-      !    WRITE(6,*)
-      !    WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Expanding S-Grid [',0,']%'
-      ! END IF
-      ! DO s = mystart, myend ! Now fill in grid
-      !    i = MOD(s-1,nr)+1
-      !    j = MOD(s-1,nr*nphi)
-      !    j = FLOOR(REAL(j) / REAL(nr))+1
-      !    k = CEILING(REAL(s) / REAL(nr*nphi))
-      !    lsmooth(s) = .FALSE.
-      !    if (sflx > 1.0) sflx = 0.9
-      !    IF (S_ARR(i,j,k)<=1.0) CYCLE
-      !    CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
-      !                 br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
-      !    ! note that s in now rho since we grid different in the outer region
-      !    IF ((ier < 0) .and. (i > 1) .and. (i < nr) .and. (k > 1) .and. (k < nz)) THEN
-      !       lsmooth(s) = .true.
-      !       CYCLE
-      !    END IF
-      !    sflx = sflx*sflx*scaleup*scaleup
-      !    S_ARR(i,j,k) = MAX(sflx,1.01)
-      !    !IF (uflx<0)  uflx = uflx+pi2
-      !    U_ARR(i,j,k) = uflx
-      !    IF (MOD(s,nr) == 0) THEN
-      !       IF (lverb) THEN
-      !          CALL backspace_out(6,6)
-      !          WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
-      !          CALL FLUSH(6)
-      !       END IF
-      !    END IF
-      ! END DO
-
-      ! ! Smooth
-      ! IF (lverb) THEN
-      !    WRITE(6,*)
-      !    WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Smoothing S-Grid [',0,']%'
-      ! END IF
-      ! DO s = mystart, myend ! Now fill in grid
-      !    IF (.not.lsmooth(s)) CYCLE
-      !    i = MOD(s-1,nr)+1
-      !    j = MOD(s-1,nr*nphi)
-      !    j = FLOOR(REAL(j) / REAL(nr))+1
-      !    k = CEILING(REAL(s) / REAL(nr*nphi))
-      !    !IF (i==1 .or. i==nr) CYCLE
-      !    !IF (k==1 .or. k==nz) CYCLE
-      !    S_ARR(i,j,k) = (MAX(S_ARR(i-1,j,k),S_ARR(i+1,j,k)) &
-      !             + MAX(S_ARR(i,j,k-1),S_ARR(i,j,k+1)))*0.5 
-      ! END DO
-
       ! Deallocations
       IF (myworkid == master) THEN
          CALL read_wout_deallocate
@@ -679,14 +547,8 @@
          IF (lasym) DEALLOCATE(rmns,zmnc,lmnc,bsupumns,bsupvmns)
          DEALLOCATE(rzl_local)
       END IF
-      DEALLOCATE(lsmooth)
       
       IF (lverb) THEN
-         !CALL backspace_out(6,36)
-         !CALL FLUSH(6)
-         !WRITE(6,'(36X)',ADVANCE='no')
-         !CALL FLUSH(6)
-         !CALL backspace_out(6,36)
          WRITE(6,*)
          CALL FLUSH(6)
       END IF    

--- a/LIBSTELL/Sources/Modules/vmec_utils.f
+++ b/LIBSTELL/Sources/Modules/vmec_utils.f
@@ -90,11 +90,13 @@ C-----------------------------------------------
       CALL cyl2flx(rzl_local, r_cyl, c_flx, ns_w, ntor_w, mpol_w, 
      1     ntmax_w, lthreed_w, lasym_w, info_loc, nfe, fmin, 
      2     RU=Ru1, ZU=Zu1, RV=Rv1, ZV=Zv1, RS=Rs1, ZS=Zs1)
-
-      IF (info_loc.eq.-1 .and. (fmin .le. fmin_acceptable)) info_loc = 0
-
+!
+!     If info == 0 then the point is found
+!     If info == -1 then the tollerance was not achieved
+!     If info < -1 then most likely the point is outside the eq.
+!
       IF (PRESENT(info)) info = info_loc
-      IF (info_loc .ne. 0) RETURN
+      IF (info_loc .lt. -1) RETURN
 
       Rv1 = nfp*Rv1;  Zv1 = nfp*Zv1
 
@@ -1105,7 +1107,6 @@ C-----------------------------------------------
          END IF
 
          fmin0 = MIN(fmin, fmin0)
-!        PRINT *,' ITRY = ', itry+1,' FMIN = ', fmin
             
       END DO
          
@@ -1122,7 +1123,7 @@ C-----------------------------------------------
 !
       IF ((PRESENT(ru) .or. PRESENT(zu) .or. 
      1     PRESENT(rv) .or. PRESENT(zv) .or.
-     2     PRESENT(rs) .or. PRESENT(zs)) .and. info.eq.0) THEN
+     2     PRESENT(rs) .or. PRESENT(zs)) .and. info.ge.-1) THEN
          IF (lscale) THEN
             CALL flx2cyl(rzl_in, c_flx, r_cyl_out, ns_loc, ntor_loc, 
      1         mpol_loc, ntmax_loc, lthreed_loc, lasym_loc, 

--- a/LIBSTELL/Sources/Modules/vmec_utils.f
+++ b/LIBSTELL/Sources/Modules/vmec_utils.f
@@ -49,7 +49,7 @@ C-----------------------------------------------
       INTEGER, OPTIONAL, INTENT(out) :: info
       REAL(rprec), INTENT(in)  :: R1, Z1, Phi
       REAL(rprec), INTENT(out) :: Br, Bphi, Bz
-      REAL(rprec), INTENT(out), OPTIONAL :: sflx, uflx
+      REAL(rprec), INTENT(inout), OPTIONAL :: sflx, uflx
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -103,7 +103,7 @@ C-----------------------------------------------
       IF (PRESENT(sflx)) sflx = c_flx(1)  
       IF (PRESENT(uflx)) uflx = c_flx(2)
 
-      IF (c_flx(1) .gt. 2) THEN
+      IF (c_flx(1) .ge. 2) THEN
          Br = 0;  Bphi = 0;  Bz = 0
          RETURN
       ELSE IF (c_flx(1) .gt. one) THEN
@@ -1153,11 +1153,11 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      !INTEGER, PARAMETER :: niter = 50
-      INTEGER, PARAMETER :: niter = 500
-      INTEGER     :: ieval, isgt1
-      REAL(rprec) :: c_flx(3), r_cyl_out(3), fvec(nvar), sflux, 
-     1               uflux, eps0, eps, epu, xc_min(2), factor
+      INTEGER, PARAMETER :: niter = 50
+      !INTEGER, PARAMETER :: niter = 500
+      INTEGER     :: ieval
+      REAL(rprec) :: c_flx(3), r_cyl_out(3), 
+     1               eps0, eps, xc_min(nvar), factor
       REAL(rprec) :: x0(3), xs(3), xu(3), dels, delu, tau, fmin0,
      1               ru1, zu1, edge_value, snew, rs1, zs1, z_small
 C-----------------------------------------------
@@ -1171,7 +1171,6 @@ C-----------------------------------------------
 !
 !     LOCAL VARIABLES:
 !     tau:      d(R,Z)/d(s,u) (Jacobian)
-!     isgt1:    counter for number of times s>1
 
 !     FIND FLUX COORDINATES (s,u) WHICH CORRESPOND TO ZERO OF TARGET FUNCTION
 !
@@ -1188,60 +1187,38 @@ C-----------------------------------------------
       iflag = -1      
       z_small=TINY(1.0_rprec)
       eps0 = SQRT(EPSILON(eps))
-      xc_min = xc_opt
 
       c_flx(3) = phi_target
       fmin0 = 1.E10_dp
-      factor = 1
+      fmin  = 1.E10_dp
+      factor = one
       nfe = 0
-      edge_value = one + one/(ns_loc-1)
       edge_value = 2*one
-      isgt1 = 0
 
-      DO ieval = 1, niter
+!     If s < 0 then rotate angle by 180
+      if (xc_opt(1) .lt. zero) xc_opt(2) = xc_opt(2) + 0.5
+!     Start s always postive in range [0,1]
+      xc_opt(1) = ABS(xc_opt(1))
+
+      xc_min(1:nvar) = xc_opt(1:nvar)
+
+!     Minimization Loop
+      DO WHILE ((nfe .lt. niter) .and. (fmin .gt. ftol))
          nfe = nfe + 1
-
-         if (xc_opt(1) .lt. zero) then
-           ! if initial guess for s is > 0,
-           ! flip theta by 180 deg
-           sflux = -xc_opt(1)
-           uflux = xc_opt(2) + 0.5_dp
-         else
-           ! standard case for s guess >= 0
-           sflux = MAX(xc_opt(1), zero)
-           uflux = xc_opt(2)
-         end if
          
-         c_flx(1) = sflux;  c_flx(2) = uflux
+         c_flx(1) = xc_opt(1);  c_flx(2) = xc_opt(2)
 
-!        COMPUTE R,Z, Ru, Zu
+!        COMPUTE R,Z, Ru, Zu, Rs, Zs
          CALL get_flxcoord(x0, c_flx, rs=rs1, zs=zs1, ru=ru1, zu=zu1)
          xu(1) = ru1; xu(3) = zu1
          xs(1) = rs1; xs(3) = zs1
-!        COMPUTE R,Z, Ru, Zu
-!         CALL get_flxcoord(x0, c_flx, ru=ru1, zu=zu1)
-!         xu(1) = ru1; xu(3) = zu1
-!
-!        MAKE SURE sflux IS LARGE ENOUGH
-!        TO COMPUTE d(sqrt(s))/ds ACCURATELY NEAR ORIGIN
-!         IF (sflux .ge. 1000*eps0) THEN
-!            eps = eps0
-!         ELSE
-!            eps = eps0*sflux
-!         END IF
-!
-!        COMPUTE Rs, Zs NUMERICALLY
-!         eps = ABS(eps)
-!         IF (sflux .ge. 1-eps) eps = -eps
-!         c_flx(1) = sflux + eps
-!         CALL get_flxcoord(r_cyl_out, c_flx)
-!         xs = (r_cyl_out - x0)/eps
-!         c_flx(1) = sflux
 
+!        Compute Function minimization (R0,Z0)
          x0(1) = x0(1) - r_target
          x0(3) = x0(3) - z_target
          fmin = (x0(1)**2 + x0(3)**2)*fnorm
 
+!        Compute Descent Direction
          IF (fmin .gt. fmin0) THEN
             factor = (2*factor)/3
             xc_opt = xc_min
@@ -1257,7 +1234,6 @@ C-----------------------------------------------
 
 !           NEWTON STEP
             tau = xu(1)*xs(3) - xu(3)*xs(1)
-            !IF (ABS(tau) .le. ABS(eps)*r_target**2) THEN
             IF (ABS(tau) .le. ABS(z_small)*r_target**2) THEN
                iflag = -2
                EXIT
@@ -1265,37 +1241,33 @@ C-----------------------------------------------
             dels = ( x0(1)*xu(3) - x0(3)*xu(1))/tau
             delu = (-x0(1)*xs(3) + x0(3)*xs(1))/tau
             IF (fmin .gt. 1.E-3_dp) THEN
-               dels = dels/2; delu = delu/2
+               dels = dels*0.5; delu = delu*0.5
             END IF
  
          END IF
- 
-         IF (fmin .le. ftol) EXIT
 
+!        Limit change in parameters
          IF (ABS(dels) .gt. one)   dels = SIGN(one, dels)
          IF (ABS(delu) .gt. twopi/8) delu = SIGN(twopi/8, delu)
 
+!        Update s
          snew = xc_opt(1) + dels*factor
+
+!        Update u
          IF (snew .lt. zero) THEN
-            xc_opt(1) = -snew/2               !Prevents oscillations around origin s=0
-            xc_opt(2) = xc_opt(2) + twopi/2 
+            xc_opt(2) = xc_opt(2) + twopi/2 - delu*factor
          ELSE
-            xc_opt(1) = snew
             xc_opt(2) = xc_opt(2) + delu*factor
          END IF
 
-         IF (xc_opt(1) .gt. edge_value) THEN
-            isgt1 = isgt1+1
-            !IF (xc_opt(1) .gt. 2._dp) isgt1 = isgt1+1
-            IF (isgt1 .gt. 5) EXIT
-         END IF
+!        Keep s positive
+         xc_opt(1) = ABS(snew)
 
       END DO
 
-      IF (isgt1.gt.5) THEN
-         iflag = -3
-         xc_min = xc_opt
-      ELSE IF (xc_min(1) .gt. edge_value) THEN
+      !PRINT *,xc_min,fmin,nfe,iflag
+
+      IF (xc_min(1) .gt. edge_value) THEN
          iflag = -3
       ELSE IF (fmin0 .le. ftol) THEN
          iflag = 0
@@ -1304,8 +1276,10 @@ C-----------------------------------------------
       END IF
       
       fmin = fmin0
+!     Return the result
       xc_opt = xc_min
-      xc_opt(2) = MOD(xc_opt(2), twopi)
+      !xc_opt(1) = MIN(MAX(xc_min(1), zero),edge_value)
+      !xc_opt(2) = MOD(xc_min(2), twopi)
 
       END SUBROUTINE newt2d
 


### PR DESCRIPTION
These changes help improve the interface between BEAMS3D and VMEC. BEAMS3D requires mangetic fields in cylindrical coordinates on a cylindrical grid. VMEC stores quantities on an `s,u,v` grid where `v` is the toroidal angle normalized to 2pi. Thus a 2D inverse lookup is used to find a given set of `s,u` coordaintes for a desired position in `R,Z` at a given toroidal angle. To do this VMEC (`vmec_utils.f`) uses a 2D newton method. This lookup sometimes fails becasue a certain tolerance was reached. Previously when this happend the `s,u` coordiantes were returned but no magnetic field data. This could lead to 'holes' in the magnetic field. To rectify this we now use a multi-pass method  in `beams3d_init_vmec.f90` to try to improve the inital `s,u` guess. If no appropriate lookup can be found then we average in R,Z the neighboring points.  In the future we should attempt to improve the 2D newton method but for now these changes seem to fix things.

This has been tested against the BENCHMARK problems and against a W7-X case.