### PR TITLE
Feature/thrift_travis

### DIFF
--- a/THRIFT/Sources/thrift_run_eccd.f90
+++ b/THRIFT/Sources/thrift_run_eccd.f90
@@ -21,7 +21,7 @@
       INTEGER :: i, ier, i1,i2
       INTEGER :: bcs0(2)
       REAL(rprec) :: Rc, w, Ieccd, Inorm, vp, dPhidrho, temp, &
-                     s_val, rho_val
+                     s_val, rho_val, mytime, fact
       REAL(rprec), DIMENSION(:), ALLOCATABLE ::  j_temp
       TYPE(EZspline1_r8) :: j_spl
 !----------------------------------------------------------------------
@@ -34,21 +34,32 @@
          RETURN
       END IF
 
-      ! Get Power at timestep
-      i1 = COUNT(PECRH_AUX_T < THRIFT_T(mytimestep))
+      ! PECRH_AUX_T is an array with default entries: 1E6
+      mytime = THRIFT_T(mytimestep)
+      i1 = COUNT(PECRH_AUX_T - mytime < 1E-6)
       i2 = i1+1
-      IF (PECRH_AUX_F(i1)==0 .or. PECRH_AUX_F(i2)==0) THEN
-         THRIFT_JECCD(:,mytimestep) = 0
-         RETURN
+      
+      ! If i==0, simply use POWER_ECRH
+      IF(i1==0) THEN
+         fact = 1.0
+      ELSEIF(i1>0) THEN
+         ! if aux_t(i1) <= mytime <= aux_t(i2), make linear interpolation
+         IF( (PECRH_AUX_T(i1) .LE. mytime) .AND. (PECRH_AUX_T(i2) .GE. mytime) ) THEN
+            fact = ( PECRH_AUX_F(i2)      - PECRH_AUX_F(i1) ) &
+                 * ( mytime - PECRH_AUX_T(i1) ) &
+                 / ( PECRH_AUX_T(i2)      - PECRH_AUX_T(i1) ) &
+                 + PECRH_AUX_F(i1)
+         ELSE
+            STOP 'HOW DID YOU END UP HERE?'
+         END IF
       END IF
 
-      ! Set Ieccd here so that in the future we can use this
-      ! to control TRAVIS ECCD by the same code.
-      Ieccd =    ( PECRH_AUX_F(i2)      - PECRH_AUX_F(i1) ) &
-               * ( THRIFT_T(mytimestep) - PECRH_AUX_T(i1) ) &
-               / ( PECRH_AUX_T(i2)      - PECRH_AUX_T(i1) ) &
-               + PECRH_AUX_F(i1)
+      POWER_ECRH = fact * POWER_ECRH
 
+      IF( MAXVAL(POWER_ECRH) < 1E-6 ) THEN
+         THRIFT_JECCD(:,mytimestep) = 0
+         RETURN
+      END IF  
 
       SELECT CASE(TRIM(eccd_type))
          CASE ('model','offaxis','test','simple')
@@ -58,6 +69,8 @@
             !        387–394 (2006).
             Rc = ecrh_rc
             w  = ecrh_w
+
+            Ieccd = POWER_ECRH(1)
 
             ! From Wolfram
             Inorm = 0.5*w*( SQRT(pi)*Rc*( ERF((1-Rc)/w) + ERF(Rc/w) )+w*( EXP(-Rc**2/w**2) - EXP(-(Rc-1)**2/w**2) ))

--- a/THRIFT/Sources/thrift_travis.f90
+++ b/THRIFT/Sources/thrift_travis.f90
@@ -69,7 +69,7 @@
             CALL FLUSH(6)
             timenow = THRIFT_T(mytimestep)
             DO i = 1,nprof_travis
-               rho_prof(i) = DBLE(i-1)/DBLE(nprof_travis-1)
+               rho_prof(i) = SQRT( DBLE(i-1)/DBLE(nprof_travis-1) )
                CALL get_prof_ne(rho_prof(i),timenow,ne_prof(i))
                CALL get_prof_te(rho_prof(i),timenow,te_prof(i))
                CALL get_prof_zeff(rho_prof(i),timenow,z_prof(i))
@@ -100,6 +100,10 @@
          ! Divide up work
          ! Note we should fix this in the end so we divide up over system ans well
          CALL MPI_CALC_MYRANGE(MPI_COMM_MYWORLD, 1, nbeams, mystart, myend)
+
+         ! Allocatel total current [A]
+         ALLOCATE(Itotal(nrho),dPdV(nrho),Pabs(nrho),Jbb(nrho),Jcdt(nrho))
+         Itotal = 0; dPdV = 0; Pabs = 0; Jbb = 0; Jcdt = 0
 
          IF (mystart <= myend) THEN
 
@@ -207,16 +211,12 @@
             ! Free the stuff we loaded.
             ! CALL Free_MagConfig_f77()
 
+            DO i = 1, nrho
+               rho = SQRT( THRIFT_S(i) )
+               CALL get_ECRH_deposition_f77(rho, dPdV(i),Pabs(i),jbb(i),jcdt(i),Itotal(i))
+            END DO
+
          END IF
-
-         ! Allocatel total current [A]
-         ALLOCATE(Itotal(nrho),dPdV(nrho),Pabs(nrho),Jbb(nrho),Jcdt(nrho))
-         Itotal = 0; dPdV = 0; Pabs = 0; Jbb = 0; Jcdt = 0
-
-         DO i = 1, nrho
-            rho = THRIFT_RHO(i)
-            CALL get_ECRH_deposition_f77(rho, dPdV(i),Pabs(i),jbb(i),jcdt(i),Itotal(i))
-         END DO
 
 #if defined(MPI_OPT)
          IF (myworkid == master) THEN
@@ -241,7 +241,7 @@
             WRITE(iunit_out,'(A)') '        RHO (r/a)          dPdV [W/m^3]          P [W]          <j.B>/<B> [A/m^2]      j [A/m^2]     '//&
                                    '        I [A]       '
             DO i=1,nrho
-               WRITE(iunit_out,'(6(ES20.10))') THRIFT_RHO(i), dPdV(i), Pabs(i), Jbb(i), Jcdt(i), Itotal(i) 
+               WRITE(iunit_out,'(6(ES20.10))') SQRT(THRIFT_S(i)), dPdV(i), Pabs(i), Jbb(i), Jcdt(i), Itotal(i) 
             END DO
             CLOSE(iunit_out)
 


### PR DESCRIPTION
Calls to `TRAVIS` from `THRIFT` should be made using sqrt of normalized flux and not the normalized flux. This bug is fixed. 

The logic on how to ramp-up/down ECRH power using the NAMELIST variables `PECRH_AUX_T` and `PECRH_AUX_F` is improved.