### PR TITLE
Bugfix/beams3 d fusion

### DIFF
--- a/BEAMS3D/Sources/beams3d_init_fusion.f90
+++ b/BEAMS3D/Sources/beams3d_init_fusion.f90
@@ -331,7 +331,7 @@
                CALL RANDOM_NUMBER(Y1_rand) ! phi
                CALL RANDOM_NUMBER(Z1_rand) ! u
                ! Calc j dex
-               j = MIN(MAX(NINT(Y1_rand*nphi),1),nphi1)
+               j = MIN(MAX(CEILING(Y1_rand*nphi1),1),nphi1)
                ! Calc u = [0,2*pi]
                utemp = Z1_rand*pi2
                ! Calc sval =[0,1]

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -434,6 +434,16 @@
       END DO
       
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      !! Set S==-1 values to default
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      IF (mylocalid == mylocalmaster) THEN
+         WHERE(S_ARR < 0.0) S_ARR=4.0
+      END IF
+#if defined(MPI_OPT)
+      CALL MPI_BARRIER(MPI_COMM_LOCAL,ierr_mpi)
+#endif
+      
+      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       !! Evaluate the profile quantities on the background grid
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       IF (lverb) THEN


### PR DESCRIPTION
Fixes two issues:

- When running without the -vac flag it is possible that S_ARR had a value of -1 at the simulation domain which affected fusion births. Issue was introduced with recent `beams3d_init_vmec.f90` change.
- When running with fusion births and NPARTICLES_START was greater than the minimum number, too many markers were placed at the 1, and nphi gridpoints.  Error biases statistics toward those areas but does not significantly impact results as marker weights were still correclty adjusted.