### PR TITLE
pySTEL: Added ability to generate VMEC input from VMEC output

### DIFF
--- a/pySTEL/fieldlines_util.py
+++ b/pySTEL/fieldlines_util.py
@@ -42,6 +42,8 @@ if __name__=="__main__":
 		help="Plots |B| along the magnetic axis (first field line).", default = False)
 	parser.add_argument("--output_asc", dest="asc_phi",
 		help="Output a given Poincare cross section at a given phi value [deg].", default = None, type=float)
+	parser.add_argument("--output_asc_orbit", dest="asc_orbit",
+		help="Output a given field line trajectory for a given fieldline.", default = None, type=int)
 	parser.add_argument("--save", dest="lsave", action='store_true',
 		help="Save the plots with ext names.", default = False)
 	args = parser.parse_args()
@@ -167,4 +169,6 @@ if __name__=="__main__":
 			if (args.lsave): fig.savefig(f'baxis_{args.fieldlines_ext}.png', dpi=fig.dpi)
 		if type(args.asc_phi) is not type(None):
 			field_data.write_asc([np.deg2rad(args.asc_phi)],nskip=args.nskip,filename=f'poincare_{args.fieldlines_ext}_phi_{int(args.asc_phi):03d}.asc')
+		if type(args.asc_orbit) is not type(None):
+			field_data.write_orbit_asc(args.asc_orbit,filename=f'poincare_{args.fieldlines_ext}_k_{int(args.asc_orbit):03d}.asc')
 	sys.exit(0)

--- a/pySTEL/libstell/boozer.py
+++ b/pySTEL/libstell/boozer.py
@@ -107,29 +107,35 @@ class BOOZER(FourierRep):
 		pyplot.colorbar(hmesh,label='[T]',ax=ax)
 		if lplotnow: pyplot.show()
 
-	def plot_fieldline(self,nlines=4,*args,**kwargs):
+	def plot_fieldline(self,*args,**kwargs):
 		"""Plots the boozer fieldline in 3D
 
 		This routine plots the boozer fieldline in 3D.
 
 		Parameters
 		----------
-		sval : int
-			Surface to plot
-		nlines : int
-			Number of lines to plot on surface (default=4)
+		sval : list (optional)
+			Surfaces to plot (default: ns_b)
+		ntheta : int (optional)
+			Number of lines to plot on surface (default: 4)
+		nphi : int (optional)
+			Number of toroidal points to use (default: 360)
+		phimin : float (optional)
+			Starting phi value (default: 0)
+		phimax : float (optional)
+			Ending phi value (default: 2pi)
 		plot3D : plot3D object (optional)
 			Plotting object to render to.
 		"""
 		import numpy as np
 		import vtk
 		from libstell.plot3D import PLOT3D 
-		plot3D  = kwargs.get('plot3D',None)
-		nphi = kwargs.get('nphi',360)
+		sdex   = kwargs.get('sdex',[self.ns_b-1])
 		ntheta = kwargs.get('ntheta',4)
+		nphi = kwargs.get('nphi',360)
 		phimin = kwargs.get('phimin',0.0)
 		phimax = kwargs.get('phimax',2*np.pi)
-		sdex   = kwargs.get('sdex',[self.ns_b-1])
+		plot3D  = kwargs.get('plot3D',None)
 		lrender = False
 		if not plot3D:
 			plt = PLOT3D()

--- a/pySTEL/libstell/boozer.py
+++ b/pySTEL/libstell/boozer.py
@@ -107,6 +107,71 @@ class BOOZER(FourierRep):
 		pyplot.colorbar(hmesh,label='[T]',ax=ax)
 		if lplotnow: pyplot.show()
 
+	def plot_fieldline(self,nlines=4,*args,**kwargs):
+		"""Plots the boozer fieldline in 3D
+
+		This routine plots the boozer fieldline in 3D.
+
+		Parameters
+		----------
+		sval : int
+			Surface to plot
+		nlines : int
+			Number of lines to plot on surface (default=4)
+		plot3D : plot3D object (optional)
+			Plotting object to render to.
+		"""
+		import numpy as np
+		import vtk
+		from libstell.plot3D import PLOT3D 
+		plot3D  = kwargs.get('plot3D',None)
+		nphi = kwargs.get('nphi',360)
+		ntheta = kwargs.get('ntheta',4)
+		phimin = kwargs.get('phimin',0.0)
+		phimax = kwargs.get('phimax',2*np.pi)
+		sdex   = kwargs.get('sdex',[self.ns_b-1])
+		lrender = False
+		if not plot3D:
+			plt = PLOT3D()
+			lrender = True
+		theta0 = np.linspace([0],[np.pi*2.0],ntheta+1)
+		theta0 = theta0[0:-1]
+		phi   = np.linspace([phimin],[phimax],nphi)
+		points_array = np.zeros((nphi,3))
+		scalar       = np.zeros((nphi,1))
+		xout         = np.zeros((self.ns_b,ntheta,nphi))
+		yout         = np.zeros((self.ns_b,ntheta,nphi))
+		zout         = np.zeros((self.ns_b,ntheta,nphi))
+		bout         = np.zeros((self.ns_b,ntheta,nphi))
+		ph           = np.zeros((ntheta,1))
+		for i in sdex:
+			for k,pht in enumerate(phi):
+				ph[:,0] = pht
+				th = theta0 + self.iota_b[i,0]*pht
+				r = self.cfunct(th,ph,self.rmnc_b,self.ixm_b,self.ixn_b)
+				z = self.sfunct(th,ph,self.zmns_b,self.ixm_b,self.ixn_b)
+				b = self.cfunct(th,ph,self.bmnc_b,self.ixm_b,self.ixn_b)
+				p = self.sfunct(th,ph,self.pmns_b,self.ixm_b,self.ixn_b)
+				phi_cart = p+ph
+				xout[i,:,k] = r[i,:,0]*np.cos(phi_cart[i,:,0])
+				yout[i,:,k] = r[i,:,0]*np.sin(phi_cart[i,:,0])
+				zout[i,:,k] = z[i,:,0]
+				bout[i,:,k] = b[i,:,0]
+		for i in sdex:
+			for j in range(ntheta):
+				points_array[:,0] = xout[i,j,:]
+				points_array[:,1] = yout[i,j,:]
+				points_array[:,2] = zout[i,j,:]
+				scalar            = bout[i,j,:]
+				points = vtk.vtkPoints()
+				for point in points_array:
+					points.InsertNextPoint(point)
+				scalar = plt.valuesToScalar(scalar)
+				plt.add3Dline(points,linewidth=2,scalars=scalar)
+		# In case it isn't set by user.
+		plt.setBGcolor()
+		if lrender: plt.render()
+
 	def calcQuasiError(self,m,n):
 		"""Calculates the quasi-symmetry error for each surface
 

--- a/pySTEL/libstell/fieldlines.py
+++ b/pySTEL/libstell/fieldlines.py
@@ -404,11 +404,39 @@ class FIELDLINES():
 			k = (np.abs(phi_arr - phival)).argmin() # Find nearest value
 			r = 1000.*self.R_lines[0:self.nlines:nskip,k:self.nsteps-2:self.npoinc].flatten()
 			z = 1000.*self.Z_lines[0:self.nlines:nskip,k:self.nsteps-2:self.npoinc].flatten()
-			p = self.PHI_lines[0:self.nlines:nskip,k:self.nsteps-2:self.npoinc].flatten()
+			p = np.mod(self.PHI_lines[0:self.nlines:nskip,k:self.nsteps-2:self.npoinc].flatten(),self.phiaxis[-1])
 			x = r*np.cos(p)
 			y = r*np.sin(p)
 			for i,x0 in enumerate(x):
 				f.write(f"{x0:10.3f} {y[i]:10.3f} {z[i]:10.3f}\n")
+		f.close()
+
+	def write_orbit_asc(self,k,filename='fieldlines_orbit.asc'):
+		"""Writes field line orbit to an ASC file
+
+		This routine writes the Poincare data into an ASC file for
+		reading into CAD software (FreeCAD). ASC files are just
+		ASCII files with the points written in x,y,z format. Output is
+		in mm.
+
+		Parameters
+		----------
+		k : int
+			Field line to output
+		nskip : int (optional)
+			Number of fieldlines to skip.
+		filename: str
+			Filename to output to (default: fieldlines_poincare.asc)
+		"""
+		import numpy as np
+		f = open(filename,'w')
+		r = 1000.*self.R_lines[k,:].flatten()
+		z = 1000.*self.Z_lines[k,:].flatten()
+		p = self.PHI_lines[k,:].flatten()
+		x = r*np.cos(p)
+		y = r*np.sin(p)
+		for i,x0 in enumerate(x):
+			f.write(f"{x0:10.3f} {y[i]:10.3f} {z[i]:10.3f}\n")
 		f.close()
 
 	def plot_heatflux(self,factor=1.0,colormap='hot',plot3D=None):

--- a/pySTEL/libstell/libstell.py
+++ b/pySTEL/libstell/libstell.py
@@ -1122,8 +1122,26 @@ class LIBSTELL():
 		charVar=['mgrid_file','input_extension','pmass_type','pcurr_type','piota_type']
 		charLen=[(200,1),(100,1),(20,1),(20,1),(20,1)]
 		string_data = self.get_module_vars(module_name,charVar=charVar,charLen=charLen,ldefined_size_arrays=True)
+		# Now read the values in input_mod that set by reading wout file
+		booList  = ['lfreeb']
+		booLen   = [1]*len(booList)
+		module_name = self.s1+'vmec_input_'+self.s2
+		boo_indata_data = self.get_module_vars(module_name,booVar=booList,booLen=booLen,ldefined_size_arrays=True)
+		if boo_indata_data['lfreeb']:
+			# Now get values in mgrid mod
+			intList  = ['nextcur']
+			intLen   = [1]*len(intList)
+			module_name = self.s1+'mgrid_mod_'+self.s2
+			scalar_mgrid_data = self.get_module_vars(module_name,intVar=intList,intLen=intLen)
+			realList = ['extcur']
+			realLen = [(scalar_mgrid_data['nextcur'],1)]*len(realList)
+			module_name = self.s1+'read_wout_mod_'+self.s2
+			array_mgrid_data = self.get_module_vars(module_name,realVar=realList,realLen=realLen)
+		else:
+			scalar_mgrid_data = {}
+			array_mgrid_data = {}
 		# Return
-		return scalar_data | array_data | string_data
+		return boo_indata_data | scalar_data | array_data | string_data | scalar_mgrid_data | array_mgrid_data
 
 	def read_boozer(self,file):
 		"""Reads a boozmn file and returns a dictionary

--- a/pySTEL/libstell/vmec.py
+++ b/pySTEL/libstell/vmec.py
@@ -706,9 +706,73 @@ class VMEC(FourierRep):
 		# Render if requested
 		if lrender: plt.render()
 
+	def wout_to_indata(self):
+		"""Converts an wout to indata
 
-
-
+		This routine sets the VMEC INDATA namelist via values from a
+		VMEC wout file.
+		"""
+		import numpy as np
+		indata = VMEC_INDATA()
+		indata.read_indata('')
+		#### setup indata
+		indata.delt = 1.0
+		indata.nstep = 200
+		indata.ns_array = np.round(np.array([0.125,0.25,0.5,1.0])*float(self.ns)).astype(int)
+		indata.niter_array = np.array([2000,4000,8000,20000])
+		indata.ftol_array = np.array([1E-30,1E-30,1E-30,self.ftolv])
+		indata.precon_type = 'none'
+		indata.prec2d_threshold = 1.0E-19
+		indata.lasym = self.lasym
+		indata.nfp = self.nfp
+		indata.mpol = int(np.max(self.xm)+1)
+		indata.ntor = int(np.max(self.xn)/self.nfp)
+		indata.ntheta = int(2*indata.mpol+6)
+		if indata.ntor == 0: 
+			indata.nzeta = 1
+		else:
+			indata.nzeta  = int(2*indata.ntor+4)
+		indata.phiedge = float(self.phi[-1,0])
+		indata.lfreeb  = self.lfreeb
+		if indata.lfreeb:
+			indata.extcur = self.extcur
+		indata.nvacskip = 6
+		indata.mgrid_file = self.mgrid_file.strip()
+		indata.gamma = self.gamma
+		indata.bloat = 1.0
+		indata.ncurr = 1
+		indata.curtor = self.itor
+		indata.ai = np.squeeze(self.ai)
+		indata.ac = np.squeeze(self.ac)
+		indata.am = np.squeeze(self.am)
+		indata.pmass_type = self.pmass_type.strip()
+		indata.piota_type = self.piota_type.strip()
+		indata.pcurr_type = self.pcurr_type.strip()
+		indata.pres_scale = 1.0
+		indata.update_indata()
+		pvmec = self.presf[0,0]
+		pindata = indata.pmass(0.0)/(np.pi*4E-7)
+		indata.pres_scale = float(np.round(float(pvmec/pindata),decimals=4))
+		i = 0
+		for mn in range(self.mnmax):
+			if (self.xm[mn] == 0):
+				indata.raxis_cc[i] = self.rmnc[0,mn]
+				indata.zaxis_cs[i] = self.zmns[0,mn]
+				if indata.lasym:
+					indata.raxis_cs[i] = self.rmns[0,mn]
+					indata.zaxis_cc[i] = self.zmnc[0,mn]
+				i = i + 1
+			mdex = int(self.xm[mn,0])
+			ndex = int(-self.xn[mn,0]/self.nfp+101)
+			#print(self.xn[mn,0],self.xm[mn,0],mdex,ndex)
+			#print(indata.rbc.shape)
+			indata.rbc[mdex,ndex] = self.rmnc[-1,mn]
+			indata.zbs[mdex,ndex] = self.zmns[-1,mn]
+			if indata.lasym:
+				indata.rbs[mdex,ndex] = self.rmns[-1,mn]
+				indata.zbc[mdex,ndex] = self.zmnc[-1,mn]
+		indata.update_indata()
+		indata.write_indata('input.'+self.input_extension.strip()+'_new')
 
 	def extrapSurface(self,surf=None,dist=0.1):
 		"""Returns an extrapolated surface.

--- a/pySTEL/vmec_util.py
+++ b/pySTEL/vmec_util.py
@@ -24,6 +24,8 @@ if __name__=="__main__":
 		help="Output STL file of VMEC boundary", default = False)
 	parser.add_argument("--magaxis", dest="lmagaxis", action='store_true',
 		help="Output xyz data of magnetic axis", default = False)
+	parser.add_argument("--wout2indata", dest="lwout2indata", action='store_true',
+		help="Create input file from wout data.", default = False)
 	parser.add_argument("--scale_volume", dest="new_vol",
 		help="Write indata with volume rescaled to new_vol m^3", 
 		default = 0.0, type=float)
@@ -49,6 +51,7 @@ if __name__=="__main__":
 			vmec_wout.read_wout(args.vmec_ext)
 			loutput = True
 		except:
+			vmec_wout.read_wout(args.vmec_ext)
 			print(f'Could not file input file: wout_{args.vmec_ext}.nc or wout.{args.vmec_ext}')
 		if not (linput or loutput): sys.exit(-1)
 		# Write rescaled indata
@@ -264,6 +267,9 @@ if __name__=="__main__":
 			ax.set_title("|B| at mid radius")
 			fig.colorbar(h,label='[T]')
 			pyplot.show()
+		# Output an input file from wout
+		if (loutput and args.lwout2indata):
+			vmec_wout.wout_to_indata()
 		# Output an STL file
 		if (loutput and args.lstl):
 			theta = np.linspace([0],[np.pi*2],512)


### PR DESCRIPTION
This pull request adds the ability to call `vmec_util.py` to generate a VMEC input file (INDATA) from a VMEC output file (wout). Additionally, reading wout files in python now properly handles reading the free boundary variables. Additionally, we can now plot the fieldlines in 3D from a boozmn file.