### PR TITLE
Feature/root analysis

### DIFF
--- a/PENTA/Sources/penta_interface_mod.f90
+++ b/PENTA/Sources/penta_interface_mod.f90
@@ -1426,23 +1426,23 @@ MODULE PENTA_INTERFACE_MOD
    END SUBROUTINE penta_merge_fluxes_vs_Er_files
 
    SUBROUTINE root_analysis
-      ! using the Maxwell construction criterium, whenever num_roots>1, determines which of them will settle
-      ! (see eg. Turkin et al. PoP 18, 022505, 2011)
       ! The array root_type indicates if the ambipolar root is set or not with .TRUE. or .FALSE.
 
       IMPLICIT NONE
 
-      INTEGER(iknd) :: i, j, idx_ion_root, idx_electron_root, one, zero
+      INTEGER(iknd) :: i, j, idx_ion_root, idx_electron_root, one, zero, idx_closest_to_zero
       REAL(rknd), DIMENSION(num_Er_test) :: Jr
-      REAL(rknd) :: temp_sum, electron_root, ion_root, integral
+      REAL(rknd) :: temp_sum, electron_root, ion_root, integral, Er_closest_to_zero
+      LOGICAL :: cond_A, cond_B
 
-      Do i=1, num_Er_test
-         temp_sum = 0.0
-         Do j=1, num_ion_species
-            temp_sum = temp_sum + Z_ion(j)*Gamma_i_vs_Er(i,j)
-         End Do
-         Jr(i) = temp_sum - Gamma_e_vs_Er(i)
-      End Do
+      ! DEPRECATED: Maxwell construction criterium
+      ! Do i=1, num_Er_test
+      !    temp_sum = 0.0
+      !    Do j=1, num_ion_species
+      !       temp_sum = temp_sum + Z_ion(j)*Gamma_i_vs_Er(i,j)
+      !    End Do
+      !    Jr(i) = temp_sum - Gamma_e_vs_Er(i)
+      ! End Do
 
       IF(ALLOCATED(root_type)) DEALLOCATE(root_type)
       ALLOCATE(root_type(num_roots))
@@ -1452,35 +1452,56 @@ MODULE PENTA_INTERFACE_MOD
       IF( num_roots ==1 ) THEN
          root_type(1) = .TRUE.
       ELSE IF(num_roots==3) THEN
-         electron_root = MAXVAL(Er_roots(1:num_roots),1)
-         ion_root = MINVAL(Er_roots(1:num_roots),1)
-         ! Find the index in Er_test_vals closest to electron_root and ion_root
-         idx_electron_root = MINLOC( ABS(Er_test_vals-electron_root), 1 )
-         idx_ion_root = MINLOC( ABS(Er_test_vals-ion_root), 1 )
-         ! Compute integrals
-         integral = SUM( Jr(idx_ion_root:idx_electron_root)*(Er_test_vals(2)-Er_test_vals(1)) )
-         ! Set root type
-         IF(integral>0) THEN
-            root_type(1) = .TRUE.
-         ELSE
-            root_type(3) = .TRUE.
-         ENDIF
-         !
+         ! pick root that corresponds to lowest Er (ion root)
+         root_type(1) = .TRUE. !Er_roots are ordered
+
+         ! ! DEPRECATED: Maxwell construction criterium
+         ! electron_root = MAXVAL(Er_roots(1:num_roots),1)
+         ! ion_root = MINVAL(Er_roots(1:num_roots),1)
+         ! ! Find the index in Er_test_vals closest to electron_root and ion_root
+         ! idx_electron_root = MINLOC( ABS(Er_test_vals-electron_root), 1 )
+         ! idx_ion_root = MINLOC( ABS(Er_test_vals-ion_root), 1 )
+         ! ! Compute integrals
+         ! integral = SUM( Jr(idx_ion_root:idx_electron_root)*(Er_test_vals(2)-Er_test_vals(1)) )
+         ! ! Set root type
+         ! IF(integral>0) THEN
+         !    root_type(1) = .TRUE.
+         ! ELSE
+         !    root_type(3) = .TRUE.
+         ! ENDIF
+         
       ELSE IF(num_roots==5) THEN
-         electron_root = MAXVAL(Er_roots(1:num_roots),1)
-         ion_root = MINVAL(Er_roots(1:num_roots),1)
-         ! Find the index in Er_test_vals closest to electron_root and ion_root
-         idx_electron_root = MINLOC( ABS(Er_test_vals-electron_root), 1 )
-         idx_ion_root = MINLOC( ABS(Er_test_vals-ion_root), 1 )
-         ! Compute integrals
-         integral = SUM( Jr(idx_ion_root:idx_electron_root)*(Er_test_vals(2)-Er_test_vals(1)) )
-         ! Set root type
-         IF(integral>0) THEN
-            root_type(1) = .TRUE.
-         ELSE
-            root_type(5) = .TRUE.
-         ENDIF
+         ! There are 2 possibilities:
+         ! possibility_1 = ['extra_stable_root','unstable_root2','ion_root','unstable_root','electron_root']
+         ! possibility_2 = ['ion_root','unstable_root','electron_root','unstable_root2','extra_stabe_root']
          !
+         ! Use criterium: ion_root is the negative root closest to Er=0
+         idx_closest_to_zero = MINLOC( ABS(Er_roots), 1 ) 
+         Er_closest_to_zero = Er_roots(idx_closest_to_zero)
+
+         cond_A = Er_closest_to_zero > 0
+         cond_B = idx_closest_to_zero >= 3 !2
+                
+         IF( (cond_A .AND. cond_B) .OR. (.NOT. cond_A  .AND. cond_B) ) THEN
+            root_type(3) = .TRUE. !possibility_1
+         ELSE
+            root_type(1) = .TRUE. !possibility_2
+         END IF
+
+         ! ! DEPRECATED: Maxwell construction criterium
+         ! electron_root = MAXVAL(Er_roots(1:num_roots),1)
+         ! ion_root = MINVAL(Er_roots(1:num_roots),1)
+         ! ! Find the index in Er_test_vals closest to electron_root and ion_root
+         ! idx_electron_root = MINLOC( ABS(Er_test_vals-electron_root), 1 )
+         ! idx_ion_root = MINLOC( ABS(Er_test_vals-ion_root), 1 )
+         ! ! Compute integrals
+         ! integral = SUM( Jr(idx_ion_root:idx_electron_root)*(Er_test_vals(2)-Er_test_vals(1)) )
+         ! ! Set root type
+         ! IF(integral>0) THEN
+         !    root_type(1) = .TRUE.
+         ! ELSE
+         !    root_type(5) = .TRUE.
+         ! ENDIF
 
       ELSE
          STOP 'ERROR: number of roots different than 1,3 or 5... how is it possible??'

--- a/THRIFT/Sources/thrift_penta.f90
+++ b/THRIFT/Sources/thrift_penta.f90
@@ -179,18 +179,10 @@
             CALL PENTA_RUN_2_EFIELD
             CALL PENTA_RUN_3_FIND_ROOTS
             CALL PENTA_RUN_4_AMBIPOLAR
-
-            ! Save JBS corresponding to the root that has the largest Er
-            ! This because whenever there are 2 stable roots, a rule of thumb is to pick the one with largest Er
-            ! root_max_Er = MAXLOC(Er_roots(1:num_roots),1)
-            ! JBS_PENTA(k) = J_BS_ambi(root_max_Er)
-            ! etapar_PENTA(k) = 1.0_rprec / sigma_par_ambi(root_max_Er)
-            ! Er_PENTA(k) = MAXVAL(Er_roots(1:num_roots),1)
-            
-            ! The call to ROOT_ANALYSIS sets the array 'root_type' which decides which root will settle according to 
-            ! Maxwell construction criterium (see eg. Turkin et al. PoP 18, 022505, 2011)
-            ! This criterium substitutes the above (now commented) lines where the selected root corresponded to
-            ! the largest Er
+          
+            ! The call to ROOT_ANALYSIS sets the array 'root_type' which decides which root to pick
+            ! The criterium is to pick the 'ion_root' whenever there are 3 or 5 roots
+            ! If num_roots = even or num_roots > 5, the code gives an error
             CALL ROOT_ANALYSIS
             ! Using root_type, pick the ambipolar root that will be saved by THRIFT
             DO i=1,num_roots

--- a/THRIFT/Sources/thrift_penta.f90
+++ b/THRIFT/Sources/thrift_penta.f90
@@ -263,17 +263,17 @@
             !JBS
             CALL EZspline_init(J_spl,ns_dkes+2,bcs0,ier)
             J_spl%x1        = rho_temp
-            J_spl%isHermite = 0
+            J_spl%isHermite = 1
             CALL EZspline_setup(J_spl,J_temp,ier,EXACT_DIM=.true.)
             !etapar
             CALL EZspline_init(eta_spl,ns_dkes+2,bcs0,ier)
             eta_spl%x1        = rho_temp
-            eta_spl%isHermite = 0
+            eta_spl%isHermite = 1
             CALL EZspline_setup(eta_spl,eta_temp,ier,EXACT_DIM=.true.)
             !Er
             CALL EZspline_init(Er_spl,ns_dkes+2,bcs0,ier)
             Er_spl%x1        = rho_temp
-            Er_spl%isHermite = 0
+            Er_spl%isHermite = 1
             CALL EZspline_setup(Er_spl,Er_temp,ier,EXACT_DIM=.true.)
             !
             DEALLOCATE(J_temp,eta_temp,Er_temp)


### PR DESCRIPTION
I am changing the criterium `THRIFT` uses to pick one of the ambipolar roots from `PENTA`. Up to now we were using Maxwell's construction criterium. The problem is that I realized this method is very sensible to resonances that sometimes appear in the fluxes (these resonances are inherent to `DKES` formulation and there is nothing we can do about them).

So now, whenever there are 3 ambipolar roots, we simply pick the first one (lowest Er).
If number of roots is 5, we pick the negative root closest to Er=0, according to the following 2 possibilities:

`! possibility_1 = ['extra_stable_root','unstable_root2','ion_root','unstable_root','electron_root']`
` ! possibility_2 = ['ion_root','unstable_root','electron_root','unstable_root2','extra_stabe_root']`

If number of roots is even or larger than 5, an error is given and the code STOPS -- as was already the case.

Finally, in this merge I am changing the splines of `Er`, `J_BS` and `eta` to Hermite, to prevent spurious oscillations.