### PR TITLE
Change THRIFT edge boundary condition and improve others

### DIFF
--- a/PENTA/Sources/penta_interface_mod.f90
+++ b/PENTA/Sources/penta_interface_mod.f90
@@ -1244,11 +1244,12 @@ MODULE PENTA_INTERFACE_MOD
 
          ! Write fluxes to file "fluxes_vs_roa"
          IF(save_all_ambipolar_roots) THEN
-            Write(str_num,*) 2*num_species + 2
+            Write(str_num,*) 2*num_species + 3
             Write(iu_flux_out,'(f7.3,' // Trim(Adjustl(str_num)) // '(" ",e15.7),' // 'i4)') &
             roa_surf,Er_test/100._rknd,J_BS_ambi(iroot),Gammas_ambi(1,iroot),  &
             QoTs_ambi(1,iroot),Gammas_ambi(2:num_species,iroot),  &
-            QoTs_ambi(2:num_species,iroot), merge(1_iknd,0_iknd, root_type(iroot))
+            QoTs_ambi(2:num_species,iroot), 1.0_rknd/sigma_par_ambi(iroot), &
+            merge(1_iknd,0_iknd, root_type(iroot))
          ENDIF
 
       !    ! Write flows to file "flows_vs_roa"
@@ -1333,7 +1334,7 @@ MODULE PENTA_INTERFACE_MOD
       Write(iunit_merged,'(f7.3)') mytime
       Write(iunit_merged,'("r/a    Er[V/cm]    J_BS [Am**-2]    ",  &
             "Gamma_e [m**-2s**-1]   Q_e/T_e [m**-2s**-1]     ",         &
-            "Gamma_i [m**-2s**-1]   Q_i/T_i [m**-2s**-1]   root_type")')
+            "Gamma_i [m**-2s**-1]   Q_i/T_i [m**-2s**-1]   etapar [Ohm.m]   root_type")')
 
       !Loop through files
       Do k=1,ns_dkes

--- a/THRIFT/Sources/thrift_evolve.f90
+++ b/THRIFT/Sources/thrift_evolve.f90
@@ -179,8 +179,6 @@
             ! Calculate iota
             IF (lverbj) WRITE(6,*) "Calculating iota"
             CALL calc_iota
-            ! Calculate <E.B>
-            THRIFT_EPARB(:,mytimestep) = THRIFT_ETAPARA(:,mytimestep) * THRIFT_JPLASMA(:,mytimestep) * THRIFT_BAV(:,mytimestep)
 
             ! Print Header
             IF (lverb .and. lfirst_pass) THEN

--- a/THRIFT/Sources/thrift_funcs.f90
+++ b/THRIFT/Sources/thrift_funcs.f90
@@ -118,8 +118,10 @@ SUBROUTINE update_vars()
         p_m1 = THRIFT_P(i-1, mytimestep)
         THRIFT_PPRIME(i,mytimestep) = (p_p1-p_m1)/(2*ds)
      END DO
-     THRIFT_PPRIME(1,mytimestep)   = 2*THRIFT_PPRIME(2,mytimestep)-THRIFT_PPRIME(3,mytimestep)
-     THRIFT_PPRIME(nsj,mytimestep) = 2*THRIFT_PPRIME(nsj-1,mytimestep)-THRIFT_PPRIME(nsj-2,mytimestep)
+    !THRIFT_PPRIME(1,mytimestep)   = 2*THRIFT_PPRIME(2,mytimestep)-THRIFT_PPRIME(3,mytimestep)
+    !THRIFT_PPRIME(nsj,mytimestep) = 2*THRIFT_PPRIME(nsj-1,mytimestep)-THRIFT_PPRIME(nsj-2,mytimestep)
+     THRIFT_PPRIME(1,mytimestep)   = (-1.5*THRIFT_P(1,mytimestep) + 2*THRIFT_P(2,mytimestep) - 0.5*THRIFT_P(3,mytimestep)) / ds
+     THRIFT_PPRIME(nsj,mytimestep) = (1.5*THRIFT_P(nsj,mytimestep) - 2*THRIFT_P(nsj-1,mytimestep) + 0.5*THRIFT_P(nsj-2,mytimestep)) / ds
    
      IF (lverbj) CALL print_calc_vars()
      

--- a/THRIFT/Sources/thrift_interface_mod.f90
+++ b/THRIFT/Sources/thrift_interface_mod.f90
@@ -91,12 +91,12 @@ MODULE THRIFT_INTERFACE_MOD
          WRITE(6,*) '     MESSAGE: ',TRIM(cmdtxt); CALL FLUSH(6)
 !DEC$ IF DEFINED (STELZIP)
          ! Zip up the results and clean
-         CALL EXECUTE_COMMAND_LINE("rm -rf dcon* jxbout* mercier* dkesout* fort.* temp_input*",WAIT=.TRUE.,EXITSTAT=ier,CMDSTAT=ierr_mpi,CMDMSG=cmdtxt)
+         CALL EXECUTE_COMMAND_LINE("rm -rf dcon* jxbout* mercier* dkesout* fort.* temp_input* boozmn*",WAIT=.TRUE.,EXITSTAT=ier,CMDSTAT=ierr_mpi,CMDMSG=cmdtxt)
          WRITE(6,*) ' Zipping files'; CALL FLUSH(6); ier = 0; ierr_mpi = 0; cmdtxt=''
          CALL EXECUTE_COMMAND_LINE("zip -r thrift_files.zip thrift_*.h5 ambipolar* fluxes_vs_Er* wout* DKES_coeffs*",WAIT=.TRUE.,EXITSTAT=ier,CMDSTAT=ierr_mpi,CMDMSG=cmdtxt)
          WRITE(6,*) ' zip: EXITSTAT=',ier,' CMDSTAT=',ierr_mpi; CALL FLUSH(6)
          WRITE(6,*) '     MESSAGE: ',TRIM(cmdtxt); CALL FLUSH(6)
-         CALL EXECUTE_COMMAND_LINE("rm -rf wout* temp_input*",WAIT=.TRUE.,EXITSTAT=ier,CMDSTAT=ierr_mpi,CMDMSG=cmdtxt)
+         CALL EXECUTE_COMMAND_LINE("rm -rf wout* temp_input* ambipolar* fluxes_vs_Er* DKES_coeffs*",WAIT=.TRUE.,EXITSTAT=ier,CMDSTAT=ierr_mpi,CMDMSG=cmdtxt)
          WRITE(6,*) ' rm: EXITSTAT=',ier,' CMDSTAT=',ierr_mpi; CALL FLUSH(6)
          WRITE(6,*) '     MESSAGE: ',TRIM(cmdtxt); CALL FLUSH(6)
          ier = 0; ierr_mpi=0

--- a/THRIFT/Sources/thrift_jinductive.f90
+++ b/THRIFT/Sources/thrift_jinductive.f90
@@ -24,7 +24,8 @@
       IMPLICIT NONE
       INTEGER :: i, j, prevtimestep, ier
       INTEGER :: bcs0(2)
-      REAL(rprec) :: rho,s,ds,dt,temp,Lext,rmaj,amin
+      REAL(rprec) :: rho,s,ds,dt,temp,Lext,rmaj,amin,vp,phia,Bsq,Bav,&
+                     etapar,fact1,fact2
       REAL(rprec), DIMENSION(:), ALLOCATABLE ::j_temp,&
                      A_temp,B_temp,C_temp,D_temp,&
                      BP_temp, CP_temp, DP_temp,temp_arr,  &
@@ -168,21 +169,44 @@
       !DIAGSUP(1) = -4
       !RHS(1)     = 0
 
-      ! Plasma edge (s=1)
+      ! Plasma edge (s=1) Robin BC including pprime
+      vp = THRIFT_VP(nsj,mytimestep)
+      phia = THRIFT_PHIEDGE(mytimestep)
       rmaj = THRIFT_RMAJOR(nsj,mytimestep); amin = THRIFT_AMINOR(nsj,mytimestep) ! R,a helpers
       Lext = mu0*rmaj*(log(8*rmaj/amin)-2) ! mu0 R (log(8R/a)-2)
-      temp = 2*pi*rmaj*mu0/THRIFT_PHIEDGE(mytimestep)*THRIFT_ETAPARA(nsj,mytimestep)/Lext*THRIFT_JSOURCE(nsj,mytimestep)
-      RHS(nsj) = THRIFT_UGRID(nsj,prevtimestep)/dt + temp ! u/dt + 2*pi*R*(mu0/phi_edge)*(eta/Lext)*Js
-      temp = rmaj/(amin**2*ds)*THRIFT_ETAPARA(nsj,mytimestep)/Lext ! X2 = R0/(a^2 ds)*eta/Lext
-      DIAGSUB(nsj-1) = -4*temp
-      DIAGMID( nsj ) = 3*temp+1.0/dt
-
+      etapar = THRIFT_ETAPARA(nsj,mytimestep)
+      Bsq = THRIFT_BSQAV(nsj,mytimestep)
+      Bav = THRIFT_BAV(nsj,mytimestep)
+      !
+      fact1 = (vp/phia)*(etapar/Lext)*(mu0/phia)
+      fact2 = (vp/phia)*(etapar/Lext)*(Bsq/phia)
+      !
+      DIAGSUB(nsj-1) = -2.0*fact2/ds
+      DIAGMID( nsj ) = 1.0/dt + 1.5*fact2/ds + fact1*THRIFT_PPRIME(nsj,mytimestep)
+      RHS(nsj) = THRIFT_UGRID(nsj,prevtimestep)/dt + fact1*Bav*THRIFT_JSOURCE(nsj,mytimestep)
+      !
       ! Row manipulations to get TDM for DGTSV
-      ! Eliminate X2
-      temp = temp/DIAGSUB(nsj-2) ! X2/an1
+      temp = fact2/(2.0*ds) ! X
+      temp = temp/DIAGSUB(nsj-2) ! X/an1
       DIAGSUB(nsj-1)    = DIAGSUB(nsj-1)  - temp*DIAGMID(nsj-1)
       DIAGMID(nsj)      = DIAGMID(nsj)    - temp*DIAGSUP(nsj-1)
       RHS(nsj)          = RHS(nsj)        - temp*RHS(nsj-1)
+
+      ! Plasma edge (s=1) Neuman BC
+      ! rmaj = THRIFT_RMAJOR(nsj,mytimestep); amin = THRIFT_AMINOR(nsj,mytimestep) ! R,a helpers
+      ! Lext = mu0*rmaj*(log(8*rmaj/amin)-2) ! mu0 R (log(8R/a)-2)
+      ! temp = 2*pi*rmaj*mu0/THRIFT_PHIEDGE(mytimestep)*THRIFT_ETAPARA(nsj,mytimestep)/Lext*THRIFT_JSOURCE(nsj,mytimestep)
+      ! RHS(nsj) = THRIFT_UGRID(nsj,prevtimestep)/dt + temp ! u/dt + 2*pi*R*(mu0/phi_edge)*(eta/Lext)*Js
+      ! temp = rmaj/(amin**2*ds)*THRIFT_ETAPARA(nsj,mytimestep)/Lext ! X2 = R0/(a^2 ds)*eta/Lext
+      ! DIAGSUB(nsj-1) = -4*temp
+      ! DIAGMID( nsj ) = 3*temp+1.0/dt
+
+      ! ! Row manipulations to get TDM for DGTSV
+      ! ! Eliminate X2
+      ! temp = temp/DIAGSUB(nsj-2) ! X2/an1
+      ! DIAGSUB(nsj-1)    = DIAGSUB(nsj-1)  - temp*DIAGMID(nsj-1)
+      ! DIAGMID(nsj)      = DIAGMID(nsj)    - temp*DIAGSUP(nsj-1)
+      ! RHS(nsj)          = RHS(nsj)        - temp*RHS(nsj-1)
       
       ! code for dI/ds = 0
       !! Eliminate X1

--- a/THRIFT/Sources/thrift_jinductive.f90
+++ b/THRIFT/Sources/thrift_jinductive.f90
@@ -224,6 +224,12 @@
       CALL curtot_to_curden(THRIFT_I(:,mytimestep),j_temp)
       THRIFT_JPLASMA(:,mytimestep) = j_temp - THRIFT_JSOURCE(:,mytimestep)
 
+      ! Calculate <E.B>
+      THRIFT_EPARB(:,mytimestep) = THRIFT_ETAPARA(:,mytimestep) * ( &
+      THRIFT_BSQAV(:,mytimestep)*j_temp * (pi*eq_Aminor**2)/THRIFT_PHIEDGE(mytimestep) - &
+      THRIFT_JSOURCE(:,mytimestep)*THRIFT_BAV(:,mytimestep) + &
+      mu0*THRIFT_PPRIME(:,mytimestep)*THRIFT_I(:,mytimestep)/THRIFT_PHIEDGE(mytimestep) )
+
       IF (lverbj) CALL print_postevolve(j_temp)
       DEALLOCATE(j_temp)
       RETURN

--- a/THRIFT/Sources/thrift_penta.f90
+++ b/THRIFT/Sources/thrift_penta.f90
@@ -265,11 +265,11 @@
             J_spl%x1        = rho_temp
             J_spl%isHermite = 1
             CALL EZspline_setup(J_spl,J_temp,ier,EXACT_DIM=.true.)
-            !etapar
+            !etapar (make spline of log since etapar usually spans over orders of magnitude)
             CALL EZspline_init(eta_spl,ns_dkes+2,bcs0,ier)
             eta_spl%x1        = rho_temp
-            eta_spl%isHermite = 1
-            CALL EZspline_setup(eta_spl,eta_temp,ier,EXACT_DIM=.true.)
+            eta_spl%isHermite = 0
+            CALL EZspline_setup(eta_spl,LOG(eta_temp),ier,EXACT_DIM=.true.)
             !Er
             CALL EZspline_init(Er_spl,ns_dkes+2,bcs0,ier)
             Er_spl%x1        = rho_temp
@@ -282,7 +282,11 @@
             DO i = 1, nsj
                   rho = SQRT( THRIFT_S(i) )
                   CALL EZspline_interp(J_spl,rho,THRIFT_JBOOT(i,mytimestep),ier)
-                  IF( etapar_type == 'dkespenta') CALL EZspline_interp(eta_spl,rho,THRIFT_ETAPARA(i,mytimestep),ier)
+                  IF( etapar_type == 'dkespenta') THEN
+                        CALL EZspline_interp(eta_spl,rho,THRIFT_ETAPARA(i,mytimestep),ier)
+                        ! Need to take the exponential, since spline of log was done
+                        THRIFT_ETAPARA(i,mytimestep) = EXP(THRIFT_ETAPARA(i,mytimestep))
+                  END IF
                   CALL EZspline_interp(Er_spl,rho,THRIFT_ER(i,mytimestep),ier)
             END DO
             CALL EZspline_free(J_spl,ier)

--- a/pySTEL/libstell/thrift.py
+++ b/pySTEL/libstell/thrift.py
@@ -49,7 +49,50 @@ class THRIFT():
         self.set_arrays_attribute(*files) 
         
         # set units of quantities
-        self.set_units()       
+        self.set_units()
+        
+    def read_thrift_folder(self, folder_path):
+        """Reads THRIFT HDF5 files inside folder_path
+
+        Files should be named: output_<n>.h5, where <n> is a positive integer.
+        The function finds the minimum n and checks that files are consecutively
+        numbered with no gaps.
+
+        Parameters
+        ----------
+        folder_path : str
+            Path to folder containing output_#.h5 files.
+        """
+        import os
+        import re
+
+        # Match files like output_123.h5
+        pattern = re.compile(r"output_(\d+)\.h5$")
+        numbered_files = []
+
+        for file_name in os.listdir(folder_path):
+            match = pattern.match(file_name)
+            if match:
+                number = int(match.group(1))
+                full_path = os.path.join(folder_path, file_name)
+                if os.path.isfile(full_path):
+                    numbered_files.append((number, full_path))
+
+        if not numbered_files:
+            raise FileNotFoundError(f"No output_*.h5 files found in {folder_path}")
+
+        # Sort by output number
+        numbered_files.sort()
+        numbers, files = zip(*numbered_files)
+
+        # Check for sequential numbering
+        expected_numbers = list(range(min(numbers), max(numbers) + 1))
+        if list(numbers) != expected_numbers:
+            missing = sorted(set(expected_numbers) - set(numbers))
+            raise FileNotFoundError(f"Missing expected files: {', '.join(f'output_{n}.h5' for n in missing)}")
+
+        # read files
+        self.read_thrift(*files)
     
     def check_time_order(self,*files):
 

--- a/pySTEL/libstell/vmec.py
+++ b/pySTEL/libstell/vmec.py
@@ -420,6 +420,25 @@ class VMEC(FourierRep):
 				curpol = 2.0*self.bsubvmnc[self.ns-1,mn]*np.pi/self.nfp 
 		return curpol
 
+	def getCurrentToroidal(self):
+			"""Returns the toroidal total current
+
+			This routine returns the net toroidal current enclosed by
+			the LCFS
+
+			Returns
+			----------
+			curtor : float
+				Total toroidal current -2*pi*B_u(s=1,m=0,n=0)/mu0 [A]
+			"""
+			import numpy as np
+			curtor = -1
+			mu0 = 4*np.pi*1E-7
+			for mn in range(self.mnmax_nyq):
+				if (self.xm_nyq[mn]==0 and self.xn_nyq[mn]==0):
+					curtor = -2.0*np.pi*self.bsubumnc[self.ns-1,mn]/mu0
+			return curtor
+
 	def getiota(self,s):
 		"""Returns the rotational transform
 

--- a/pySTEL/libstell/vmec.py
+++ b/pySTEL/libstell/vmec.py
@@ -46,6 +46,7 @@ class VMEC(FourierRep):
 		self.vp = self.h2f(self.vp)
 		self.overr = self.h2f(self.overr)
 		self.specw = self.h2f(self.specw)
+		self.bdotb = self.h2f(self.bdotb)
 		for mn in range(self.mnmax):
 			self.lmns[:,mn] = self.h2fmn(self.lmns[:,mn],self.xm[mn])
 		for mn in range(self.mnmax_nyq):
@@ -495,14 +496,13 @@ class VMEC(FourierRep):
 
 		Returns
 		----------
-		iotap : float
-			Rotational Transform Derivative diota/ds [arb]
+		pressurep : float
+			Pressure Derivative dpressure/ds [Pa]
 		"""
 		import numpy as np
 		x = np.linspace(0,1,self.ns)
-		f = np.diff(np.squeeze(self.presf),prepend=0)*(self.ns-1)
+		f = np.gradient(np.squeeze(self.presf),x,edge_order=2)
 		return np.interp(s,x,f)
-
 
 	def getBcyl(self,R,phi,Z):
 		"""Wrapper to the GetBcyl_WOUT function


### PR DESCRIPTION
The main changes of this pull request are:

1) Edge boundary condition of `THRIFT` is changed to include a pprime term (diamagnetic) which was missing and is important to ensure that the simulation reaches the expected steady-state. This new BC follows equations (D8) and (D13) of Schmitt PhD Thesis

2) Spline of parallel resistivity coming from PENTA is made with the log. This improves the spline as etapar spans over several orders of magnitude

3) EparallelB is now correctly computed using Eqs. (3.61) , (3.64) and (3.65) of Schmitt thesis. Once again, the previous formula was relying on `THRIFT_JPLASMA` thus missing a pprime term

4) Improves `vmec.py` and `thrift.py`

