### PR TITLE
BEAMS3D: Added option for user hardcoded background grids.

### DIFF
--- a/BEAMS3D/BEAMS3D.dep
+++ b/BEAMS3D/BEAMS3D.dep
@@ -216,6 +216,14 @@ beams3d_init_restart.o: \
       beams3d_grid.o
       
 
+beams3d_init_user.o: \
+      ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
+      ../../LIBSTELL/$(LOCTYPE)/mpi_params.o \
+      ../../LIBSTELL/$(LOCTYPE)/mpi_inc.o \
+      beams3d_runtime.o \
+      beams3d_grid.o
+      
+
 beams3d_init_vmec.o: \
       ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
       ../../LIBSTELL/$(LOCTYPE)/wall_mod.o \

--- a/BEAMS3D/ObjectList
+++ b/BEAMS3D/ObjectList
@@ -1,4 +1,5 @@
 ObjectFiles = \
+beams3d_init_user.o \
 beams3d_init_mumat.o \
 beams3d_interface_mod.o \
 beams3d_beam_density.o \

--- a/BEAMS3D/Sources/beams3d_init.f90
+++ b/BEAMS3D/Sources/beams3d_init.f90
@@ -122,7 +122,10 @@
          IF (lverb) WRITE(6,'(A)') '   RESTART GRID FILE: ' // TRIM(continue_grid_string)
          CALL read_beams3d_mag(TRIM(continue_grid_string),MPI_COMM_SHARMEM,ier)
          phimin = 0
-         CALL get_beams3d_grid(nr,nz,nphi,rmin,rmax,zmin,zmax,phimax)         
+         CALL get_beams3d_grid(nr,nz,nphi,rmin,rmax,zmin,zmax,phimax)    
+      ELSE IF (luser_init) THEN
+         CALL read_beams3d_input('input.' // TRIM(id_string),ier)
+         IF (lverb) WRITE(6,'(A)') '   FILE: input.' // TRIM(id_string)
       END IF
 
 #if defined(HDF5_PAR)
@@ -432,6 +435,8 @@
          CALL beams3d_init_mgrid
       ELSE IF (lcoil) THEN
          CALL beams3d_init_coil
+      ELSE IF (luser_init) THEN
+         CALL beams3d_init_user
       END IF
 
       ! Put the plasma field on the background grid

--- a/BEAMS3D/Sources/beams3d_init_user.f90
+++ b/BEAMS3D/Sources/beams3d_init_user.f90
@@ -1,0 +1,93 @@
+!-----------------------------------------------------------------------
+!     Module:        beams3d_init_user
+!     Authors:       S. Lazerson (samuel.lazerson@gauss-fusion.com)
+!     Date:          05/21/2025
+!     Description:   This subroutine allows one to create a user
+!                    defined scenario for doing example plots.
+!-----------------------------------------------------------------------
+      SUBROUTINE beams3d_init_user
+!-----------------------------------------------------------------------
+!     Libraries
+!-----------------------------------------------------------------------
+      USE stel_kinds, ONLY: rprec
+      USE beams3d_runtime
+      USE beams3d_grid, ONLY: raxis,phiaxis,zaxis, nr, nphi, nz, &
+                                 rmin, rmax, zmin, zmax, phimin, &
+                                 phimax, B_R, B_Z, B_PHI, S_ARR
+      USE mpi_params  
+      USE mpi_inc      
+!-----------------------------------------------------------------------
+!     Local Variables
+!          ier            Error Flag
+!          iunit          File ID Number
+!-----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER, PARAMETER :: BYTE_8 = SELECTED_INT_KIND (8)
+#if defined(MPI_OPT)
+      INTEGER(KIND=BYTE_8),ALLOCATABLE :: mnum(:), moffsets(:)
+      INTEGER :: numprocs_local, mylocalid, mylocalmaster
+      INTEGER :: MPI_COMM_LOCAL
+#endif
+      INTEGER(KIND=BYTE_8) :: chunk
+      INTEGER :: ier, iunit, s, i, j, mystart, myend, k, ik, ig, coil_dex
+      REAL(rprec)  :: br, bphi, bz, current, current_first, &
+                      br_temp, bphi_temp, bz_temp
+!-----------------------------------------------------------------------
+!     Begin Subroutine
+!-----------------------------------------------------------------------
+
+      ! Divide up Work
+#if defined(MPI_OPT)
+      CALL MPI_COMM_DUP( MPI_COMM_SHARMEM, MPI_COMM_LOCAL, ierr_mpi)
+      CALL MPI_COMM_RANK( MPI_COMM_LOCAL, mylocalid, ierr_mpi )              ! MPI
+      CALL MPI_COMM_SIZE( MPI_COMM_LOCAL, numprocs_local, ierr_mpi )          ! MPI
+#endif
+      mylocalmaster = master
+
+      IF (lverb) THEN
+         WRITE(6,'(A)')   '----- USER Defined Scenario -----'
+         CALL FLUSH(6)
+      END IF
+
+      ! Break up the Work
+      CALL MPI_CALC_MYRANGE(MPI_COMM_LOCAL, 1, nr*nphi*nz, mystart, myend)
+      
+      ! Here is where you can set the mangetic field.
+      DO s = mystart, myend
+         i = MOD(s-1,nr)+1
+         j = MOD(s-1,nr*nphi)
+         j = FLOOR(REAL(j) / REAL(nr))+1
+         k = CEILING(REAL(s) / REAL(nr*nphi))
+         ! Pure vertical field
+         B_R(i,j,k)   = 0.0
+         B_PHI(i,j,k) = 0.0
+         B_Z(i,j,k)   = 1.0+10.0*ABS(zaxis(k)/zaxis(nz))**2.0
+         S_ARR(i,j,k) = 0.0
+         IF (lverb .and. (MOD(s,nr) == 0)) THEN
+            CALL backspace_out(6,6)
+            WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
+            CALL FLUSH(6)
+         END IF
+      END DO
+      
+      ! Clean up the progress bar
+      IF (lverb) THEN
+         CALL backspace_out(6,36)
+         WRITE(6,'(38X)',ADVANCE='no')
+         CALL backspace_out(6,36)
+         WRITE(6,*)
+         CALL FLUSH(6)
+      END IF    
+
+#if defined(MPI_OPT)
+      CALL MPI_BARRIER(MPI_COMM_LOCAL,ierr_mpi)
+      CALL MPI_COMM_FREE(MPI_COMM_LOCAL,ierr_mpi)
+      CALL MPI_BARRIER(MPI_COMM_BEAMS,ierr_mpi)
+      IF (ierr_mpi /=0) CALL handle_err(MPI_BARRIER_ERR,'beams3d_init_user',ierr_mpi)
+#endif
+      
+      RETURN
+!-----------------------------------------------------------------------
+!     End Subroutine
+!-----------------------------------------------------------------------    
+      END SUBROUTINE beams3d_init_user

--- a/BEAMS3D/Sources/beams3d_interface_mod.f90
+++ b/BEAMS3D/Sources/beams3d_interface_mod.f90
@@ -157,6 +157,7 @@ CONTAINS
          lmumat = .false.
          lvessel = .false.
          lvac = .false.
+         luser_init = .false.
          lcontinue_grid = .false.
          lrestart_particles = .false.
          lhitonly  = .false.
@@ -218,6 +219,10 @@ CONTAINS
             case ("-vmec")
                 i = i + 1
                 lvmec = .true.
+                CALL GETCARG(i, id_string, numargs)
+            case ("-user") ! Vacuum Fields Only
+                i = i + 1
+                luser_init = .true.
                 CALL GETCARG(i, id_string, numargs)
             case ("-pies")
                 i = i + 1
@@ -381,7 +386,7 @@ CONTAINS
       CALL MPI_BCAST(restart_string, 256, MPI_CHARACTER, master, MPI_COMM_BEAMS, ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'beams3d_main', ierr_mpi)
       CALL MPI_BCAST(continue_grid_string, 256, MPI_CHARACTER, master, MPI_COMM_BEAMS, ierr_mpi)
-      IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'beams3d_main', ierr_mpi)	  
+      IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'beams3d_main', ierr_mpi)
       CALL MPI_BCAST(eqdsk_string, 256, MPI_CHARACTER, master, MPI_COMM_BEAMS, ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'beams3d_main', ierr_mpi)
       CALL MPI_BCAST(mumat_string, 256, MPI_CHARACTER, master, MPI_COMM_BEAMS, ierr_mpi)
@@ -457,6 +462,8 @@ CONTAINS
       CALL MPI_BCAST(lboxsim,1,MPI_LOGICAL, master, MPI_COMM_BEAMS,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'beams3d_main',ierr_mpi)
       CALL MPI_BCAST(lbeamdensity,1,MPI_LOGICAL, master, MPI_COMM_BEAMS,ierr_mpi)
+      IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'beams3d_main',ierr_mpi)
+      CALL MPI_BCAST(luser_init,1,MPI_LOGICAL, master, MPI_COMM_BEAMS,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'beams3d_main',ierr_mpi)
       CALL MPI_BCAST(rminor_norm,1,MPI_DOUBLE_PRECISION, master, MPI_COMM_BEAMS,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'beams3d_main',ierr_mpi)

--- a/BEAMS3D/Sources/beams3d_runtime.f90
+++ b/BEAMS3D/Sources/beams3d_runtime.f90
@@ -159,7 +159,8 @@ MODULE beams3d_runtime
                ldepo, lbeam_simple, lw7x, lsuzuki, &
                lascot, lascot4, lfidasim, lfidasim_cyl, lsplit, &
                lvessel_beam, lascotfl, lrandomize, leqdsk, lhint, &
-               lboxsim, limas, lfieldlines, lbeamdensity, lmumat
+               lboxsim, limas, lfieldlines, lbeamdensity, lmumat, &
+               luser_init
     INTEGER :: nextcur, nprocs_beams, ndt, ndt_max
     INTEGER, ALLOCATABLE :: beam(:)
     REAL(rprec) :: dt, pi, invpi2, mu0, to3, dt_save, rminor_norm


### PR DESCRIPTION
This basically adds a command line option `--user` which allows BEAMS3D to populate the background grids with user defined data. Useful for creating test-particle simulations and testing various parts of the code.