### PR TITLE
Update Arch Linux configuration for standard pacman packages

### DIFF
--- a/SHARE/make_arch_linux.inc
+++ b/SHARE/make_arch_linux.inc
@@ -1,7 +1,13 @@
 #######################################################################
+#            Arch Linux Configuration
+#            For use with pacman packages: openmpi, hdf5-openmpi,
+#            netcdf-openmpi, scalapack, blas, lapack
+#######################################################################
+
+#######################################################################
 #            Define Basic Utilities
 #######################################################################
-  SHELL ?= /bin/zsh
+  SHELL ?= /bin/sh
   PWD1 = `pwd`
   MYHOME = $(HOME)/bin
   PRECOMP:= /usr/bin/cpp -traditional -DLINUX
@@ -25,13 +31,10 @@
   MPI_COMPILE = mpif90
   MPI_COMPILE_FREE = mpif90 -ffree-form \
                      -ffree-line-length-none -ffixed-line-length-none
-  MPI_COMPILE_C = mpicc.openmpi
+  MPI_COMPILE_C = mpicc
   MPI_LINK = mpif90
   MPI_RUN = mpiexec
-  MPI_RUN_OPTS = -np 4
-#  MPI_RUN_OPTS_SM = -np 16
-#  MPI_RUN_OPTS_MD = -np 64
-#  MPI_RUN_OPTS_LG = -np 256
+  MPI_RUN_OPTS = --use-hwthread-cpus
 
 #######################################################################
 #            NAG Options
@@ -50,8 +53,8 @@
 #            NTCC Options
 #######################################################################
   LNTCC = F
-  NTCC_INC = -I/usr/include
-  NTCC_LIB = -L/usr/lib -laladdinsub -lr8slatec -ladpak\
+  NTCC_INC = -I$(NTCCHOME)/mod
+  NTCC_LIB = -L$(NTCCHOME)/lib -laladdinsub -lr8slatec -ladpak\
              -lcppsub -lcomput -lpspline -lportlib -lezcdf -lmds_sub \
              -lmdstransp -lvaxonly
 
@@ -60,29 +63,28 @@
 #######################################################################
   LHDF5 = T
   HDF5_INC = -I/usr/include
-  HDF5_LIB = -L/usr/lib \
-             -lhdf5 -lhdf5hl_fortran -lhdf5_hl -lhdf5_fortran
+  HDF5_LIB = -L/usr/lib -lhdf5 -lhdf5_hl -lhdf5_fortran -lhdf5_hl_fortran
 
 #######################################################################
 #             PGPLOT Options
 #######################################################################
   LPGPLOT = F
   PGPLOT_INC = -I$(PGPLOT_DIR)
-  PGPLOT_LIB = -L$(PGPLOT_DIR) -lpgplot -L/usr/lib/x86_64-linux-gnu -lX11
+  PGPLOT_LIB = -L$(PGPLOT_DIR) -lpgplot -L/usr/lib -lX11
 
 #######################################################################
 #             SILO Options
 #######################################################################
   LSILO = F
   SILO_INC = -I$(SILOHOME)/include
-  SILO_LIB = -L$(SILOHOME)/lib/x86_64-linux-gnu -lsiloh5
+  SILO_LIB = -L$(SILOHOME)/lib -lsiloh5
 
 #######################################################################
 #            FFTW3 Options
 #######################################################################
   LFFTW3 = F
-  FFTW3_INC = 
-  FFTW3_LIB = 
+  FFTW3_INC =
+  FFTW3_LIB =
 
 #######################################################################
 #            DKES/NEO Options
@@ -93,62 +95,101 @@
 #######################################################################
 #            GENE Options
 #######################################################################
-  LGENE = F
+ifneq ("$(wildcard $(GENE_PATH))","")
+  LGENE = T
   GENE_INC = -I$(GENE_PATH)
   GENE_DIR = $(GENE_PATH)
   LIB_GENE = libgene.a
   GENE_LIB = $(GENE_DIR)/$(LIB_GENE) \
-             -L/u/slazerso/src/GENE17_2016/external/pppl_cluster/futils/src -lfutils \
              -L$(FFTWHOME)/lib -lfftw3 \
              -L$(SLEPC_DIR)/$(PETSC_ARCH)/lib -lslepc \
              -L$(PETSC_DIR)/$(PETSC_ARCH)/lib -lpetsc -lX11
+else
+  LGENE = F
+endif
 
 #######################################################################
 #            COILOPT++ Options
 #######################################################################
-  LCOILOPT = F
+ifneq ("$(wildcard $(COILOPT_PATH))","")
+  LCOILOPT = T
   COILOPT_INC = -I$(COILOPT_PATH)
   COILOPTPP_DIR = $(COILOPT_PATH)
   LIB_COILOPTPP = libcoilopt++.a
   COILOPT_LIB = $(COILOPT_PATH)/$(LIB_COILOPTPP) \
-                -L$(GSLHOME)/lib/x86_64-linux-gnu -lgsl -lgslcblas -lstdc++ -lmpi_cxx
+                -L$(GSLHOME)/lib -lgsl -lgslcblas -lstdc++
+else
+  LCOILOPT = F
+endif
 
 #######################################################################
 #            TERPSICHORE Options
 #######################################################################
-  LTERPSICHORE= F
+ifneq ("$(wildcard $(TERPSICHORE_PATH))","")
+  LTERPSICHORE= T
   TERPSICHORE_INC = -I$(TERPSICHORE_PATH)
   TERPSICHORE_DIR = $(TERPSICHORE_PATH)
   LIB_TERPSICHORE = libterpsichore.a
   TERPSICHORE_LIB = $(TERPSICHORE_DIR)/$(LIB_TERPSICHORE)
+else
+  LTERPSICHORE = F
+endif
 
 #######################################################################
 #            TRAVIS Options
 #######################################################################
-  LTRAVIS= F
+ifneq ("$(wildcard $(TRAVIS_PATH))","")
+  LTRAVIS = T
   TRAVIS_DIR = $(TRAVIS_PATH)
   LIB_TRAVIS = libtravis64_sopt.a
   LIB_MCONF  = libmconf64.a
-  TRAVIS_LIB = $(TRAVIS_DIR)/lib/$(LIB_TRAVIS) \
-               $(TRAVIS_DIR)/mag_conf/lib/$(LIB_MCONF) -lstdc++
+  LIB_FADDEEVA = libfaddeeva64.a
+  TRAVIS_LIB = $(TRAVIS_DIR)lib/$(LIB_TRAVIS) \
+               $(TRAVIS_DIR)faddeeva_package/lib/$(LIB_FADDEEVA) \
+               $(TRAVIS_DIR)magconf/lib/$(LIB_MCONF) -lstdc++
+else
+  LTRAVIS = F
+endif
 
 #######################################################################
 #            REGCOIL Options
 #######################################################################
-  LREGCOIL= F
+ifneq ("$(wildcard $(REGCOIL_PATH))","")
+  LREGCOIL= T
   REGCOIL_DIR = $(REGCOIL_PATH)
-  REGCOIL_INC = -I$(REGCOIL_DIR) 
+  REGCOIL_INC = -I$(REGCOIL_DIR)
   LIB_REGCOIL = libregcoil.a
   REGCOIL_LIB = $(REGCOIL_DIR)/$(LIB_REGCOIL) -fopenmp
+else
+  LREGCOIL = F
+endif
+
+#######################################################################
+#            SFINCS Options
+#######################################################################
+ifneq ("$(wildcard $(SFINCS_PATH))","")
+  LSFINCS = T
+  SFINCS_DIR = $(SFINCS_PATH)
+  SFINCS_INC = -I$(SFINCS_DIR)
+  LIB_SFINCS = libsfincs.a
+  SFINCS_LIB = $(SFINCS_DIR)/$(LIB_SFINCS) \
+             -L$(PETSC_DIR)/$(PETSC_ARCH)/lib -lpetsc -lX11
+else
+  LSFINCS = F
+endif
 
 #######################################################################
 #            Available Energy Options
 #######################################################################
-  LAEOPT= F
+ifneq ("$(wildcard $(AEOPT_PATH))","")
+  LAEOPT = T
   AEOPT_DIR = $(AEOPT_PATH)
-  AEOPT_INC = -I$(AEOPT_DIR) 
+  AEOPT_INC = -I$(AEOPT_DIR)
   LIB_AEOPT = libtrapAE.a
   AEOPT_LIB = $(AEOPT_PATH)/$(LIB_AEOPT)
+else
+  LAEOPT = F
+endif
 
 #######################################################################
 #            MANGO Options
@@ -156,11 +197,8 @@
 ifneq ("$(wildcard $(MANGO_PATH))","")
   LMANGO = T
   MANGO_DIR = $(MANGO_PATH)
-# Any flags specified on the next 2 lines will be added to the
-# MANGO_F_COMPILE_FLAGS and MANGO_F_LINK_FLAGS lines as defined in
-# $(MANGO_DIR)/lib/mangoMakeVariables
-  MANGO_INC = 
-  MANGO_LIB = 
+  MANGO_INC =
+  MANGO_LIB =
 else
   LMANGO = F
 endif
@@ -168,34 +206,4 @@ endif
 #######################################################################
 #            LIBSTELL Shared Options
 #######################################################################
-#LIB_SHARE = $(BLASHOME)/lib/libblas.so \
-          $(SCALAPACK_HOME)/lib/libscalapack-openmpi.so \
-          $(BLACS_HOME)/lib/libblacs-openmpi.so  $(BLACS_HOME)/lib/libblacsCinit-openmpi.so $(BLACS_HOME)/lib/libblacsF77init-openmpi.so \
-          $(HDF5_HOME)/lib/x86_64-linux-gnu/libhdf5_hl.so $(HDF5_HOME)/lib/x86_64-linux-gnu/libhdf5_fortran.so $(HDF5_HOME)/lib/x86_64-linux-gnu/libhdf5hl_fortran.so $(HDF5_HOME)/lib/x86_64-linux-gnu/libhdf5.so \
-          $(HDF5_HOME)/lib/x86_64-linux-gnu/libmpi_usempif08.so $(HDF5_HOME)/lib/x86_64-linux-gnu/libhdf5_openmpi_fortran.so \
-          $(NETCDF_HOME)/lib/x86_64-linux-gnu/libnetcdf.so $(NETCDF_HOME)/lib/x86_64-linux-gnu/libnetcdff.so $(NETCDF_HOME)/lib/x86_64-linux-gnu/libnetcdf_c++.so \
-          $(SILOHOME)/lib/x86_64-linux-gnu/libsiloh5.so \
-          $(GSLHOME)/lib/x86_64-linux-gnu/libgsl.so \
-          $(GCC6_HOME)/libgfortran.so $(GCC6_HOME)/libstdc++.so \
-          $(MPIHOME)/lib/x86_64-linux-gnu/libmpi.so $(MPIHOME)/lib/x86_64-linux-gnu/libmpi_mpifh.so \
-          /usr/lib/x86_64-linux-gnu/libm.so /usr/lib/liblapack.so /usr/lib/x86_64-linux-gnu/libdl.so
-#LIB_SHARE = $(BLASHOME)/lib/libblas.so \
-          $(SCALAPACK_HOME)/lib/libscalapack-openmpi.so.1 \
-          $(BLACS_HOME)/lib/libblacs-openmpi.so.1 \
-          $(BLACS_HOME)/lib/libblacsCinit-openmpi.so.1 \
-          $(BLACS_HOME)/lib/libblacsF77init-openmpi.so.1 \
-          $(HDF5_HOME)/lib/x86_64-linux-gnu/libhdf5_openmpi_fortran.so \
-          $(NETCDF_HOME)/lib/libnetcdf.so \
-          $(NETCDF_HOME)/lib/libnetcdff.so \
-          $(NETCDF_HOME)/lib/libnetcdf_c++.so \
-          $(SILOHOME)/lib/x86_64-linux-gnu/libsiloh5.so \
-          $(GSLHOME)/lib/x86_64-linux-gnu/libgsl.so \
-          $(GCC49_HOME)/libgfortran.so \
-          $(GCC49_HOME)/libstdc++.so \
-          $(MPIHOME)/lib/libmpi.so \
-          $(MPIHOME)/lib/libmpif77.so \
-          /usr/lib/x86_64-linux-gnu/libm.so \
-          /usr/lib/liblapack.so \
-          /usr/lib/x86_64-linux-gnu/libdl.so
-
-
+LIB_SHARE = -lc -lgfortran -lstdc++ -lmpi -lmpi_mpifh -lz -lc -lm -lpthread $(LIBS) -lc


### PR DESCRIPTION
## Summary

Updates the Arch Linux machine configuration to work correctly with standard pacman packages.

## Changes

- Add descriptive header listing required pacman packages (openmpi, hdf5-openmpi, netcdf-openmpi, scalapack, blas, lapack)
- Use standard `mpicc`/`mpif90` without `.openmpi` suffix (Arch convention)
- Fix HDF5 library names to use underscores (`hdf5_hl_fortran` vs `hdf5hl_fortran`) matching Arch package naming
- Remove Debian-specific `x86_64-linux-gnu` paths
- Add missing SFINCS section for optional SFINCS support
- Use wildcard detection for optional components (GENE, COILOPT++, TERPSICHORE, TRAVIS, REGCOIL, SFINCS, AEOPT, MANGO)
- Clean up trailing whitespace and commented-out code
- Use `--use-hwthread-cpus` for MPI run options

## Test plan

- Tested on Arch Linux with packages: `openmpi`, `hdf5-openmpi`, `netcdf-openmpi`, `scalapack`, `blas`, `lapack`