### PR TITLE
Inclusion of the LgradB metric in STELLOPT

### DIFF
--- a/LIBSTELL/Sources/Modules/stel_tools.f90
+++ b/LIBSTELL/Sources/Modules/stel_tools.f90
@@ -78,8 +78,11 @@
       DOUBLE PRECISION, PRIVATE ::  R_target, PHI_target, Z_target, S_MAX
       INTEGER, PRIVATE     ::  bcs0(2) = (/ 0, 0/)
       INTEGER, PRIVATE     ::  bcs1(2) = (/-1,-1/)
-      DOUBLE PRECISION, PARAMETER,PRIVATE      :: pi2 = 6.283185482025146D+00
-      DOUBLE PRECISION, PARAMETER,PRIVATE      :: one = 1.000000000000000D+00
+      DOUBLE PRECISION, PARAMETER,PRIVATE      :: pi2  = 6.283185482025146D+00
+      DOUBLE PRECISION, PARAMETER,PRIVATE      :: zero = 0.000000000000000D+00
+      DOUBLE PRECISION, PARAMETER,PRIVATE      :: half = 0.500000000000000D+00
+      DOUBLE PRECISION, PARAMETER,PRIVATE      :: one  = 1.000000000000000D+00
+      DOUBLE PRECISION, PARAMETER,PRIVATE      :: two  = 2.000000000000000D+00
       DOUBLE PRECISION, PARAMETER,PRIVATE      :: search_tol = 1.000000000000000D-12
       DOUBLE PRECISION, DIMENSION(:), POINTER, PRIVATE :: x1, x2, x3
       DOUBLE PRECISION, DIMENSION(:,:), POINTER, PRIVATE ::&
@@ -602,12 +605,12 @@
             ! <|grad(rho)|^2>
             grho2 = SUM(SUM(gs*f_temp,DIM=1),DIM=1)
             grho2 = grho2 / Vp
-            grho2(1) = 2*grho2(2) - grho2(3)
+            grho2(1) = two*grho2(2) - grho2(3)
             ! <|grad(rho)|>|
             gs = sqrt(gs) !|grad(rho)|
             grho = SUM(SUM(gs*f_temp,DIM=1),DIM=1)
             grho = grho / Vp
-            grho(1) = 2*grho(2) - grho(3)
+            grho(1) = two*grho(2) - grho(3)
             ! Construct splines
             CALL EZspline_setup(Vp_spl,ABS(Vp*pi2*pi2/(nu*nv)),iflag) ! ABS because of negative Jacobian
             CALL EZspline_setup(grho_spl,grho,iflag)
@@ -648,25 +651,25 @@
                               LV4D(1,:,:,:)*nfp*nfp
             f_temp = f_temp / G4D(1,:,:,:)
             grho   = SUM(SUM(f_temp(1:nu1,1:nv1,:),DIM=1),DIM=1)/(nu1*nv1)
-            grho(1) = 2*grho(2) - grho(3)
+            grho(1) = two*grho(2) - grho(3)
             CALL EZspline_setup(S22_spl,grho,iflag); f_temp = 0; grho = 0
             ! Bav
             f_temp = B4D(1,:,:,:)*G4D(1,:,:,:)
             grho   = SUM(SUM(f_temp,DIM=1),DIM=1)
             grho2 = grho / Vp
-            grho2(1) = 2*grho2(2) - grho2(3)
+            grho2(1) = two*grho2(2) - grho2(3)
             CALL EZspline_setup(Bav_spl,grho2,iflag); f_temp = 0; grho = 0
             ! Bsq
             f_temp = B4D(1,:,:,:)*B4D(1,:,:,:)*G4D(1,:,:,:)
             grho   = SUM(SUM(f_temp,DIM=1),DIM=1)
             grho2 = grho / Vp
-            grho2(1) = 2*grho2(2) - grho2(3)
+            grho2(1) = two*grho2(2) - grho2(3)
             CALL EZspline_setup(Bsq_spl,grho2,iflag); f_temp = 0; grho = 0
             ! B.V
             f_temp = BV4D(1,:,:,:)*G4D(1,:,:,:)
             grho   = SUM(SUM(f_temp,DIM=1),DIM=1)
             grho2 = grho / Vp
-            grho2(1) = 2*grho2(2) - grho2(3)
+            grho2(1) = two*grho2(2) - grho2(3)
             CALL EZspline_setup(BVav_spl,grho2,iflag); f_temp = 0; grho = 0
             ! PHI
             f_temp = BV4D(1,:,:,:)*G4D(1,:,:,:)
@@ -677,13 +680,13 @@
                         + ZU4D(1,:,:,:)*ZU4D(1,:,:,:)) * BU4D(1,:,:,:) &
                    +  (   RU4D(1,:,:,:)*RV4D(1,:,:,:) &
                         + ZU4D(1,:,:,:)*ZV4D(1,:,:,:)) * BV4D(1,:,:,:)*nfp
-            grho   = pi2*SUM(f_temp(:,1,:),DIM=1)/(nu1*pi2*2E-7) ! B_u
+            grho   = pi2*SUM(f_temp(:,1,:),DIM=1)/(nu1*pi2*2.0D-7) ! B_u
             CALL EZspline_setup(I_SPL,grho,iflag); f_temp = 0; grho = 0
             ! Rmajor
             f_temp = R4D(1,:,:,:)*G4D(1,:,:,:)
             grho   = SUM(SUM(f_temp,DIM=1),DIM=1)
             grho2 = grho / Vp
-            grho2(1) = 2*grho2(2) - grho2(3)
+            grho2(1) = two*grho2(2) - grho2(3)
             CALL EZspline_setup(RMAJ_spl,grho2,iflag); f_temp = 0; grho = 0
             ! Volume
             grho = [(sum(Vp(1:u)),u=1,size(Vp))]
@@ -695,7 +698,7 @@
             grho   = BSQ_SPL%fspl(1,:)
             f_temp = B4D(1,:,:,:)*B4D(1,:,:,:)
             grho2 = grho / MAXVAL(MAXVAL(f_temp,DIM=1),DIM=1)
-            grho2(1) = 2*grho2(2) - grho2(3) ! Grho2 is <B^2/B_max^2>
+            grho2(1) = two*grho2(2) - grho2(3) ! Grho2 is <B^2/B_max^2>
             ! Now do lambda
             IF (ALLOCATED(fmn_temp)) DEALLOCATE(fmn_temp)
             ALLOCATE(fmn_temp(nlambda,k1:k2))
@@ -712,7 +715,7 @@
             END DO
             grho = SUM(fmn_temp,DIM=1)*dlambda
             grho2 = one - 0.75*grho2*Vp*grho
-            grho2(1) = 2*grho2(2) - grho2(3)
+            grho2(1) = two*grho2(2) - grho2(3)
             CALL EZspline_setup(FTRAP_spl,grho2,iflag); f_temp = 0; grho = 0
 
             ! Deallocate arrays
@@ -1164,7 +1167,7 @@
          FORALL(mn = k1:k2) f_temp(:,:,mn) = ru_e(:,:,mn) + rho(mn)*ru_o(:,:,mn) 
          ru12 = 0;
          DO mn = k1p,k2
-            ru12(:,:,mn) = (f_temp(:,:,mn)+f_temp(:,:,mn-1))*0.5
+            ru12(:,:,mn) = (f_temp(:,:,mn)+f_temp(:,:,mn-1))*half
          END DO
          ru12(:,:,k1)=ru12(:,:,k1p)
          CALL EZspline_setup(Ru_spl,f_temp,iflag); f_temp = 0
@@ -1173,7 +1176,7 @@
          FORALL(mn = k1:k2) f_temp(:,:,mn) = zu_e(:,:,mn) + rho(mn)*zu_o(:,:,mn) 
          zu12 = 0;
          DO mn = k1p,k2
-            zu12(:,:,mn) = (f_temp(:,:,mn)+f_temp(:,:,mn-1))*0.5
+            zu12(:,:,mn) = (f_temp(:,:,mn)+f_temp(:,:,mn-1))*half
          END DO
          zu12(:,:,k1)=zu12(:,:,k1p)
          CALL EZspline_setup(Zu_spl,f_temp,iflag); f_temp = 0
@@ -1246,17 +1249,17 @@
             f_temp(:,:,mn) = f_temp(:,:,mn) - zu12(:,:,mn)*rs(:,:,mn)&
                            - 0.25*(   zu_o(:,:,mn)*r_o(:,:,mn) + zu_o(:,:,mn-1)*r_o(:,:,mn-1) &
                                    + (zu_e(:,:,mn)*r_o(:,:,mn) + zu_e(:,:,mn-1)*r_o(:,:,mn-1))*rhoinv(mn))
-            f_temp(:,:,mn) = 0.5*(R4D(1,:,:,mn) + R4D(1,:,:,mn-1))*f_temp(:,:,mn)
+            f_temp(:,:,mn) = half*(R4D(1,:,:,mn) + R4D(1,:,:,mn-1))*f_temp(:,:,mn)
          END DO
          f_temp(:,:,k1) = f_temp(:,:,k1p)
 
          ! Put on full grid
          ! From the half grid (2:ns) just average to (2:ns-1)
-         f_temp(:,:,k1p:k2-1) = 0.5*(f_temp(:,:,k1p:k2-1)+f_temp(:,:,k1p+1:k2))
-         f_temp(:,:,k2) = 2.0*f_temp(:,:,k2) - f_temp(:,:,k2-1) ! Extrapolate to edge
+         f_temp(:,:,k1p:k2-1) = half*(f_temp(:,:,k1p:k2-1)+f_temp(:,:,k1p+1:k2))
+         f_temp(:,:,k2) = two*f_temp(:,:,k2) - f_temp(:,:,k2-1) ! Extrapolate to edge
          !This works but is probably not the correct way to extrapolate near the axis
-         f_temp(:,:,k1p) = 2*f_temp(:,:,k1p+1) - f_temp(:,:,k1p+2)
-         f_temp(:,:,k1) = 2*f_temp(:,:,k1p) - f_temp(:,:,k1p+1)
+         f_temp(:,:,k1p) = two*f_temp(:,:,k1p+1) - f_temp(:,:,k1p+2)
+         f_temp(:,:,k1) = two*f_temp(:,:,k1p) - f_temp(:,:,k1p+1)
 
          ! Create Spline
          CALL EZspline_setup(G_spl,f_temp,iflag); f_temp = 0
@@ -1369,12 +1372,12 @@
          ! <|grad(rho)|^2>
          grho2 = SUM(SUM(gs*f_temp,DIM=1),DIM=1)
          grho2 = grho2 / Vp
-         grho2(1) = 2*grho2(2) - grho2(3)
+         grho2(1) = two*grho2(2) - grho2(3)
          ! <|grad(rho|>|
          gs = sqrt(gs) !|grad(rho)|
          grho = SUM(SUM(gs*f_temp,DIM=1),DIM=1)
          grho = grho / Vp
-         grho(1) = 2*grho(2) - grho(3)
+         grho(1) = two*grho(2) - grho(3)
          ! Construct splines
          CALL EZspline_setup(Vp_spl,ABS(Vp*pi2*pi2/(nu*nv)),iflag) ! ABS because of negative Jacobian
          CALL EZspline_setup(grho_spl,grho,iflag)
@@ -1417,13 +1420,13 @@
          f_temp = B4D(1,:,:,:)*G4D(1,:,:,:)
          grho   = SUM(SUM(f_temp,DIM=1),DIM=1)
          grho2 = grho / Vp
-         grho2(1) = 2*grho2(2) - grho2(3)
+         grho2(1) = two*grho2(2) - grho2(3)
          CALL EZspline_setup(Bav_spl,grho2,iflag); f_temp = 0; grho = 0
          ! Bsq
          f_temp = B4D(1,:,:,:)*B4D(1,:,:,:)*G4D(1,:,:,:)
          grho   = SUM(SUM(f_temp,DIM=1),DIM=1)
          grho2 = grho / Vp
-         grho2(1) = 2*grho2(2) - grho2(3)
+         grho2(1) = two*grho2(2) - grho2(3)
          CALL EZspline_setup(Bsq_spl,grho2,iflag); f_temp = 0; grho = 0
          ! PHI
          f_temp = BV4D(1,:,:,:)*G4D(1,:,:,:)
@@ -1434,13 +1437,13 @@
                      + ZU4D(1,:,:,:)*ZU4D(1,:,:,:)) * BU4D(1,:,:,:) &
                 +  (   RU4D(1,:,:,:)*RV4D(1,:,:,:) &
                      + ZU4D(1,:,:,:)*ZV4D(1,:,:,:)) * BV4D(1,:,:,:)*nfp
-         grho   = pi2*SUM(f_temp(:,1,:),DIM=1)/(nu1*pi2*2E-7) ! B_u
+         grho   = pi2*SUM(f_temp(:,1,:),DIM=1)/(nu1*pi2*2.0D-7) ! B_u
          CALL EZspline_setup(I_SPL,grho,iflag); f_temp = 0; grho = 0
          ! Rmajor
          f_temp = R4D(1,:,:,:)*G4D(1,:,:,:)
          grho   = SUM(SUM(f_temp,DIM=1),DIM=1)
          grho2 = grho / Vp
-         grho2(1) = 2*grho2(2) - grho2(3)
+         grho2(1) = two*grho2(2) - grho2(3)
          CALL EZspline_setup(RMAJ_spl,grho2,iflag); f_temp = 0; grho = 0
          ! Volume
          grho = [(sum(Vp(1:u)),u=1,size(Vp))]
@@ -1544,7 +1547,7 @@
       IF (x(2) < 0.0) x(2) = x(2) + pi2
       IF (x(1) < 0) THEN
          x(1) = ABS(x(1))
-         x(2) = x(2)+pi2*0.5
+         x(2) = x(2)+pi2*half
          x(2) = MOD(x(2),pi2)
       END IF
       ier = 0; domain_flag = 0
@@ -1716,8 +1719,8 @@
          IF ((info > 0) .AND. (info < 4)) ier = 0
          IF (domain_flag .ne. 0) THEN
             ier = 9
-            s_val = S_MAX+0.5
-            IF (PRESENT(u_val)) u_val = 2*pi2
+            s_val = S_MAX+half
+            IF (PRESENT(u_val)) u_val = two*pi2
             RETURN
          END IF
          s_val = xc_opt(1)*xc_opt(1)
@@ -2047,7 +2050,7 @@
          Rmajor = fval(1);
          CALL r8fvspline(ict,1,1,fval,k,zparam,hz,hzi,VOL2D(1,1),nx3)
          Vol = fval(1);
-         Aminor = SQRT(2*Vol/(pi2*pi2*Rmajor))
+         Aminor = SQRT(two*Vol/(pi2*pi2*Rmajor))
       ELSE
          ier=-1
       END IF
@@ -2471,7 +2474,7 @@
       DOUBLE PRECISION :: s_val, u_val, v_val, br, bphi
       DOUBLE PRECISION :: R_grad(3), Z_grad(3)
       IF (ier < 0) RETURN
-      s_val = 0.5
+      s_val = half
       CALL get_equil_s(r_val,phi_val,z_val,s_val,ier,u_val)
       IF (ier < 0) RETURN
       v_val = PHI_target
@@ -2529,7 +2532,7 @@
       Br = 0; Bphi = 0; Bz =0
       R_grad = 0; Z_grad = 0
       u_val = ATAN2(z_val,r_val)
-      s_val = 0.5
+      s_val = half
       CALL get_equil_s(r_val,phi_val,z_val,s_val,ier,u_val)
       IF (ier < 0) RETURN
       v_val = PHI_target
@@ -2710,7 +2713,7 @@
          !CALL EZspline_interp(Vp_spl,rho_val,vp_val,ier)
          CALL r8fvspline(ict1,1,1,fval,k,zparam,hz,hzi,VP2D(1,1),nx3)
          vp_val = fval(1,1)
-         Bsqavp_val = 2*rho_val*Bsqavp_val/vp_val  ! d/dV = (dPhi/drho)*(dV/dPhi)^-1 * d/drho
+         Bsqavp_val = two*rho_val*Bsqavp_val/vp_val  ! d/dV = (dPhi/drho)*(dV/dPhi)^-1 * d/drho
       END IF
       IF (PRESENT(Bvav_val)) THEN
          CALL r8fvspline(ict1,1,1,fval,k,zparam,hz,hzi,BVAV2D(1,1),nx3)
@@ -2794,7 +2797,7 @@
          dlam = fval(1)
          dth = -(th + lam - th1)/(one+dlam)
          n1 = n1 + 1
-         th = th + 0.5*dth
+         th = th + half*dth
       END DO
       coord(1) = s
       coord(2) = th
@@ -2811,16 +2814,18 @@
       RETURN
       END SUBROUTINE pest2vmec_sgl
       
-      SUBROUTINE get_equil_LgradB_dbl(s_val,u_val,v_val,lgradB,ier)
+      SUBROUTINE get_equil_LgradB_dbl(s_val,u_val,v_val,lgradB,ier,R_out,Z_out)
       USE EZspline
       IMPLICIT NONE
       DOUBLE PRECISION, INTENT(in)    ::  s_val
       DOUBLE PRECISION, INTENT(in)    ::  u_val
       DOUBLE PRECISION, INTENT(in)    ::  v_val
       DOUBLE PRECISION, INTENT(out)   ::  lgradB
+      DOUBLE PRECISION, INTENT(out), OPTIONAL   ::  R_out
+      DOUBLE PRECISION, INTENT(out), OPTIONAL   ::  Z_out
       INTEGER, INTENT(inout)     ::  ier
       DOUBLE PRECISION :: rho_val, drhods
-      DOUBLE PRECISION :: R, Z, sqrtG
+      DOUBLE PRECISION :: R, Z, sqrtG, cop, sip, gradB_norm
       DOUBLE PRECISION, DIMENSION(3) :: Rgrad, Zgrad
       DOUBLE PRECISION :: dRduu, dRdvv, dRdss
       DOUBLE PRECISION :: dRduv, dRdus, dRdvs
@@ -2829,9 +2834,18 @@
       DOUBLE PRECISION :: gradsR,gradsP,gradsZ
       DOUBLE PRECISION :: graduR,graduP,graduZ
       DOUBLE PRECISION :: gradvR,gradvP,gradvZ
+      DOUBLE PRECISION :: gradsX,gradsY
+      DOUBLE PRECISION :: graduX,graduY
+      DOUBLE PRECISION :: gradvX,gradvY
       DOUBLE PRECISION :: bs, bsds, bsdu, bsdv
       DOUBLE PRECISION :: bu, buds, budu, budv
       DOUBLE PRECISION :: bv, bvds, bvdu, bvdv
+      DOUBLE PRECISION :: dBxds, dBxdu, dBxdv
+      DOUBLE PRECISION :: dByds, dBydu, dBydv
+      DOUBLE PRECISION :: dBzds, dBzdu, dBzdv
+      DOUBLE PRECISION :: dBxdx, dBxdy, dBxdz
+      DOUBLE PRECISION :: dBydx, dBydy, dBydz
+      DOUBLE PRECISION :: dBzdx, dBzdy, dBzdz
       INTEGER :: i,j,k
       REAL*8 :: xparam, yparam, zparam, hx, hy, hz, hxi, hyi, hzi
       REAL*8 :: fval1(1)
@@ -2842,12 +2856,12 @@
       INTEGER, parameter :: ict2(10)=(/0,1,1,1,0,0,0,0,0,0/)
       INTEGER, parameter :: ict3(10)=(/1,1,1,1,0,0,0,0,0,0/)
       INTEGER, parameter :: ict4(10)=(/1,1,1,1,1,1,1,1,1,1/)
-      lgradB = 0.0
+      lgradB = zero
       IF (ier < 0) RETURN
       rho_val = SQRT(s_val)
       drhods = one/rho_val
-      cop = DCOS(v/nfp)
-      sip = DSIN(v/nfp)
+      cop = DCOS(v_val/nfp)
+      sip = DSIN(v_val/nfp)
       ! Get grid values
       CALL lookupgrid3d(u_val,v_val,rho_val,i,j,k,hx,hy,hz,hxi,hyi,hzi,xparam,yparam,zparam)
       CALL r8fvtricub(ict4, 1, 1, fval4, i, j, k, xparam, yparam, zparam, &
@@ -2856,51 +2870,92 @@
       R = fval4(1,1); Rgrad(1) = fval4(1,2); Rgrad(2) = fval4(1,3); Rgrad(3) = fval4(1,4)
       dRduu = fval4(1,5); dRdvv = fval4(1,6); dRdss = fval4(1,7)
       dRduv = fval4(1,8); dRdus = fval4(1,9); dRdvs = fval4(1,10)
+      ! All our toroidal deriviatives are d/dv not d/dphi
+      ! phi = v_val/nfp so dv/dphi = nfp
+      dRdss = dRdss * drhods * drhods; dRdus = dRdus * drhods; dRdvs = dRdvs * drhods
+      dRdvv = dRdvv * nfp * nfp; dRduv = dRduv * nfp; dRdvs = dRdvs * nfp
+      Rgrad(2) = Rgrad(2) * nfp; Rgrad(3) = Rgrad(3) * drhods
       CALL r8fvtricub(ict4, 1, 1, fval4, i, j, k, xparam, yparam, zparam, &
                       hx, hxi, hy, hyi, hz, hzi, &
                       Z4D(1,1,1,1), nx1, nx2, nx3)
       Z = fval4(1,1); Zgrad(1) = fval4(1,2); Zgrad(2) = fval4(1,3); Zgrad(3) = fval4(1,4)
       dZduu = fval4(1,5); dZdvv = fval4(1,6); dZdss = fval4(1,7)
       dZduv = fval4(1,8); dZdus = fval4(1,9); dZdvs = fval4(1,10)
+      dZdss = dZdss * drhods * drhods; dZdus = dZdus * drhods; dZdvs = dZdvs * drhods
+      dZdvv = dZdvv * nfp * nfp; dZduv = dZduv * nfp; dZdvs = dZdvs * nfp
+      Zgrad(2) = Zgrad(2) * nfp; Zgrad(3) = Zgrad(3) * drhods
       CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
                       hx, hxi, hy, hyi, hz, hzi, &
                       BS4D(1,1,1,1), nx1, nx2, nx3)
-      bs = fval3(1,1); bsdu = fval3(1,2); bsdv = fval3(1,3); bsds = fval3(1,4)
+      bs = fval3(1,1); bsdu = fval3(1,2); bsdv = fval3(1,3) * nfp; bsds = fval3(1,4) * drhods
       CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
                       hx, hxi, hy, hyi, hz, hzi, &
                       BU4D(1,1,1,1), nx1, nx2, nx3)
-      bu = fval3(1,1); budu = fval3(1,2); budv = fval3(1,3); buds = fval3(1,4)
+      bu = fval3(1,1); budu = fval3(1,2); budv = fval3(1,3) * nfp; buds = fval3(1,4) * drhods
       CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
                       hx, hxi, hy, hyi, hz, hzi, &
                       BV4D(1,1,1,1), nx1, nx2, nx3)
-      bv = fval3(1,1); bvdu = fval3(1,2); bvdv = fval3(1,3); bvds = fval3(1,4)
+      bv = fval3(1,1); bvdu = fval3(1,2); bvdv = fval3(1,3) * nfp; bvds = fval3(1,4) * drhods
       CALL r8fvtricub(ict1, 1, 1, fval1, i, j, k, xparam, yparam, zparam, &
                       hx, hxi, hy, hyi, hz, hzi, &
                       G4D(1,1,1,1), nx1, nx2, nx3)
-      sqrtG = fval1(1,1)
+      sqrtG = fval1(1)
       ! Compute the grad values
       gradsR = -Zgrad(1)*R/sqrtG
       gradsP =  (Rgrad(2)*Zgrad(1)-Rgrad(1)*Zgrad(2))/sqrtG
       gradsZ =  Rgrad(1)*R/sqrtG
-      graduR = -Rgrad(3)*R*drhods/sqrtG
-      graduP =  (Rgrad(3)*Zgrad(2)-Rgrad(2)*Zgrad(3))*drhods/sqrtG
-      graduZ =  Zgrad(3)*R*drhods/sqrtG
-      gradvR =  0.0_rprec
-      gradvP =  1.0_rprec/(R*sqrtG)
-      gradvZ =  0.0_rprec
+      graduR = -Rgrad(3)*R/sqrtG
+      graduP =  (Rgrad(3)*Zgrad(2)-Rgrad(2)*Zgrad(3))/sqrtG
+      graduZ =  Zgrad(3)*R/sqrtG
+      gradvR =  zero
+      gradvP =  one/(R*sqrtG)
+      gradvZ =  zero
+      gradsX =  gradsR * cop - gradsP * sip 
+      gradsY =  gradsP * cop + gradsR * sip
+      graduX =  graduR * cop - graduP * sip 
+      graduY =  graduP * cop + graduR * sip
+      gradvX =  gradvR * cop - gradvP * sip 
+      gradvY =  gradvP * cop + gradvR * sip
       ! Compute the derivatives
       dBxds = buds * Rgrad(1) * cop + bu * dRdus * cop + bvds * Rgrad(2) * cop &
               + bv * dRdvs * cop - bvds * R * sip - bv * Rgrad(3) * sip
       dBxdu = budu * Rgrad(1) * cop + bu * dRduu * cop + bvdu * Rgrad(2) * cop &
               + bv * dRduv * cop - bvdu * R * sip - bv * Rgrad(1) * sip
-      !dBxdv = budv * Rgrad(1) * cop + bu * dRduv * cop + bvdv * Rgrad(2) * cop &
-      !        + bv * dRduv * cop - bvdu * R * sip - bv * Rgrad(1) * sip
-
-
+      dBxdv =   budv * Rgrad(1) * cop + bu * dRduv * cop - bu * Rgrad(1) * sip &
+              + bvdv * Rgrad(2) * cop + bv * dRdvv * cop - bv * Rgrad(2) * sip &
+              - bvdv * R * sip - bv * Rgrad(2) * cop - bv * R * cop
+      dByds = buds * Rgrad(1) * sip + bu * dRdus * sip + bvds * Rgrad(2) * sip &
+              + bv * dRdvs * sip + bvds * R * cop + bv * Rgrad(3) * cop
+      dBydu = budu * Rgrad(1) * sip + bu * dRduu * sip + bvdu * Rgrad(2) * sip &
+              + bv * dRduv * sip + bvdu * R * cop + bv * Rgrad(1) * cop
+      dBydv =   budv * Rgrad(1) * sip + bu * dRduv * sip + bu * Rgrad(1) * cop &
+              + bvdv * Rgrad(2) * sip + bv * dRdvv * sip + bv * Rgrad(2) * cop &
+              + bvdv * R * cop + bv * Rgrad(2) * sip + bv * R * sip
+      dBzds = buds * Zgrad(1) + bu * dZdus + bvds * Zgrad(2) + bv * dZdvs
+      dBzdu = budu * Zgrad(1) + bu * dZduu + bvdu * Zgrad(2) + bv * dZduv
+      dBzdv = budv * Zgrad(1) + bu * dZduv + bvdv * Zgrad(2) + bv * dZdvv
+      ! Now compute the grad(B) in cartesian coordinates
+      dBxdx = dBxds * gradsX + dBxdu * graduX + dBxdv * gradvZ
+      dBxdy = dBxds * gradsY + dBxdu * graduY + dBxdv * gradvY
+      dBxdz = dBxds * gradsZ + dBxdu * graduZ + dBxdv * gradvZ
+      dBydx = dByds * gradsX + dBydu * graduX + dBydv * gradvZ
+      dBydy = dByds * gradsY + dBydu * graduY + dBydv * gradvY
+      dBydz = dByds * gradsZ + dBydu * graduZ + dBydv * gradvZ
+      dBzdx = dBzds * gradsX + dBzdu * graduX + dBzdv * gradvZ
+      dBzdy = dBzds * gradsY + dBzdu * graduY + dBzdv * gradvY
+      dBzdz = dBzds * gradsZ + dBzdu * graduZ + dBzdv * gradvZ
+      ! Now compute the Frobenius norm of grad(B)
+      gradB_norm = DSQRT (   dBxdx * dBxdx + dBxdy * dBxdy + dBxdz * dBxdz &
+                           + dBydx * dBydx + dBydy * dBydy + dBydz * dBydz &
+                           + dBzdx * dBzdx + dBzdy * dBzdy + dBzdz * dBzdz )
+      ! And finally LgradB
+      lgradB = DSQRT(two * (bs*bs+bu*bu+bv*bv)) / gradB_norm
+      IF (PRESENT(R_out)) R_out = R
+      IF (PRESENT(Z_out)) Z_out = Z
       RETURN
       END SUBROUTINE get_equil_LgradB_dbl
       
-      SUBROUTINE get_equil_LgradB_sgl(s_val,u_val,v_val,lgradB,ier)
+      SUBROUTINE get_equil_LgradB_sgl(s_val,u_val,v_val,lgradB,ier,R_out,Z_out)
       USE EZspline
       IMPLICIT NONE
       REAL, INTENT(in)    ::  s_val
@@ -2908,13 +2963,19 @@
       REAL, INTENT(in)    ::  v_val
       REAL, INTENT(out)   ::  lgradB
       INTEGER, INTENT(inout)     ::  ier
+      REAL, INTENT(out), OPTIONAL   ::  R_out
+      REAL, INTENT(out), OPTIONAL   ::  Z_out
       DOUBLE PRECISION    ::  s_dbl
       DOUBLE PRECISION    ::  u_dbl
       DOUBLE PRECISION    ::  v_dbl
       DOUBLE PRECISION   ::  lgradB_dbl
+      DOUBLE PRECISION   ::  R_dbl
+      DOUBLE PRECISION   ::  Z_dbl
       s_dbl = s_val; u_dbl = u_val; v_dbl = v_val;
-      CALL get_equil_LgradB_dbl(s_dbl,u_dbl,v_dbl,lgradB_dbl,ier)
+      CALL get_equil_LgradB_dbl(s_dbl,u_dbl,v_dbl,lgradB_dbl,ier,R_out=R_dbl,Z_out=Z_dbl)
       lgradB = lgradB_dbl
+      IF (PRESENT(R_out)) R_out = R_dbl
+      IF (PRESENT(Z_out)) Z_out = Z_dbl
       RETURN
       END SUBROUTINE get_equil_LgradB_sgl
       

--- a/LIBSTELL/Sources/Modules/stel_tools.f90
+++ b/LIBSTELL/Sources/Modules/stel_tools.f90
@@ -159,6 +159,9 @@
       INTERFACE get_equil_ftrap
          MODULE PROCEDURE get_equil_ftrap_dbl, get_equil_ftrap_sgl
       END INTERFACE
+      INTERFACE get_equil_LgradB
+         MODULE PROCEDURE get_equil_LgradB_dbl, get_equil_LgradB_sgl
+      END INTERFACE
 !      INTERFACE get_equil_iota
 !         MODULE PROCEDURE get_equil_iota_dbl, get_equil_iota_sgl
 !      END INTERFACE
@@ -2807,6 +2810,113 @@
       coord = coord_dbl
       RETURN
       END SUBROUTINE pest2vmec_sgl
+      
+      SUBROUTINE get_equil_LgradB_dbl(s_val,u_val,v_val,lgradB,ier)
+      USE EZspline
+      IMPLICIT NONE
+      DOUBLE PRECISION, INTENT(in)    ::  s_val
+      DOUBLE PRECISION, INTENT(in)    ::  u_val
+      DOUBLE PRECISION, INTENT(in)    ::  v_val
+      DOUBLE PRECISION, INTENT(out)   ::  lgradB
+      INTEGER, INTENT(inout)     ::  ier
+      DOUBLE PRECISION :: rho_val, drhods
+      DOUBLE PRECISION :: R, Z, sqrtG
+      DOUBLE PRECISION, DIMENSION(3) :: Rgrad, Zgrad
+      DOUBLE PRECISION :: dRduu, dRdvv, dRdss
+      DOUBLE PRECISION :: dRduv, dRdus, dRdvs
+      DOUBLE PRECISION :: dZduu, dZdvv, dZdss
+      DOUBLE PRECISION :: dZduv, dZdus, dZdvs
+      DOUBLE PRECISION :: gradsR,gradsP,gradsZ
+      DOUBLE PRECISION :: graduR,graduP,graduZ
+      DOUBLE PRECISION :: gradvR,gradvP,gradvZ
+      DOUBLE PRECISION :: bs, bsds, bsdu, bsdv
+      DOUBLE PRECISION :: bu, buds, budu, budv
+      DOUBLE PRECISION :: bv, bvds, bvdu, bvdv
+      INTEGER :: i,j,k
+      REAL*8 :: xparam, yparam, zparam, hx, hy, hz, hxi, hyi, hzi
+      REAL*8 :: fval1(1)
+      REAL*8 :: fval2(1,3)
+      REAL*8 :: fval3(1,4)
+      REAL*8 :: fval4(1,10)
+      INTEGER, parameter :: ict1(10)=(/1,0,0,0,0,0,0,0,0,0/)
+      INTEGER, parameter :: ict2(10)=(/0,1,1,1,0,0,0,0,0,0/)
+      INTEGER, parameter :: ict3(10)=(/1,1,1,1,0,0,0,0,0,0/)
+      INTEGER, parameter :: ict4(10)=(/1,1,1,1,1,1,1,1,1,1/)
+      lgradB = 0.0
+      IF (ier < 0) RETURN
+      rho_val = SQRT(s_val)
+      drhods = one/rho_val
+      cop = DCOS(v/nfp)
+      sip = DSIN(v/nfp)
+      ! Get grid values
+      CALL lookupgrid3d(u_val,v_val,rho_val,i,j,k,hx,hy,hz,hxi,hyi,hzi,xparam,yparam,zparam)
+      CALL r8fvtricub(ict4, 1, 1, fval4, i, j, k, xparam, yparam, zparam, &
+                      hx, hxi, hy, hyi, hz, hzi, &
+                      R4D(1,1,1,1), nx1, nx2, nx3)
+      R = fval4(1,1); Rgrad(1) = fval4(1,2); Rgrad(2) = fval4(1,3); Rgrad(3) = fval4(1,4)
+      dRduu = fval4(1,5); dRdvv = fval4(1,6); dRdss = fval4(1,7)
+      dRduv = fval4(1,8); dRdus = fval4(1,9); dRdvs = fval4(1,10)
+      CALL r8fvtricub(ict4, 1, 1, fval4, i, j, k, xparam, yparam, zparam, &
+                      hx, hxi, hy, hyi, hz, hzi, &
+                      Z4D(1,1,1,1), nx1, nx2, nx3)
+      Z = fval4(1,1); Zgrad(1) = fval4(1,2); Zgrad(2) = fval4(1,3); Zgrad(3) = fval4(1,4)
+      dZduu = fval4(1,5); dZdvv = fval4(1,6); dZdss = fval4(1,7)
+      dZduv = fval4(1,8); dZdus = fval4(1,9); dZdvs = fval4(1,10)
+      CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
+                      hx, hxi, hy, hyi, hz, hzi, &
+                      BS4D(1,1,1,1), nx1, nx2, nx3)
+      bs = fval3(1,1); bsdu = fval3(1,2); bsdv = fval3(1,3); bsds = fval3(1,4)
+      CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
+                      hx, hxi, hy, hyi, hz, hzi, &
+                      BU4D(1,1,1,1), nx1, nx2, nx3)
+      bu = fval3(1,1); budu = fval3(1,2); budv = fval3(1,3); buds = fval3(1,4)
+      CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
+                      hx, hxi, hy, hyi, hz, hzi, &
+                      BV4D(1,1,1,1), nx1, nx2, nx3)
+      bv = fval3(1,1); bvdu = fval3(1,2); bvdv = fval3(1,3); bvds = fval3(1,4)
+      CALL r8fvtricub(ict1, 1, 1, fval1, i, j, k, xparam, yparam, zparam, &
+                      hx, hxi, hy, hyi, hz, hzi, &
+                      G4D(1,1,1,1), nx1, nx2, nx3)
+      sqrtG = fval1(1,1)
+      ! Compute the grad values
+      gradsR = -Zgrad(1)*R/sqrtG
+      gradsP =  (Rgrad(2)*Zgrad(1)-Rgrad(1)*Zgrad(2))/sqrtG
+      gradsZ =  Rgrad(1)*R/sqrtG
+      graduR = -Rgrad(3)*R*drhods/sqrtG
+      graduP =  (Rgrad(3)*Zgrad(2)-Rgrad(2)*Zgrad(3))*drhods/sqrtG
+      graduZ =  Zgrad(3)*R*drhods/sqrtG
+      gradvR =  0.0_rprec
+      gradvP =  1.0_rprec/(R*sqrtG)
+      gradvZ =  0.0_rprec
+      ! Compute the derivatives
+      dBxds = buds * Rgrad(1) * cop + bu * dRdus * cop + bvds * Rgrad(2) * cop &
+              + bv * dRdvs * cop - bvds * R * sip - bv * Rgrad(3) * sip
+      dBxdu = budu * Rgrad(1) * cop + bu * dRduu * cop + bvdu * Rgrad(2) * cop &
+              + bv * dRduv * cop - bvdu * R * sip - bv * Rgrad(1) * sip
+      !dBxdv = budv * Rgrad(1) * cop + bu * dRduv * cop + bvdv * Rgrad(2) * cop &
+      !        + bv * dRduv * cop - bvdu * R * sip - bv * Rgrad(1) * sip
+
+
+      RETURN
+      END SUBROUTINE get_equil_LgradB_dbl
+      
+      SUBROUTINE get_equil_LgradB_sgl(s_val,u_val,v_val,lgradB,ier)
+      USE EZspline
+      IMPLICIT NONE
+      REAL, INTENT(in)    ::  s_val
+      REAL, INTENT(in)    ::  u_val
+      REAL, INTENT(in)    ::  v_val
+      REAL, INTENT(out)   ::  lgradB
+      INTEGER, INTENT(inout)     ::  ier
+      DOUBLE PRECISION    ::  s_dbl
+      DOUBLE PRECISION    ::  u_dbl
+      DOUBLE PRECISION    ::  v_dbl
+      DOUBLE PRECISION   ::  lgradB_dbl
+      s_dbl = s_val; u_dbl = u_val; v_dbl = v_val;
+      CALL get_equil_LgradB_dbl(s_dbl,u_dbl,v_dbl,lgradB_dbl,ier)
+      lgradB = lgradB_dbl
+      RETURN
+      END SUBROUTINE get_equil_LgradB_sgl
       
       SUBROUTINE line_int_dbl(fcn,r1,r2,val,length)
       IMPLICIT NONE

--- a/LIBSTELL/Sources/Modules/stel_tools.f90
+++ b/LIBSTELL/Sources/Modules/stel_tools.f90
@@ -2904,8 +2904,6 @@
       CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
                       hx, hxi, hy, hyi, hz, hzi, &
                       BV4D(1,1,1,1), nx1, nx2, nx3)
-      !PRINT *,'BV4D'
-      !PRINT *,BV4D(1,1,1,:)
       bv = fval3(1,1); bvdu = fval3(1,2); bvdv = fval3(1,3) * nfp; bvds = fval3(1,4) * drhods
       !PRINT *,'  X,dXds,dXdu,dXdv'
       !PRINT *,'R ',R,dRds,dRdu,dRdv
@@ -2914,7 +2912,7 @@
       !PRINT *,'Bu',bu,buds,budu,budv
       !PRINT *,'Bv',bv,bvds,bvdu,bvdv
       ! sqrt(g)
-      sqrtG = - R * (dRdu*dZds - dRds*dZdu)
+      sqrtG = R * (dRdu*dZds - dRds*dZdu)
       !PRINT *,'sqrt(G)',sqrtG
       ! Compute the grad values
       gradsR = -dZdu*R/sqrtG

--- a/LIBSTELL/Sources/Modules/stel_tools.f90
+++ b/LIBSTELL/Sources/Modules/stel_tools.f90
@@ -2826,7 +2826,8 @@
       INTEGER, INTENT(inout)     ::  ier
       DOUBLE PRECISION :: rho_val, drhods
       DOUBLE PRECISION :: R, Z, sqrtG, cop, sip, gradB_norm
-      DOUBLE PRECISION, DIMENSION(3) :: Rgrad, Zgrad
+      DOUBLE PRECISION :: dRdu, dRdv, dRds
+      DOUBLE PRECISION :: dZdu, dZdv, dZds
       DOUBLE PRECISION :: dRduu, dRdvv, dRdss
       DOUBLE PRECISION :: dRduv, dRdus, dRdvs
       DOUBLE PRECISION :: dZduu, dZdvv, dZdss
@@ -2837,7 +2838,7 @@
       DOUBLE PRECISION :: gradsX,gradsY
       DOUBLE PRECISION :: graduX,graduY
       DOUBLE PRECISION :: gradvX,gradvY
-      DOUBLE PRECISION :: bs, bsds, bsdu, bsdv
+      !DOUBLE PRECISION :: bs, bsds, bsdu, bsdv
       DOUBLE PRECISION :: bu, buds, budu, budv
       DOUBLE PRECISION :: bv, bvds, bvdu, bvdv
       DOUBLE PRECISION :: dBxds, dBxdu, dBxdv
@@ -2858,8 +2859,8 @@
       INTEGER, parameter :: ict4(10)=(/1,1,1,1,1,1,1,1,1,1/)
       lgradB = zero
       IF (ier < 0) RETURN
-      rho_val = SQRT(s_val)
-      drhods = one/rho_val
+      rho_val = DSQRT(s_val)
+      drhods = one/(two*rho_val)
       cop = DCOS(v_val/nfp)
       sip = DSIN(v_val/nfp)
       ! Get grid values
@@ -2867,49 +2868,68 @@
       CALL r8fvtricub(ict4, 1, 1, fval4, i, j, k, xparam, yparam, zparam, &
                       hx, hxi, hy, hyi, hz, hzi, &
                       R4D(1,1,1,1), nx1, nx2, nx3)
-      R = fval4(1,1); Rgrad(1) = fval4(1,2); Rgrad(2) = fval4(1,3); Rgrad(3) = fval4(1,4)
+      R = fval4(1,1); dRdu = fval4(1,2); dRdv = fval4(1,3); dRds = fval4(1,4)
       dRduu = fval4(1,5); dRdvv = fval4(1,6); dRdss = fval4(1,7)
       dRduv = fval4(1,8); dRdus = fval4(1,9); dRdvs = fval4(1,10)
+      ! Spline is over rho so s=rho**2 drho/ds = 0.5/sqrt(s) d2rho/ds2 = -0.25*s**-1.5
+      !dRdss = ( dRdss  + Rgrad(3) ) * -0.25 / (rho*rho*rho)
+      dRdus = dRdus * drhods; dRdvs = dRdvs * drhods
       ! All our toroidal deriviatives are d/dv not d/dphi
       ! phi = v_val/nfp so dv/dphi = nfp
-      dRdss = dRdss * drhods * drhods; dRdus = dRdus * drhods; dRdvs = dRdvs * drhods
       dRdvv = dRdvv * nfp * nfp; dRduv = dRduv * nfp; dRdvs = dRdvs * nfp
-      Rgrad(2) = Rgrad(2) * nfp; Rgrad(3) = Rgrad(3) * drhods
+      dRdv = dRdv * nfp; dRds = dRds * drhods
       CALL r8fvtricub(ict4, 1, 1, fval4, i, j, k, xparam, yparam, zparam, &
                       hx, hxi, hy, hyi, hz, hzi, &
                       Z4D(1,1,1,1), nx1, nx2, nx3)
-      Z = fval4(1,1); Zgrad(1) = fval4(1,2); Zgrad(2) = fval4(1,3); Zgrad(3) = fval4(1,4)
+      Z = fval4(1,1); dZdu = fval4(1,2); dZdv = fval4(1,3); dZds = fval4(1,4)
       dZduu = fval4(1,5); dZdvv = fval4(1,6); dZdss = fval4(1,7)
       dZduv = fval4(1,8); dZdus = fval4(1,9); dZdvs = fval4(1,10)
-      dZdss = dZdss * drhods * drhods; dZdus = dZdus * drhods; dZdvs = dZdvs * drhods
+      !dZdss = ( dZdss  + Zgrad(3) ) * -0.25 / (rho*rho*rho)
+      dZdus = dZdus * drhods; dZdvs = dZdvs * drhods
       dZdvv = dZdvv * nfp * nfp; dZduv = dZduv * nfp; dZdvs = dZdvs * nfp
-      Zgrad(2) = Zgrad(2) * nfp; Zgrad(3) = Zgrad(3) * drhods
-      CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
-                      hx, hxi, hy, hyi, hz, hzi, &
-                      BS4D(1,1,1,1), nx1, nx2, nx3)
-      bs = fval3(1,1); bsdu = fval3(1,2); bsdv = fval3(1,3) * nfp; bsds = fval3(1,4) * drhods
+      dZdv = dZdv * nfp; dZds = dZds * drhods
+      ! B^s (not needed if B^s = 0)
+      !bs = zero
+      !CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
+      !                hx, hxi, hy, hyi, hz, hzi, &
+      !                BS4D(1,1,1,1), nx1, nx2, nx3)
+      !bs = fval3(1,1); bsdu = fval3(1,2); bsdv = fval3(1,3) * nfp; bsds = fval3(1,4) * drhods
+      ! B^theta = B^u
       CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
                       hx, hxi, hy, hyi, hz, hzi, &
                       BU4D(1,1,1,1), nx1, nx2, nx3)
       bu = fval3(1,1); budu = fval3(1,2); budv = fval3(1,3) * nfp; buds = fval3(1,4) * drhods
+      ! B^phi*R = R*B^v
       CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
                       hx, hxi, hy, hyi, hz, hzi, &
                       BV4D(1,1,1,1), nx1, nx2, nx3)
-      bv = fval3(1,1); bvdu = fval3(1,2); bvdv = fval3(1,3) * nfp; bvds = fval3(1,4) * drhods
-      CALL r8fvtricub(ict1, 1, 1, fval1, i, j, k, xparam, yparam, zparam, &
-                      hx, hxi, hy, hyi, hz, hzi, &
-                      G4D(1,1,1,1), nx1, nx2, nx3)
-      sqrtG = fval1(1)
+      !bv = fval3(1,1)
+      bvdu = fval3(1,2)
+      bvdv = fval3(1,3) * nfp
+      bvds = fval3(1,4) * drhods
+      bv = fval3(1,1) * R
+      bvdu = R*fval3(1,2)          + bv * dRdu
+      bvdv = R*fval3(1,3) * nfp    + bv * dRdv
+      bvds = R*fval3(1,4) * drhods + bv * dRds
+      ! sqrt(g)
+      !CALL r8fvtricub(ict1, 1, 1, fval1, i, j, k, xparam, yparam, zparam, &
+      !                hx, hxi, hy, hyi, hz, hzi, &
+      !                G4D(1,1,1,1), nx1, nx2, nx3)
+      !sqrtG = fval1(1)
+      sqrtG =  one / ( R * dRdu * dZds - R * dZdu * dRds )
       ! Compute the grad values
-      gradsR = -Zgrad(1)*R/sqrtG
-      gradsP =  (Rgrad(2)*Zgrad(1)-Rgrad(1)*Zgrad(2))/sqrtG
-      gradsZ =  Rgrad(1)*R/sqrtG
-      graduR = -Rgrad(3)*R/sqrtG
-      graduP =  (Rgrad(3)*Zgrad(2)-Rgrad(2)*Zgrad(3))/sqrtG
-      graduZ =  Zgrad(3)*R/sqrtG
+      gradsR = -dZdu*R/sqrtG
+      gradsP =  (dRdv*dZdu-dRdu*dZdv)/sqrtG
+      gradsZ =  dRdu*R/sqrtG
+      graduR =  dZds*R/sqrtG
+      graduP =  (dRds*dZdv-dRdv*dZds)/sqrtG
+      graduZ = -dRds*R/sqrtG
       gradvR =  zero
-      gradvP =  one/(R*sqrtG)
+      gradvP =  one/R
       gradvZ =  zero
+      !PRINT *,gradsR, gradsP, gradsZ
+      !PRINT *,graduR, graduP, graduZ
+      !PRINT *,gradvR, gradvP, gradvZ
       gradsX =  gradsR * cop - gradsP * sip 
       gradsY =  gradsP * cop + gradsR * sip
       graduX =  graduR * cop - graduP * sip 
@@ -2917,39 +2937,50 @@
       gradvX =  gradvR * cop - gradvP * sip 
       gradvY =  gradvP * cop + gradvR * sip
       ! Compute the derivatives
-      dBxds = buds * Rgrad(1) * cop + bu * dRdus * cop + bvds * Rgrad(2) * cop &
-              + bv * dRdvs * cop - bvds * R * sip - bv * Rgrad(3) * sip
-      dBxdu = budu * Rgrad(1) * cop + bu * dRduu * cop + bvdu * Rgrad(2) * cop &
-              + bv * dRduv * cop - bvdu * R * sip - bv * Rgrad(1) * sip
-      dBxdv =   budv * Rgrad(1) * cop + bu * dRduv * cop - bu * Rgrad(1) * sip &
-              + bvdv * Rgrad(2) * cop + bv * dRdvv * cop - bv * Rgrad(2) * sip &
-              - bvdv * R * sip - bv * Rgrad(2) * cop - bv * R * cop
-      dByds = buds * Rgrad(1) * sip + bu * dRdus * sip + bvds * Rgrad(2) * sip &
-              + bv * dRdvs * sip + bvds * R * cop + bv * Rgrad(3) * cop
-      dBydu = budu * Rgrad(1) * sip + bu * dRduu * sip + bvdu * Rgrad(2) * sip &
-              + bv * dRduv * sip + bvdu * R * cop + bv * Rgrad(1) * cop
-      dBydv =   budv * Rgrad(1) * sip + bu * dRduv * sip + bu * Rgrad(1) * cop &
-              + bvdv * Rgrad(2) * sip + bv * dRdvv * sip + bv * Rgrad(2) * cop &
-              + bvdv * R * cop + bv * Rgrad(2) * sip + bv * R * sip
-      dBzds = buds * Zgrad(1) + bu * dZdus + bvds * Zgrad(2) + bv * dZdvs
-      dBzdu = budu * Zgrad(1) + bu * dZduu + bvdu * Zgrad(2) + bv * dZduv
-      dBzdv = budv * Zgrad(1) + bu * dZduv + bvdv * Zgrad(2) + bv * dZdvv
+      dBxds = buds * dRdu * cop + bu * dRdus * cop + bvds * dRdv * cop &
+              + bv * dRdvs * cop - bvds * R * sip - bv * dRds * sip
+      dBxdu = budu * dRdu * cop + bu * dRduu * cop + bvdu * dRdv * cop &
+              + bv * dRduv * cop - bvdu * R * sip - bv * dRdu * sip
+      dBxdv =   budv * dRdu * cop + bu * dRduv * cop - bu * dRdu * sip &
+              + bvdv * dRdv * cop + bv * dRdvv * cop - bv * dRdv * sip &
+              - bvdv * R * sip - bv * dRdv * sip - bv * R * cop
+      dByds = buds * dRdu * sip + bu * dRdus * sip + bvds * dRdv * sip &
+              + bv * dRdvs * sip + bvds * R * cop + bv * dRds * cop
+      dBydu = budu * dRdu * sip + bu * dRduu * sip + bvdu * dRdv * sip &
+              + bv * dRduv * sip + bvdu * R * cop + bv * dRdu * cop
+      dBydv =   budv * dRdu * sip + bu * dRduv * sip + bu * dRdu * cop &
+              + bvdv * dRdv * sip + bv * dRdvv * sip + bv * dRdv * cop &
+              + bvdv * R * cop + bv * dRdv * cop - bv * R * sip
+      dBzds = buds * dZdu + bu * dZdus + bvds * dZdv + bv * dZdvs
+      dBzdu = budu * dZdu + bu * dZduu + bvdu * dZdv + bv * dZduv
+      dBzdv = budv * dZdu + bu * dZduv + bvdv * dZdv + bv * dZdvv
+      !PRINT *,dBxds, dBxdu, dBxdv
+      !PRINT *,dByds, dBydu, dBydv
+      !PRINT *,dBzds, dBzdu, dBzdv
       ! Now compute the grad(B) in cartesian coordinates
-      dBxdx = dBxds * gradsX + dBxdu * graduX + dBxdv * gradvZ
+      dBxdx = dBxds * gradsX + dBxdu * graduX + dBxdv * gradvX
       dBxdy = dBxds * gradsY + dBxdu * graduY + dBxdv * gradvY
       dBxdz = dBxds * gradsZ + dBxdu * graduZ + dBxdv * gradvZ
-      dBydx = dByds * gradsX + dBydu * graduX + dBydv * gradvZ
+      dBydx = dByds * gradsX + dBydu * graduX + dBydv * gradvX
       dBydy = dByds * gradsY + dBydu * graduY + dBydv * gradvY
       dBydz = dByds * gradsZ + dBydu * graduZ + dBydv * gradvZ
-      dBzdx = dBzds * gradsX + dBzdu * graduX + dBzdv * gradvZ
+      dBzdx = dBzds * gradsX + dBzdu * graduX + dBzdv * gradvX
       dBzdy = dBzds * gradsY + dBzdu * graduY + dBzdv * gradvY
       dBzdz = dBzds * gradsZ + dBzdu * graduZ + dBzdv * gradvZ
+      !PRINT *,'grad(B)'
+      !PRINT *,dBxdx,dBxdy,dBxdz
+      !PRINT *,dBydx,dBydy,dBydz
+      !PRINT *,dBzdx,dBzdy,dBzdz
+      !PRINT *,DSQRT(bu*bu+bv*bv)
+      !STOP
       ! Now compute the Frobenius norm of grad(B)
       gradB_norm = DSQRT (   dBxdx * dBxdx + dBxdy * dBxdy + dBxdz * dBxdz &
                            + dBydx * dBydx + dBydy * dBydy + dBydz * dBydz &
                            + dBzdx * dBzdx + dBzdy * dBzdy + dBzdz * dBzdz )
+      !PRINT *,gradB_norm
+      !STOP
       ! And finally LgradB
-      lgradB = DSQRT(two * (bs*bs+bu*bu+bv*bv)) / gradB_norm
+      lgradB = DSQRT(two * (bu*bu+bv*bv)) / gradB_norm
       IF (PRESENT(R_out)) R_out = R
       IF (PRESENT(Z_out)) Z_out = Z
       RETURN

--- a/LIBSTELL/Sources/Modules/stel_tools.f90
+++ b/LIBSTELL/Sources/Modules/stel_tools.f90
@@ -2847,6 +2847,7 @@
       DOUBLE PRECISION :: dBxdx, dBxdy, dBxdz
       DOUBLE PRECISION :: dBydx, dBydy, dBydz
       DOUBLE PRECISION :: dBzdx, dBzdy, dBzdz
+      DOUBLE PRECISION :: modB,Br,Bphi,Bz
       INTEGER :: i,j,k
       REAL*8 :: xparam, yparam, zparam, hx, hy, hz, hxi, hyi, hzi
       REAL*8 :: fval1(1)
@@ -2903,20 +2904,18 @@
       CALL r8fvtricub(ict3, 1, 1, fval3, i, j, k, xparam, yparam, zparam, &
                       hx, hxi, hy, hyi, hz, hzi, &
                       BV4D(1,1,1,1), nx1, nx2, nx3)
-      !bv = fval3(1,1)
-      bvdu = fval3(1,2)
-      bvdv = fval3(1,3) * nfp
-      bvds = fval3(1,4) * drhods
-      bv = fval3(1,1) * R
-      bvdu = R*fval3(1,2)          + bv * dRdu
-      bvdv = R*fval3(1,3) * nfp    + bv * dRdv
-      bvds = R*fval3(1,4) * drhods + bv * dRds
+      !PRINT *,'BV4D'
+      !PRINT *,BV4D(1,1,1,:)
+      bv = fval3(1,1); bvdu = fval3(1,2); bvdv = fval3(1,3) * nfp; bvds = fval3(1,4) * drhods
+      !PRINT *,'  X,dXds,dXdu,dXdv'
+      !PRINT *,'R ',R,dRds,dRdu,dRdv
+      !PRINT *,'Z ',Z,dZds,dZdu,dZdv
+      !PRINT *,'  BX,dBds,dBdu,dBdv'
+      !PRINT *,'Bu',bu,buds,budu,budv
+      !PRINT *,'Bv',bv,bvds,bvdu,bvdv
       ! sqrt(g)
-      !CALL r8fvtricub(ict1, 1, 1, fval1, i, j, k, xparam, yparam, zparam, &
-      !                hx, hxi, hy, hyi, hz, hzi, &
-      !                G4D(1,1,1,1), nx1, nx2, nx3)
-      !sqrtG = fval1(1)
-      sqrtG =  one / ( R * dRdu * dZds - R * dZdu * dRds )
+      sqrtG = - R * (dRdu*dZds - dRds*dZdu)
+      !PRINT *,'sqrt(G)',sqrtG
       ! Compute the grad values
       gradsR = -dZdu*R/sqrtG
       gradsP =  (dRdv*dZdu-dRdu*dZdv)/sqrtG
@@ -2927,15 +2926,20 @@
       gradvR =  zero
       gradvP =  one/R
       gradvZ =  zero
-      !PRINT *,gradsR, gradsP, gradsZ
-      !PRINT *,graduR, graduP, graduZ
-      !PRINT *,gradvR, gradvP, gradvZ
+      !PRINT *,'grad(X)_R,P,Z'
+      !PRINT *,'s',gradsR, gradsP, gradsZ
+      !PRINT *,'u',graduR, graduP, graduZ
+      !PRINT *,'v',gradvR, gradvP, gradvZ
       gradsX =  gradsR * cop - gradsP * sip 
       gradsY =  gradsP * cop + gradsR * sip
       graduX =  graduR * cop - graduP * sip 
       graduY =  graduP * cop + graduR * sip
       gradvX =  gradvR * cop - gradvP * sip 
       gradvY =  gradvP * cop + gradvR * sip
+      !PRINT *,'grad(X)_X,Y,Z'
+      !PRINT *,'s',gradsX, gradsY, gradsZ
+      !PRINT *,'u',graduX, graduY, graduZ
+      !PRINT *,'v',gradvX, gradvY, gradvZ
       ! Compute the derivatives
       dBxds = buds * dRdu * cop + bu * dRdus * cop + bvds * dRdv * cop &
               + bv * dRdvs * cop - bvds * R * sip - bv * dRds * sip
@@ -2954,9 +2958,10 @@
       dBzds = buds * dZdu + bu * dZdus + bvds * dZdv + bv * dZdvs
       dBzdu = budu * dZdu + bu * dZduu + bvdu * dZdv + bv * dZduv
       dBzdv = budv * dZdu + bu * dZduv + bvdv * dZdv + bv * dZdvv
-      !PRINT *,dBxds, dBxdu, dBxdv
-      !PRINT *,dByds, dBydu, dBydv
-      !PRINT *,dBzds, dBzdu, dBzdv
+      !PRINT *,'dBX/ds,dBX/du,dBXdv'
+      !PRINT *,'X',dBxds, dBxdu, dBxdv
+      !PRINT *,'Y',dByds, dBydu, dBydv
+      !PRINT *,'Z',dBzds, dBzdu, dBzdv
       ! Now compute the grad(B) in cartesian coordinates
       dBxdx = dBxds * gradsX + dBxdu * graduX + dBxdv * gradvX
       dBxdy = dBxds * gradsY + dBxdu * graduY + dBxdv * gradvY
@@ -2971,16 +2976,22 @@
       !PRINT *,dBxdx,dBxdy,dBxdz
       !PRINT *,dBydx,dBydy,dBydz
       !PRINT *,dBzdx,dBzdy,dBzdz
-      !PRINT *,DSQRT(bu*bu+bv*bv)
-      !STOP
+      ! Compute modB
+      Br   = bu * drdu + bv * drdv
+      Bphi = bv * R
+      Bz   = bu * dzdu + bv * dzdv
+      modB = DSQRT(Br * Br + Bphi * Bphi + Bz * Bz)
+      !PRINT *,'modB,Br,Bphi,Bz'
+      !PRINT *,modB,Br,Bphi,Bz
       ! Now compute the Frobenius norm of grad(B)
       gradB_norm = DSQRT (   dBxdx * dBxdx + dBxdy * dBxdy + dBxdz * dBxdz &
                            + dBydx * dBydx + dBydy * dBydy + dBydz * dBydz &
                            + dBzdx * dBzdx + dBzdy * dBzdy + dBzdz * dBzdz )
-      !PRINT *,gradB_norm
-      !STOP
       ! And finally LgradB
-      lgradB = DSQRT(two * (bu*bu+bv*bv)) / gradB_norm
+      lgradB = modb * DSQRT(two) / gradB_norm
+      !PRINT *,'B,gradB_norm,lgradB'
+      !PRINT *,modb,gradB_norm,lgradB
+      !STOP
       IF (PRESENT(R_out)) R_out = R
       IF (PRESENT(Z_out)) Z_out = Z
       RETURN

--- a/LIBSTELL/Sources/STELLOPT/stellopt_input_mod.f90
+++ b/LIBSTELL/Sources/STELLOPT/stellopt_input_mod.f90
@@ -272,6 +272,7 @@
                          target_betapol, sigma_betapol, &
                          target_betator, sigma_betator, &
                          target_wp, sigma_wp, &
+                         target_lgradb, sigma_lgradb, &
                          target_aspect, sigma_aspect, &
                          target_extcur, sigma_extcur, &
                          target_aspect_max, sigma_aspect_max, width_aspect_max, &
@@ -634,6 +635,8 @@
       sigma_betator    = bigno
       target_wp        = 0.0
       sigma_wp         = bigno
+      target_lgradb    = 1.0
+      sigma_lgradb     = bigno
       target_aspect    = 0.0
       sigma_aspect     = bigno
       target_aspect_max= 0.0
@@ -1485,6 +1488,10 @@
       IF (sigma_totalbootstrap < bigno) THEN
          WRITE(iunit,outflt) 'TARGET_TOTALBOOTSTRAP',target_totalbootstrap
          WRITE(iunit,outflt) 'SIGMA_TOTALBOOTSTRAP',sigma_totalbootstrap
+      END IF 
+      IF (sigma_lgradb < bigno) THEN
+         WRITE(iunit,outflt) 'TARGET_LGRADB',target_lgradb
+         WRITE(iunit,outflt) 'SIGMA_LGRADB',sigma_lgradb
       END IF 
       IF (ANY(lbooz)) THEN
          WRITE(iunit,'(A)') '!----------------------------------------------------------------------'

--- a/LIBSTELL/Sources/STELLOPT/stellopt_targets.f90
+++ b/LIBSTELL/Sources/STELLOPT/stellopt_targets.f90
@@ -83,6 +83,7 @@
       REAL(rprec) ::  target_kappa_box, sigma_kappa_box, phi_kappa_box
       REAL(rprec) ::  target_kappa_avg, sigma_kappa_avg
       REAL(rprec) ::  target_totalbootstrap, sigma_totalbootstrap
+      REAL(rprec) ::  target_lgradb, sigma_lgradb
       REAL(rprec) ::  target_x, sigma_x
       REAL(rprec) ::  target_y, sigma_y
       REAL(rprec) ::  target_rosenbrock2d, sigma_rosenbrock2d
@@ -280,6 +281,7 @@
       INTEGER, PARAMETER :: jtarget_bmin       = 610
       INTEGER, PARAMETER :: jtarget_bmax       = 611
       INTEGER, PARAMETER :: jtarget_orbit      = 612
+      INTEGER, PARAMETER :: jtarget_lgradb     = 613
       INTEGER, PARAMETER :: jtarget_x          = 900
       INTEGER, PARAMETER :: jtarget_y          = 901
       INTEGER, PARAMETER :: jtarget_Rosenbrock_F   = 902
@@ -338,6 +340,8 @@
             WRITE(iunit, out_format) 'Min Pressure'
          CASE(jtarget_rbtor)
             WRITE(iunit, out_format) 'R*Btor'
+         CASE(jtarget_lgradb)
+            WRITE(iunit, out_format) 'Lgrad(B)'
          CASE(jtarget_b0)
             WRITE(iunit, out_format) 'B0 (phi=0)'
          CASE(jtarget_r0)

--- a/STELLOPTV2/ObjectList
+++ b/STELLOPTV2/ObjectList
@@ -1,4 +1,5 @@
 ObjectFiles = \
+chisq_lgradb.o \
 chisq_coilcoil_distance.o \
 chisq_coil_torsion.o \
 chisq_coil_curvature.o \

--- a/STELLOPTV2/STELLOPTV2.dep
+++ b/STELLOPTV2/STELLOPTV2.dep
@@ -2,6 +2,7 @@
 
 chisq_lgradb.o : \
       stellopt_runtime.o \
+      equil_vals.o \
       $(LIB_DIR)/$(LOCTYPE)/stellopt_targets.o \
       $(LIB_DIR)/$(LOCTYPE)/stel_tools.o 
 

--- a/STELLOPTV2/STELLOPTV2.dep
+++ b/STELLOPTV2/STELLOPTV2.dep
@@ -1,5 +1,10 @@
 # Microsoft Developer Studio Generated Dependency File, included by STELLOPT.mak
 
+chisq_lgradb.o : \
+      stellopt_runtime.o \
+      $(LIB_DIR)/$(LOCTYPE)/stellopt_targets.o \
+      $(LIB_DIR)/$(LOCTYPE)/stel_tools.o 
+
 chisq_coil_curvature.o : \
       stellopt_runtime.o \
       $(LIB_DIR)/$(LOCTYPE)/stellopt_vars.o \

--- a/STELLOPTV2/Sources/Chisq/chisq_lgradb.f90
+++ b/STELLOPTV2/Sources/Chisq/chisq_lgradb.f90
@@ -12,7 +12,7 @@
 !-----------------------------------------------------------------------
       USE stellopt_runtime
       USE stellopt_targets
-      USE stel_tools, ONLY: get_equil_RZ
+      USE stel_tools, ONLY: get_equil_LgradB
       
 !-----------------------------------------------------------------------
 !     Input/Output Variables
@@ -30,33 +30,39 @@
       INTEGER, PARAMETER :: nu_local = 128
       INTEGER, PARAMETER :: nv_local = 96
       INTEGER :: u, v, ier
-      REAL(rprec) :: s,theta,zeta
+      REAL(rprec) :: s,theta,zeta, lgradB_min
+      DOUBLE PRECISION :: lgradB, R, Z
       REAL(rprec), DIMENSION(nu_local,nv_local) :: Bxds
 !----------------------------------------------------------------------
 !     BEGIN SUBROUTINE
 !----------------------------------------------------------------------
       IF (iflag < 0) RETURN
-      IF (iflag == 1) WRITE(iunit_out,'(A,2(2X,I3.3))') 'LGRADB ',1,3
-      IF (iflag == 1) WRITE(iunit_out,'(A)') 'TARGET  SIGMA  LGRADB'
+      IF (iflag == 1) WRITE(iunit_out,'(A,2(2X,I3.3))') 'LGRADB ',nu_local*nv_local,3
+      IF (iflag == 1) WRITE(iunit_out,'(A)') 'TARGET  SIGMA  LGRADB S THETA PHI R Z'
       IF (niter >= 0) THEN
          s = 1.0_rprec
+         lgradB = bigno
          DO u = 1, nu_local
             DO v = 1, nv_local
                theta = DBLE(u-1)/DBLE(nu_local)
                zeta  = DBLE(v-1)/DBLE(nv_local)
                ier = 0
-               ! First compute the vector gradients
-               CALL get_equil_LgradB(s,u,v,R,Z,ier,Rgrad,Zgrad)
-         ! Compute the Frobenius norm
-         mtargets = mtargets + 1
-         targets(mtargets) = target
-         sigmas(mtargets)  = sigma
-         vals(mtargets)     = beta
-         IF (iflag == 1) WRITE(iunit_out,'(3ES22.12E3)') target,sigma,beta
+               CALL get_equil_LgradB(s, theta, zeta, lgradB, ier, R_out=R, Z_out=Z)
+               mtargets = mtargets + 1
+               targets(mtargets) = target
+               sigmas(mtargets)  = sigma
+               vals(mtargets)     = lgradB_min
+               IF (iflag == 1) WRITE(iunit_out,'(8ES22.12E3)') target, sigma, lgradB, s, theta, zeta/nfp, R, Z
+            END DO
+         END DO
       ELSE
          IF (sigma < bigno) THEN
-            mtargets = mtargets + 1
-            IF (niter == -2) target_dex(mtargets)=jtarget_lgradb
+            DO u = 1, nu_local
+               DO v = 1, nv_local
+                  mtargets = mtargets + 1
+                  IF (niter == -2) target_dex(mtargets)=jtarget_lgradb
+               END DO
+            END DO
          END IF
       END IF
       RETURN

--- a/STELLOPTV2/Sources/Chisq/chisq_lgradb.f90
+++ b/STELLOPTV2/Sources/Chisq/chisq_lgradb.f90
@@ -13,11 +13,13 @@
       USE stellopt_runtime
       USE stellopt_targets
       USE stel_tools, ONLY: get_equil_LgradB
+      USE equil_vals, ONLY: nfp
       
 !-----------------------------------------------------------------------
 !     Input/Output Variables
 !
 !-----------------------------------------------------------------------
+      IMPLICIT NONE
       REAL(rprec), INTENT(in)    ::  target
       REAL(rprec), INTENT(in)    ::  sigma
       INTEGER,     INTENT(in)    ::  niter
@@ -30,29 +32,29 @@
       INTEGER, PARAMETER :: nu_local = 128
       INTEGER, PARAMETER :: nv_local = 96
       INTEGER :: u, v, ier
-      REAL(rprec) :: s,theta,zeta, lgradB_min
+      REAL(rprec) :: s,theta,zeta
       DOUBLE PRECISION :: lgradB, R, Z
-      REAL(rprec), DIMENSION(nu_local,nv_local) :: Bxds
 !----------------------------------------------------------------------
 !     BEGIN SUBROUTINE
 !----------------------------------------------------------------------
       IF (iflag < 0) RETURN
-      IF (iflag == 1) WRITE(iunit_out,'(A,2(2X,I3.3))') 'LGRADB ',nu_local*nv_local,3
-      IF (iflag == 1) WRITE(iunit_out,'(A)') 'TARGET  SIGMA  LGRADB S THETA PHI R Z'
+      IF (iflag == 1) WRITE(iunit_out,'(A,2(2X,I6.6))') 'LGRADB ',nu_local*nv_local,8
+      IF (iflag == 1) WRITE(iunit_out,'(A)') 'TARGET  SIGMA  LGRADB  S  THETA  PHI  R  Z'
       IF (niter >= 0) THEN
          s = 1.0_rprec
          lgradB = bigno
          DO u = 1, nu_local
             DO v = 1, nv_local
-               theta = DBLE(u-1)/DBLE(nu_local)
-               zeta  = DBLE(v-1)/DBLE(nv_local)
+               theta = DBLE(u-1)/DBLE(nu_local)*pi2
+               zeta  = DBLE(v-1)/DBLE(nv_local)*pi2
                ier = 0
                CALL get_equil_LgradB(s, theta, zeta, lgradB, ier, R_out=R, Z_out=Z)
                mtargets = mtargets + 1
                targets(mtargets) = target
                sigmas(mtargets)  = sigma
-               vals(mtargets)     = lgradB_min
-               IF (iflag == 1) WRITE(iunit_out,'(8ES22.12E3)') target, sigma, lgradB, s, theta, zeta/nfp, R, Z
+               vals(mtargets)    = lgradB
+               IF (lgradB > target) sigmas(mtargets)  = sigma*10.0
+               IF (iflag == 1) WRITE(iunit_out,'(8ES22.12E3)') target, sigmas(mtargets), lgradB, s, theta, zeta/nfp, R, Z
             END DO
          END DO
       ELSE

--- a/STELLOPTV2/Sources/Chisq/chisq_lgradb.f90
+++ b/STELLOPTV2/Sources/Chisq/chisq_lgradb.f90
@@ -1,0 +1,66 @@
+!-----------------------------------------------------------------------
+!     Subroutine:    chisq_LgradB
+!     Authors:       S. Lazerson (samuel.lazerson@gauss-fusion)
+!     Date:          08/04/2025
+!     Description:   Computes L_grad(B) used as a proxy for the
+!                    coil plasma distance as defined in:
+!                    https://dx.doi.org/10.1088/1361-6587/ad1a3e
+!-----------------------------------------------------------------------
+      SUBROUTINE chisq_lgradb(target,sigma,niter,iflag)
+!-----------------------------------------------------------------------
+!     Libraries
+!-----------------------------------------------------------------------
+      USE stellopt_runtime
+      USE stellopt_targets
+      USE stel_tools, ONLY: get_equil_RZ
+      
+!-----------------------------------------------------------------------
+!     Input/Output Variables
+!
+!-----------------------------------------------------------------------
+      REAL(rprec), INTENT(in)    ::  target
+      REAL(rprec), INTENT(in)    ::  sigma
+      INTEGER,     INTENT(in)    ::  niter
+      INTEGER,     INTENT(in)    ::  iflag
+      
+!-----------------------------------------------------------------------
+!     Local Variables
+!
+!-----------------------------------------------------------------------
+      INTEGER, PARAMETER :: nu_local = 128
+      INTEGER, PARAMETER :: nv_local = 96
+      INTEGER :: u, v, ier
+      REAL(rprec) :: s,theta,zeta
+      REAL(rprec), DIMENSION(nu_local,nv_local) :: Bxds
+!----------------------------------------------------------------------
+!     BEGIN SUBROUTINE
+!----------------------------------------------------------------------
+      IF (iflag < 0) RETURN
+      IF (iflag == 1) WRITE(iunit_out,'(A,2(2X,I3.3))') 'LGRADB ',1,3
+      IF (iflag == 1) WRITE(iunit_out,'(A)') 'TARGET  SIGMA  LGRADB'
+      IF (niter >= 0) THEN
+         s = 1.0_rprec
+         DO u = 1, nu_local
+            DO v = 1, nv_local
+               theta = DBLE(u-1)/DBLE(nu_local)
+               zeta  = DBLE(v-1)/DBLE(nv_local)
+               ier = 0
+               ! First compute the vector gradients
+               CALL get_equil_LgradB(s,u,v,R,Z,ier,Rgrad,Zgrad)
+         ! Compute the Frobenius norm
+         mtargets = mtargets + 1
+         targets(mtargets) = target
+         sigmas(mtargets)  = sigma
+         vals(mtargets)     = beta
+         IF (iflag == 1) WRITE(iunit_out,'(3ES22.12E3)') target,sigma,beta
+      ELSE
+         IF (sigma < bigno) THEN
+            mtargets = mtargets + 1
+            IF (niter == -2) target_dex(mtargets)=jtarget_lgradb
+         END IF
+      END IF
+      RETURN
+!----------------------------------------------------------------------
+!     END SUBROUTINE
+!----------------------------------------------------------------------
+      END SUBROUTINE chisq_lgradb

--- a/STELLOPTV2/Sources/General/stellopt_load_equil.f90
+++ b/STELLOPTV2/Sources/General/stellopt_load_equil.f90
@@ -227,6 +227,7 @@
             !    f = f(jlo)*wlo + f(jhi)*whi  Interpolant
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             !   First interpolate from half grid to full (respect overwrite indexing)
+            !   Note we take the VMEC quantities and put them into the _temp arrays
             DO k = 2, ns_vmec-1
                WHERE (MOD(NINT(REAL(xm_temp(:))),2) .eq. 0)
                   mfact(:,1)= 0.5
@@ -250,7 +251,7 @@
             END DO
 
             !   Second, extrapolate to ns
-            !       note that ns-1 is full grid but ns is on half grid
+            !       note that ns-1 is full grid (temp array) but ns is on half grid (vmec_array)
             k = ns_vmec
             WHERE (MOD(NINT(REAL(xm_temp(:))),2) .eq. 0)
                mfact(:,1)= 2.0 ! ns (half grid point)
@@ -260,18 +261,19 @@
                mfact(:,2)=-1.0*SQRT((ns_vmec-1)/(k-2.0))
             ENDWHERE
             lmns_temp(:,k) = mfact(:,1)*lmns_temp(:,k)+mfact(:,2)*lmns_temp(:,k-1)
-            gmnc_temp(:,k) = mfact(:,1)*gmnc_vmec(:,k)+mfact(:,2)*gmnc_vmec(:,k-1)
-            bmnc_temp(:,k) = mfact(:,1)*bmnc_vmec(:,k)+mfact(:,2)*bmnc_vmec(:,k-1)
-            bsupumnc_temp(:,k) = mfact(:,1)*bsupumnc_vmec(:,k)+mfact(:,2)*bsupumnc_vmec(:,k-1)
-            bsupvmnc_temp(:,k) = mfact(:,1)*bsupvmnc_vmec(:,k)+mfact(:,2)*bsupvmnc_vmec(:,k-1)
+            gmnc_temp(:,k) = mfact(:,1)*gmnc_vmec(:,k)+mfact(:,2)*gmnc_temp(:,k-1)
+            bmnc_temp(:,k) = mfact(:,1)*bmnc_vmec(:,k)+mfact(:,2)*bmnc_temp(:,k-1)
+            bsupumnc_temp(:,k) = mfact(:,1)*bsupumnc_vmec(:,k)+mfact(:,2)*bsupumnc_temp(:,k-1)
+            bsupvmnc_temp(:,k) = mfact(:,1)*bsupvmnc_vmec(:,k)+mfact(:,2)*bsupvmnc_temp(:,k-1)
             IF (lasym_vmec) THEN
                lmnc_temp(:,k) = mfact(:,1)*lmnc_temp(:,k)+mfact(:,2)*lmnc_temp(:,k-1)
-               gmns_temp(:,k) = mfact(:,1)*gmns_vmec(:,k)+mfact(:,2)*gmns_vmec(:,k-1)
-               bmns_temp(:,k) = mfact(:,1)*bmns_vmec(:,k)+mfact(:,2)*bmns_vmec(:,k-1)
-               bsupumns_temp(:,k) = mfact(:,1)*bsupumns_vmec(:,k)+mfact(:,2)*bsupumns_vmec(:,k-1)
-               bsupvmns_temp(:,k) = mfact(:,1)*bsupvmns_vmec(:,k)+mfact(:,2)*bsupvmns_vmec(:,k-1)
+               gmns_temp(:,k) = mfact(:,1)*gmns_vmec(:,k)+mfact(:,2)*gmns_temp(:,k-1)
+               bmns_temp(:,k) = mfact(:,1)*bmns_vmec(:,k)+mfact(:,2)*bmns_temp(:,k-1)
+               bsupumns_temp(:,k) = mfact(:,1)*bsupumns_vmec(:,k)+mfact(:,2)*bsupumns_temp(:,k-1)
+               bsupvmns_temp(:,k) = mfact(:,1)*bsupvmns_vmec(:,k)+mfact(:,2)*bsupvmns_temp(:,k-1)
             END IF            
             !   Third extrapolate to axis This is the Samantha Lazerson bugfix 2023.01.29
+            !   Not here we take VMEC half grid quantities and extrapolate to axis in _temp array
             k = 1
             WHERE (MOD(NINT(REAL(xm_temp(:))),2) .eq. 0)
                mfact(:,1)= 2.0

--- a/STELLOPTV2/Sources/General/stellopt_load_targets.f90
+++ b/STELLOPTV2/Sources/General/stellopt_load_targets.f90
@@ -112,8 +112,12 @@
       ! TOTAL_BOOTSTRAP
       IF (sigma_totalbootstrap < bigno)  &
          CALL chisq_totalbootstrap(target_totalbootstrap,sigma_totalbootstrap,ncnt,iflag)
+      ! CURVATURE (P2)
       IF (sigma_curvature_p2 < bigno) &
          CALL chisq_curvature_p2(target_curvature_p2, sigma_curvature_p2, ncnt, iflag)
+      ! LGRADB
+      IF (sigma_lgradb < bigno)  &
+         CALL chisq_lgradb(target_lgradb,sigma_lgradb,ncnt,iflag)
 
       !------------- ARRAY TARGETS ----------------------------
       ! EXTERNAL CURRENTS

--- a/pySTEL/STELLOPT.py
+++ b/pySTEL/STELLOPT.py
@@ -901,7 +901,7 @@ class MyApp(QMainWindow):
 					'S11','S12','S21','S22','MAGWELL',\
 					'CURVATURE_KERT','CURVATURE_P2','TOTALBOOTSTRAP',\
 					'BNORMAL', 'COIL_CURVATURE', 'COIL_TORSION', \
-					'COILCOIL_DISTANCE']
+					'COILCOIL_DISTANCE', 'LGRADB']
 		self.ui.ComboBoxOPTplot_type.clear()
 		self.ui.ComboBoxOPTplot_type.addItem('Chi-Squared')
 		# Handle Chisquared plots
@@ -936,6 +936,8 @@ class MyApp(QMainWindow):
 			self.ui.ComboBoxOPTplot_type.addItem('DKES_L11')
 			self.ui.ComboBoxOPTplot_type.addItem('DKES_L31')
 			self.ui.ComboBoxOPTplot_type.addItem('DKES_L33')
+		if 'LGRADB_TARGET' in vars(self.stel_data).keys():
+			self.ui.ComboBoxOPTplot_type.addItem('LGRADB_surf')
 		# Handle Wout Comparrison Plots
 		files = os.listdir(self.workdir)
 		if any('wout' in mystring for mystring in files):
@@ -1054,6 +1056,24 @@ class MyApp(QMainWindow):
 				self.ui.ComboBoxOPTplot_surf.clear()
 				self.gist_data = gist.GIST()
 				self.gist_data.read_gist(test_file)
+			elif plot_name in ['LGRADB_surf']:
+				self.fig2.clf()
+				self.ax2 = self.fig2.add_axes([0.2,0.2,0.7,0.7])
+				self.ui.ComboBoxOPTplot_surf.clear()
+				iter_val = int(test_file)
+				print(iter_val)
+				iter_dex=np.flatnonzero(self.stel_data.ITER == iter_val)[0]
+				print(iter_dex)
+				theta = np.unique(self.stel_data.LGRADB_THETA[iter_dex,:])
+				phi = np.unique(self.stel_data.LGRADB_PHI[iter_dex,:])
+				ntheta = len(theta)
+				nphi   = len(phi)
+				lgradb = np.reshape(self.stel_data.LGRADB_LGRADB[iter_dex,:],(ntheta,nphi))
+				hmesh=self.ax2.pcolormesh(phi,theta,lgradb,cmap='jet')
+				self.ax2.set_xlabel('Toroidal Angle [rad]')
+				self.ax2.set_ylabel('Poloidal Angle [rad]')
+				_plt.colorbar(hmesh,label=r'$L_{\nabla B}$',ax=self.ax2)
+
 
 	def UpdateBoozerSpec(self):
 		plot_name = self.ui.ComboBoxOPTplot_type.currentText()
@@ -1931,6 +1951,11 @@ class MyApp(QMainWindow):
 			file_list = sorted(glob.glob("jacobian.*"))
 			for item in file_list:
 				self.ui.ComboBoxOPTplot_iter.addItem(item)
+			self.UpdateIterFile()
+		elif (plot_name == 'LGRADB_surf'):
+			iter_list = self.stel_data.ITER
+			for item in iter_list:
+				self.ui.ComboBoxOPTplot_iter.addItem(str(int(item)))
 			self.UpdateIterFile()
 		elif (plot_name == 'B-Normal'):
 			file_list = sorted(glob.glob("bnorm_real.*"))

--- a/pySTEL/libstell/stellopt.py
+++ b/pySTEL/libstell/stellopt.py
@@ -35,7 +35,7 @@ class STELLOPT():
 			'COIL_BNORM', 'REGCOIL_CHI2_B', 'CURVATURE_P2', 'GAMMA_C', \
 			'KINK', 'QUASIISO', 'B10B11', 'TOTALBOOTSTRAP', \
 			'BNORMAL', 'COIL_CURVATURE', 'COIL_TORSION', \
-			'COILCOIL_DISTANCE']
+			'COILCOIL_DISTANCE', 'LGRADB']
 
 	def read_stellopt_map(self,filename='map.dat'):
 		"""Reads a STELLOPT MAP output file
@@ -321,6 +321,8 @@ class STELLOPT():
 				val   = getattr(self,targ_name+'_VAL')
 				chisq = (targ-val)/sigma
 				setattr(self,targ_name+'_CHISQ',chisq*chisq)
+		# Flatten ITER
+		self.ITER = self.ITER.flatten()
 
 	def plot_stellopt_jacobian(self,target='all',ax=None):
 		"""Plot the Jacobian for a given target
@@ -352,7 +354,6 @@ class STELLOPT():
 		x_var = np.arange(len(self.var))
 		y_target = np.arange(len(self.targetnames))
 		if target == 'all':
-			x_var 
 			hmesh=ax.pcolormesh(x_var,y_target,np.squeeze(self.jac2d),cmap='jet')
 			ax.set_xticks(x_var, labels=self.var, fontsize=9)
 			plt.setp(ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")


### PR DESCRIPTION
This pull request adds support for the L_grad(B) coil metric in STELLOPT. A subroutine for computing L_grad(B) has been added to `stel_tools` and checked against the results from ["The magnetic gradient scale length explains why certain plasmas require close external magnetic coils"](https://doi.org/10.1088/1361-6587/ad1a3e).  Additionally, a bug was discovered in how the edge half-grid quantities were being extrapolated to the full grid in `stellopt_load_equil`.