### PR TITLE
Fix GCC version comparison for versions >= 10

### DIFF
--- a/SHARE/make_debian.inc
+++ b/SHARE/make_debian.inc
@@ -33,7 +33,8 @@ SILOHOME = /usr/lib/$(ARCH)-linux-gnu
   LIBS    = -L/usr/lib -lopenblas -lscalapack-openmpi
 
   GFORTRAN_VERSION := $(shell $(FC) -dumpversion)
-  ifeq "$(shell [ $(GFORTRAN_VERSION) -gt 9 ] && echo true)" "true"
+  GFORTRAN_VERSION_MAJOR := $(firstword $(subst ., ,$(GFORTRAN_VERSION)))
+  ifeq "$(shell [ $(GFORTRAN_VERSION_MAJOR) -gt 9 ] && echo true)" "true"
       FLAGS_R += -fallow-argument-mismatch
       FLAGS_D += -fallow-argument-mismatch
   endif

--- a/SHARE/make_redhat.inc
+++ b/SHARE/make_redhat.inc
@@ -21,7 +21,8 @@
             /lib64/openmpi/lib/libscalapack.so.2
 
   GFORTRAN_VERSION := $(shell $(FC) -dumpversion)
-  ifeq "$(shell [ $(GFORTRAN_VERSION) -gt 9 ] && echo true)" "true"
+  GFORTRAN_VERSION_MAJOR := $(firstword $(subst ., ,$(GFORTRAN_VERSION)))
+  ifeq "$(shell [ $(GFORTRAN_VERSION_MAJOR) -gt 9 ] && echo true)" "true"
       FLAGS_R += -fallow-argument-mismatch
       FLAGS_D += -fallow-argument-mismatch
   endif

--- a/SHARE/make_ubuntu.inc
+++ b/SHARE/make_ubuntu.inc
@@ -31,7 +31,8 @@
 
   # Need to allow argument mismatch for gfortran version 10 and above
   GFORTRAN_VERSION := $(shell $(FC) -dumpversion)
-  ifeq "$(shell [ $(GFORTRAN_VERSION) -gt 9 ] && echo true)" "true"
+  GFORTRAN_VERSION_MAJOR := $(firstword $(subst ., ,$(GFORTRAN_VERSION)))
+  ifeq "$(shell [ $(GFORTRAN_VERSION_MAJOR) -gt 9 ] && echo true)" "true"
       FLAGS_R += -fallow-argument-mismatch
       FLAGS_D += -fallow-argument-mismatch
   endif


### PR DESCRIPTION
## Summary

The shell comparison `[ $(GFORTRAN_VERSION) -gt 9 ]` in make_debian.inc, make_redhat.inc, and make_ubuntu.inc fails when `gfortran -dumpversion` returns a semver string like "15.2.1" (as seen with GCC 15+):

```
/bin/sh: line 1: [: 15.2.1: integer expected
```

This happens because the `-gt` operator expects integers, not strings containing dots.

## Changes

Extract the major version number before comparison using make's `firstword` and `subst` functions:

```makefile
GFORTRAN_VERSION := $(shell $(FC) -dumpversion)
GFORTRAN_VERSION_MAJOR := $(firstword $(subst ., ,$(GFORTRAN_VERSION)))
ifeq "$(shell [ $(GFORTRAN_VERSION_MAJOR) -gt 9 ] && echo true)" "true"
```

This converts "15.2.1" to "15" before the integer comparison.

## Files modified

- SHARE/make_debian.inc
- SHARE/make_redhat.inc
- SHARE/make_ubuntu.inc

## Test plan

- Tested with GCC 15.2.1 on Arch Linux - version comparison now works correctly