### PR TITLE
Bugfix/raven

### DIFF
--- a/SHARE/make_raven.inc
+++ b/SHARE/make_raven.inc
@@ -16,10 +16,10 @@
 #######################################################################
   FLAGS_R = -I${MKLROOT}/include/intel64/lp64 -I$(MKL_HOME)/include \
             -O2 -assume noold_unit_star \
-            -xCORE-AVX512 -qopt-zmm-usage=high -fp-model strict -ip
+            -xCORE-AVX512 -qopt-zmm-usage=high -fp-model strict
   FLAGS_D = -I${MKLROOT}/include/intel64/lp64 -I$(MKL_HOME)/include \
             -O0 -assume noold_unit_star \
-            -xCORE-AVX512 -qopt-zmm-usage=high -fp-model strict -ip \
+            -xCORE-AVX512 -qopt-zmm-usage=high -fp-model strict \
             -check all,noarg_temp_created -ftrapuv -g -traceback
   LIBS    =  ${MKLROOT}/lib/intel64/libmkl_blas95_lp64.a \
              ${MKLROOT}/lib/intel64/libmkl_lapack95_lp64.a \
@@ -30,13 +30,13 @@
              ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a \
              -Wl,--end-group -lpthread -lm -ldl
 #######################################################################
-#            MPI Options
+#            MPI Options 2025 it's called mpiifx not mpiifort
 #######################################################################
   LMPI    = T
-  MPI_COMPILE = mpiifort
-  MPI_COMPILE_FREE = mpiifort
-  MPI_COMPILE_C = mpiifort
-  MPI_LINK = mpiifort
+  MPI_COMPILE = mpiifx
+  MPI_COMPILE_FREE = mpiifx
+  MPI_COMPILE_C = mpiifx
+  MPI_LINK = mpiifx
   MPI_RUN  = srun
   MPI_RUN_OPTS = --nodes=1 --ntasks-per-node=72 --time=0:30:00 -p express
   MPI_RUN_OPTS_SM   = --nodes=1 --ntasks-per-node=72 --time=0:30:00 -p express
@@ -53,8 +53,8 @@
 #            NETCDF Options
 #######################################################################
   LNETCDF = T
-  NETCDF_INC = $(shell nc-config --fflags)
-  NETCDF_LIB = $(shell nc-config --flibs)
+  NETCDF_INC = $(shell nf-config --fflags)
+  NETCDF_LIB = $(shell nf-config --flibs)
 
 #######################################################################
 #            HDF5 Options

--- a/STELLOPTV2/makestelloptv2
+++ b/STELLOPTV2/makestelloptv2
@@ -114,64 +114,64 @@ clean:
 
 #Construct vmec library. 
 $(LIB_VMEC) :
-	@cd $(VMEC_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_VMEC) *.o 
+	@cd $(VMEC_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o 
 	
 #Construct beams3d library. 
 $(LIB_BEAMS3D) :
-	@cd $(BEAMS3D_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_BEAMS3D) *.o
+	@cd $(BEAMS3D_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
 #Construct bnorm library. 
 $(LIB_BNORM) :
-	@cd $(BNORM_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_BNORM) *.o
+	@cd $(BNORM_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
 #Construct bootsj library. 
 $(LIB_BOOTSJ) :
-	@cd $(BOOTSJ_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_BOOTSJ) *.o
+	@cd $(BOOTSJ_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
 #Construct boozer library. 
 $(LIB_BOOZ) :
-	@cd $(BOOZ_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_BOOZ) *.o
+	@cd $(BOOZ_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
 #Construct cobra library. 
 $(LIB_COBRA) :
-	@cd $(COBRA_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_COBRA) *.o
+	@cd $(COBRA_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
 #Construct diagno library. 
 $(LIB_DIAGNO) :
-	@cd $(DIAGNO_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_DIAGNO) *.o
+	@cd $(DIAGNO_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
 #Construct DKES library. 
 $(LIB_DKES) :
-	@cd $(DKES_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_DKES) *.o
+	@cd $(DKES_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
-#Construct DKES library. 
+#Construct JINV library. 
 $(LIB_JINV) :
-	@cd $(JINV_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_JINV) *.o
+	@cd $(JINV_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
 #Construct fieldlines library. 
 $(LIB_FIELDLINES) :
-	@cd $(FIELDLINES_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_FIELDLINES) *.o
+	@cd $(FIELDLINES_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
 #Construct MAKEGRID library. 
 $(LIB_MGRID) :
-	@cd $(MGRID_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_MGRID) *.o
+	@cd $(MGRID_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
 #Construct NEO library. 
 $(LIB_NEO) :
-	@cd $(NEO_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_NEO) *.o
+	@cd $(NEO_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 
 #Construct COILOPT library. 
 $(LIB_COILOPTPP) :
-	@cd $(COILOPTPP_DIR); make; ar -cruv $(LIB_COILOPTPP) *.o 
+	@cd $(COILOPTPP_DIR); make; rm -f $@; ar -cruv $@ *.o 
 
 #Construct GENE library
 $(LIB_GENE) :
-	@cd $(GENE_DIR); ar -cruv $(LIB_GENE) *.o
+	@cd $(GENE_DIR); rm -f $@; ar -cruv $@ *.o
 
-#Construct COILOPT library. 
+#Construct REGCOIL library. 
 $(LIB_REGCOIL) :
-	@cd $(REGCOIL_DIR); make CLUSTER=$(MACHINE); ar -cruv $(LIB_REGCOIL) *.o 
+	@cd $(REGCOIL_DIR); make CLUSTER=$(MACHINE); rm -f $@; ar -cruv $@ *.o 
 
 #Construct TERPSICHORE library. 
 $(LIB_TERPSICHORE) :
-	@cd $(TERPSICHORE_DIR);make; ar -cruv $(LIB_TERPSICHORE) *.o
+	@cd $(TERPSICHORE_DIR);make;  rm -f $@; ar -cruv $@ *.o

--- a/THRIFT/makethrift
+++ b/THRIFT/makethrift
@@ -79,24 +79,24 @@ clean:
 
 #Construct vmec library. 
 $(LIB_VMEC) :
-	@cd $(VMEC_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_VMEC) *.o
+	@cd $(VMEC_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
 #Construct bootsj library. 
 $(LIB_BOOTSJ) :
-	@cd $(BOOTSJ_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_BOOTSJ) *.o
+	@cd $(BOOTSJ_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
 	
 #Construct boozer library. 
 $(LIB_BOOZ) :
-	@cd $(BOOZ_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_BOOZ) *.o
+	@cd $(BOOZ_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
    
 #Construct diagno library. 
 $(LIB_DIAGNO) :
-	@cd $(DIAGNO_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_DIAGNO) *.o
+	@cd $(DIAGNO_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
    
 #Construct DKES library. 
 $(LIB_DKES) :
-	@cd $(DKES_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_DKES) *.o
+	@cd $(DKES_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o
    
 #Construct PENTA library. 
 $(LIB_PENTA) :
-	@cd $(PENTA_DIR); make $(TYPE); cd $(LOCTYPE); ar -cruv $(LIB_PENTA) *.o
+	@cd $(PENTA_DIR); make $(TYPE); cd $(LOCTYPE); rm -f $@; ar -cruv $@ *.o


### PR DESCRIPTION
This addresses a bug found on Raven, but not limited too, where code library files were only being appended to. This means that if for example you built libbeams3d.a and then later files were moved. The old .o files were still in the .a file and linking may complain about duplicate files. This updated causes the code to always delete the libcode.a file before creating the archive lib file.

There are also some updates for the most recent compilers on Raven.