### PR TITLE
Added makefile inc for compilation in conda environment

### DIFF
--- a/SHARE/make_conda.inc
+++ b/SHARE/make_conda.inc
@@ -1,0 +1,229 @@
+#######################################################################
+#            Define Basic Utilities
+#######################################################################
+  SHELL = /bin/sh
+  ARCH := $(shell uname -m)
+  PWD1 = `pwd`
+  MYHOME ?= $(HOME)/bin
+  PRECOMP:= /lib/cpp -traditional -DLINUX
+  COMPILE = $(FC)
+  COMPILE_FREE = $(FC) -ffree-form -ffree-line-length-none -ffixed-line-length-none
+  LINK    = ld $(FLAGS) -o
+  LINK_AR = ar -ruv
+  LINK_C  = $(CC) -shared -Wl,-z-defs
+
+#######################################################################
+#            System-specific path and binary definitions
+#######################################################################
+FC = gfortran
+BLASHOME = $(CONDA_PREFIX)/lib/
+BLACS_HOME = $(CONDA_PREFIX)/lib/
+SCALAPACK_HOME = $(CONDA_PREFIX)/lib/
+MPIHOME = $(CONDA_PREFIX)/lib/
+NETCDF_HOME = $(CONDA_PREFIX)/lib/
+HDF5_HOME = $(CONDA_PREFIX)/lib/
+PGPLOT_DIR = $(CONDA_PREFIX)/lib/
+SILOHOME = $(CONDA_PREFIX)/lib/
+
+#######################################################################
+#            Define Compiler Flags
+#######################################################################
+  FLAGS_R = -O2 -fexternal-blas -fbacktrace
+  FLAGS_D = -g -O0 -fexternal-blas -fcheck=all 
+  LIBS    = -L$(CONDA_PREFIX)/lib -lopenblas -lscalapack
+
+  GFORTRAN_VERSION := $(shell $(FC) -dumpversion)
+  GFORTRAN_MAJOR_VERSION := $(firstword $(subst ., ,$(GFORTRAN_VERSION)))
+  ifeq ($(shell [ $(GFORTRAN_MAJOR_VERSION) -gt 9 ] && echo true),true)
+    FLAGS_R += -fallow-argument-mismatch
+    FLAGS_D += -fallow-argument-mismatch
+  endif
+
+#######################################################################
+#            MPI Options
+#######################################################################
+  LMPI    = T
+  MPI_COMPILE = mpif90.openmpi
+  MPI_COMPILE_FREE = $(MPI_COMPILE) -ffree-form \
+                     -ffree-line-length-none -ffixed-line-length-none
+  MPI_COMPILE_C = mpicc.openmpi
+  MPI_LINK = mpif90.openmpi
+  MPI_RUN = mpiexec
+  MPI_RUN_OPTS = --use-hwthread-cpus
+
+#######################################################################
+#            NAG Options
+#######################################################################
+  LNAG = F
+  NAG_LIB = -L$(NAG_ROOT)/lib -lnag_nag
+
+#######################################################################
+#            NETCDF Options
+#######################################################################
+  LNETCDF = T
+  NETCDF_INC = $(shell nf-config --fflags)
+  NETCDF_LIB = $(shell nf-config --flibs)
+
+#######################################################################
+#            NTCC Options
+#######################################################################
+  LNTCC = F
+  NTCC_INC = -I$(NTCCHOME)/mod
+  NTCC_LIB = -L$(NTCCHOME)/lib -laladdinsub -lr8slatec -ladpak\
+             -lcppsub -lcomput -lpspline -lportlib -lezcdf -lmds_sub \
+             -lmdstransp -lvaxonly
+
+#######################################################################
+#            HDF5 Options
+#######################################################################
+  LHDF5 = T
+  HDF5_INC = -I$(CONDA_PREFIX)/include/
+  HDF5_LIB = -L$(CONDA_PREFIX)/lib/hdf5/ \
+             -lhdf5 -lhdf5hl_fortran -lhdf5_hl -lhdf5_fortran
+
+#######################################################################
+#             PGPLOT Options
+#######################################################################
+  LPGPLOT = F
+  PGPLOT_INC = -I$(PGPLOT_DIR)
+  PGPLOT_LIB = -L$(PGPLOT_DIR) -lpgplot -L$(CONDA_PREFIX)/lib -lX11
+
+#######################################################################
+#             SILO Options
+#######################################################################
+  LSILO = F
+  SILO_INC = -I$(SILOHOME)/include
+  SILO_LIB = -L$(SILOHOME)/lib -lsiloh5
+
+#######################################################################
+#            FFTW3 Options
+#######################################################################
+  LFFTW3 = F
+  FFTW3_INC = 
+  FFTW3_LIB = 
+
+#######################################################################
+#            DKES/NEO Options
+#######################################################################
+  LDKES = T
+  LNEO  = T
+
+#######################################################################
+#            GENE Options
+#######################################################################
+ifneq ("$(wildcard $(GENE_PATH))","")
+  LGENE = T
+  GENE_INC = -I$(GENE_PATH)
+  GENE_DIR = $(GENE_PATH)
+  LIB_GENE = libgene.a
+  GENE_LIB = $(GENE_DIR)/$(LIB_GENE) \
+             -L/u/slazerso/src/GENE17_2016/external/pppl_cluster/futils/src -lfutils \
+             -L$(FFTWHOME)/lib -lfftw3 \
+             -L$(SLEPC_DIR)/$(PETSC_ARCH)/lib -lslepc \
+             -L$(PETSC_DIR)/$(PETSC_ARCH)/lib -lpetsc -lX11
+else
+  LGENE = F
+endif
+
+#######################################################################
+#            COILOPT++ Options
+#######################################################################
+ifneq ("$(wildcard $(COILOPT_PATH))","")
+  LCOILOPT = T
+  COILOPT_INC = -I$(COILOPT_PATH)
+  COILOPTPP_DIR = $(COILOPT_PATH)
+  LIB_COILOPTPP = libcoilopt++.a
+  COILOPT_LIB = $(COILOPT_PATH)/$(LIB_COILOPTPP) \
+                -L$(GSLHOME)/lib -lgsl -lgslcblas -lstdc++ -lmpi_cxx
+else
+  LCOILOPT = F
+endif
+
+#######################################################################
+#            TERPSICHORE Options
+#######################################################################
+ifneq ("$(wildcard $(TERPSICHORE_PATH))","")
+  LTERPSICHORE= T
+  TERPSICHORE_INC = -I$(TERPSICHORE_PATH)
+  TERPSICHORE_DIR = $(TERPSICHORE_PATH)
+  LIB_TERPSICHORE = libterpsichore.a
+  TERPSICHORE_LIB = $(TERPSICHORE_DIR)/$(LIB_TERPSICHORE)
+else
+  LTERPSICHORE = F
+endif
+
+#######################################################################
+#            TRAVIS Options
+#######################################################################
+ifneq ("$(wildcard $(TRAVIS_PATH))","")
+  LTRAVIS = T
+  TRAVIS_DIR = $(TRAVIS_PATH)
+  LIB_TRAVIS = libtravis64_sopt.a
+  LIB_MCONF  = libmconf64.a
+  LIB_FADDEEVA = libfaddeeva64.a
+  TRAVIS_LIB = $(TRAVIS_DIR)lib/$(LIB_TRAVIS) \
+               $(TRAVIS_DIR)faddeeva_package/lib/$(LIB_FADDEEVA) \
+               $(TRAVIS_DIR)magconf/lib/$(LIB_MCONF) -lstdc++
+else
+  LTRAVIS = F
+endif
+
+#######################################################################
+#            REGCOIL Options
+#######################################################################
+ifneq ("$(wildcard $(REGCOIL_PATH))","")
+  LREGCOIL= T
+  REGCOIL_DIR = $(REGCOIL_PATH)
+  REGCOIL_INC = -I$(REGCOIL_DIR) 
+  LIB_REGCOIL = libregcoil.a
+  REGCOIL_LIB = $(REGCOIL_DIR)/$(LIB_REGCOIL) -fopenmp
+else
+  LREGCOIL = F
+endif
+
+#######################################################################
+#            SFINCS Options
+#######################################################################
+ifneq ("$(wildcard $(SFINCS_PATH))","")
+  LSFINCS = T
+  SFINCS_DIR = $(SFINCS_PATH)
+  SFINCS_INC = -I$(SFINCS_DIR)
+  LIB_SFINCS = libsfincs.a
+  SFINCS_LIB = $(SFINCS_DIR)/$(LIB_SFINCS) \
+             -L$(PETSC_DIR)/$(PETSC_ARCH)/lib -lpetsc -lX11
+else
+  LSFINCS = F
+endif
+
+#######################################################################
+#            Available Energy Options
+#######################################################################
+ifneq ("$(wildcard $(AEOPT_PATH))","")
+  LAEOPT = T
+  AEOPT_DIR = $(AEOPT_PATH)
+  AEOPT_INC = -I$(AEOPT_DIR) 
+  LIB_AEOPT = libtrapAE.a
+  AEOPT_LIB = $(AEOPT_PATH)/$(LIB_AEOPT)
+else
+  LAEOPT = F
+endif
+
+#######################################################################
+#            MANGO Options
+#######################################################################
+ifneq ("$(wildcard $(MANGO_PATH))","")
+  LMANGO = T
+  MANGO_DIR = $(MANGO_PATH)
+# Any flags specified on the next 2 lines will be added to the
+# MANGO_F_COMPILE_FLAGS and MANGO_F_LINK_FLAGS lines as defined in
+# $(MANGO_DIR)/lib/mangoMakeVariables
+  MANGO_INC = 
+  MANGO_LIB = 
+else
+  LMANGO = F
+endif
+
+#######################################################################
+#            LIBSTELL Shared Options
+#######################################################################
+LIB_SHARE = -lc -lgfortran -lstdc++ -lmpi -lmpi_mpifh -lz -lc -lm -lpthread $(LIBS) -lc


### PR DESCRIPTION
This adds an include file for compilation in a conda environment. This has been modified from `make_debian.inc`.

Instructions for environment creation and compilation (which can be added directly to the gh-pages branch) are below. One potential issue lies with the `scalapack` package, as it is unclear whether it is mpi-enabled and I don't know how to test if it is. 

 

STELLOPT Compilation in a Conda environment
==============================

This page details how to compile the STELLOPT family of codes in a
[conda](https://conda-forge.org/) environment. 

Installation Steps
-----

1\. Create your environment (here named `stellopt_env`) and install its dependencies

    conda create -n stellopt_env gfortran gxx hdf5[build="mpi*"] hdf5tools netcdf-fortran netcdf4 openblas openmpi-mpifort python scalapack

2\. Activate your environment

    conda activate stellopt_env

3\. Setup your environment variables

    export MACHINE="conda"
    export STELLOPT_PATH=<path to repo directory>

If you are already on the repo directory, then:

    export STELLOPT_PATH=$(pwd)