### PR TITLE
Modifications to the transport solver PID's and changing of gyro-Bohm definition

### DIFF
--- a/LIBSTELL/Sources/Modules/thrift_globals.f90
+++ b/LIBSTELL/Sources/Modules/thrift_globals.f90
@@ -55,7 +55,7 @@
       INTEGER, PARAMETER :: nions_max = 6
       REAL(rprec) :: dt_plasma_solver, tol_plasma_solver
       REAL(rprec) :: stiffness_beurskens, aLT_critical_beurskens, alpha_beurskens, &
-                     alpha_chi_external, tau_fast_alphas
+                     alpha_chi_external, tau_fast_alphas, mass_ref_species
       INTEGER :: max_subiter_plasma_solver, Nr_plasma_solver
       REAL(rprec), DIMENSION(nions_max+1) :: chi_all, T0_init_all, frac_alpha_heating
       REAL(rprec), DIMENSION(nions_max) :: Dn_ions, N0_init_ions

--- a/LIBSTELL/Sources/Modules/thrift_input_mod.f90
+++ b/LIBSTELL/Sources/Modules/thrift_input_mod.f90
@@ -45,7 +45,7 @@
                               Dn_ions, chi_all, N0_init_ions, T0_init_all, &
                               stiffness_beurskens, aLT_critical_beurskens, &
                               alpha_beurskens, frac_alpha_heating, alpha_chi_external, &
-                              tau_fast_alphas
+                              tau_fast_alphas, mass_ref_species
       
 !-----------------------------------------------------------------------
 !     Subroutines
@@ -122,6 +122,7 @@
       frac_alpha_heating(2) = 0.1
       frac_alpha_heating(3) = 0.1
       tau_fast_alphas = 0.5
+      mass_ref_species = 1.6726219E-27
       RETURN
       END SUBROUTINE init_thrift_input
       

--- a/THRIFT/Sources/thrift_plasma_solver_mod.f90
+++ b/THRIFT/Sources/thrift_plasma_solver_mod.f90
@@ -1264,11 +1264,11 @@ MODULE thrift_plasma_solver_mod
         ! Ion database
         REAL(rprec), PARAMETER :: DA = 1.66053906660E-27
         CHARACTER(len=10), PARAMETER :: names(*) = [ &
-            'hydrogen  ', 'deuterium ', 'tritium   ', 'helium3   ', 'helium4   ', 'tungsten74' ]
+            'hydrogen  ', 'deuterium ', 'tritium   ', 'helium3   ', 'helium4   ','neon      ', 'tungsten74' ]
         REAL(rprec), PARAMETER :: mass_database(*) = [ &
             1.007276466621_rprec, 2.01410177811_rprec, 3.01604928_rprec, &
-            3.0160293_rprec, 4.002603254_rprec, 183.84_rprec ]
-        REAL(rprec), PARAMETER :: Zcharge_database(*) = [ 1., 1., 1., 2., 2., 74. ]
+            3.0160293_rprec, 4.002603254_rprec, 20.1797_rprec, 183.84_rprec ]
+        REAL(rprec), PARAMETER :: Zcharge_database(*) = [ 1., 1., 1., 2., 2., 10., 74. ]
 
         DO i = 1, num_ions
             found = .false.

--- a/THRIFT/Sources/thrift_plasma_solver_mod.f90
+++ b/THRIFT/Sources/thrift_plasma_solver_mod.f90
@@ -1244,7 +1244,7 @@ MODULE thrift_plasma_solver_mod
         REAL(rprec), INTENT(in) :: t,te_eV,ne,ti_eV,ni,max_dp,max_dn
         CHARACTER(len = 200) :: progress_str
 
-        WRITE(progress_str,'(1X,F6.3,3X,I2,6X,F7.3,11X,ES8.2,11X,F7.3,13X,ES8.2,12X,ES8.2,11X,ES8.2)') &
+        WRITE(progress_str,'(1X,F7.3,3X,I2,6X,F7.3,11X,ES8.2,11X,F7.3,13X,ES8.2,12X,ES8.2,11X,ES8.2)') &
                   t,nsub,te_eV/1000,ne,ti_eV/1000,ni,max_dp,max_dn
         WRITE(ilogplasma,'(A)') TRIM(progress_str)
 

--- a/THRIFT/Sources/thrift_plasma_solver_mod.f90
+++ b/THRIFT/Sources/thrift_plasma_solver_mod.f90
@@ -1067,26 +1067,32 @@ MODULE thrift_plasma_solver_mod
     SUBROUTINE get_beurskens_ions_chi(iion,chi_beurskens)
         !--------------------------------------------------------------
         !--------------------------------------------------------------
-        REAL(rprec) :: mi,qi,B
+        REAL(rprec) :: Bref,mref
         INTEGER, INTENT(IN) :: iion
         INTEGER :: ier,Nr
         REAL(rprec), INTENT(INOUT), DIMENSION(:) :: chi_beurskens
-        REAL(rprec), DIMENSION(:), ALLOCATABLE :: Bsq,chi_gB,dTidrho,X,H,Te,Ti
-
-        mi = Matom_prof(iion)
-        qi = e_charge * Zatom_prof(iion)
+        REAL(rprec), DIMENSION(:), ALLOCATABLE :: chi_gB,dTidrho,X,H,Te,Ti,ni,nref,Tref,Q_gB
 
         Nr = Nr_plasma_solver
 
-        ALLOCATE(Bsq(Nr),chi_gB(Nr),dTidrho(Nr),X(Nr),H(Nr),Te(Nr),Ti(Nr))
-
-        CALL EZspline_interp(bsq_spl,Nr,rho_plasma_grid,Bsq,ier)
+        ALLOCATE(chi_gB(Nr),dTidrho(Nr),X(Nr),H(Nr),Te(Nr),Ti(Nr),ni(Nr),nref(Nr),Tref(Nr),Q_gB(Nr))
 
         Te = plasma_T(1,:)
         Ti = plasma_T(1+iion,:)
+        ni = plasma_N(1+iion,:)
 
-        !chi gyroBohm (for the scaling)
-        chi_gB = (e_charge*Ti/mi)**1.5 * mi*mi / (qi**2 * Bsq) / eq_Aminor
+        ! Currently we assume that T_ref~T_j and n_ref~n_j
+        nref = ni
+        Tref = Ti
+        mref = mass_ref_species
+        Bref = eq_phiedge / (pi*eq_Aminor**2)
+
+        !Q gyroBohm (for the scaling)
+        Q_gB = 2.0_rprec * SQRT(2.0_rprec) * nref * SQRT(mref) * (e_charge*Tref)**2.5_rprec
+        Q_gB = Q_gB / (e_charge*Bref*eq_Aminor)**2
+        
+        !chi gyroBohm
+        chi_gB = Q_gB * eq_Aminor/(ni*e_charge*Ti)
         
         ! dimensionless Beurskens model
         ! CALL EZspline_derivative1_array_r8(T_splines(1+iion), 1, Nr,rho_plasma_grid,dTidrho,ier)
@@ -1100,7 +1106,7 @@ MODULE thrift_plasma_solver_mod
         
         chi_beurskens = chi_gB * stiffness_beurskens * X * H * (Te/Ti)**alpha_beurskens
 
-        DEALLOCATE(Bsq,chi_gB,dTidrho,X,H,Te,Ti)
+        DEALLOCATE(chi_gB,dTidrho,X,H,Te,Ti,ni,nref,Tref,Q_gB)
         
         RETURN
 
@@ -1110,33 +1116,31 @@ MODULE thrift_plasma_solver_mod
         !--------------------------------------------------------------
         !--------------------------------------------------------------
         ! Computes chi by multiplying normalized chi with chi_gB
-        REAL(rprec) :: mi,qi,B
+        REAL(rprec) :: Bref,mref
         INTEGER, INTENT(IN) :: ispecies
         INTEGER :: ier,Nr,iion
         REAL(rprec), INTENT(INOUT), DIMENSION(:) :: chi_external
-        REAL(rprec), DIMENSION(:), ALLOCATABLE :: Bsq,chi_gB,dTdrho,T,Te,Ti,aLT,chi_normalized
+        REAL(rprec), DIMENSION(:), ALLOCATABLE :: chi_gB,dTdrho,T,n,Te,Ti,aLT,chi_normalized,nref,Tref,Q_gB
 
         Nr = Nr_plasma_solver
-        ALLOCATE(Bsq(Nr),chi_gB(Nr),dTdrho(Nr),T(Nr),Te(Nr),Ti(Nr),aLT(Nr),chi_normalized(Nr))
+        ALLOCATE(chi_gB(Nr),dTdrho(Nr),T(Nr),n(Nr),Te(Nr),aLT(Nr),chi_normalized(Nr),nref(Nr),Tref(Nr),Q_gB(Nr))
 
-        ! In case of electrons, use chi_gB of the 1st ion
-        IF(ispecies==1) THEN 
-            iion=1
-            Ti = plasma_T(1,:)
-        ELSE
-            iion=ispecies-1
-            Ti = plasma_T(ispecies,:)
-        ENDIF
-        mi = Matom_prof(iion)
-        qi = e_charge * Zatom_prof(iion)
-
-        T = plasma_T(ispecies,:)
         Te = plasma_T(1,:)
+        T = plasma_T(ispecies,:)
+        n = plasma_N(ispecies,:)
 
-        CALL EZspline_interp(bsq_spl,Nr,rho_plasma_grid,Bsq,ier)
+        ! Currently we assume that T_ref~T_j and n_ref~n_j
+        nref = n
+        Tref = T
+        mref = mass_ref_species
+        Bref = eq_phiedge / (pi*eq_Aminor**2)
 
-        !chi gyroBohm (for the scaling)
-        chi_gB = (e_charge*Ti/mi)**1.5 * mi*mi / (qi**2 * Bsq) / eq_Aminor
+        !Q gyroBohm (for the scaling)
+        Q_gB = 2.0_rprec * SQRT(2.0_rprec) * nref * SQRT(mref) * (e_charge*Tref)**2.5_rprec
+        Q_gB = Q_gB / (e_charge*Bref*eq_Aminor)**2
+        
+        !chi gyroBohm
+        chi_gB = Q_gB * eq_Aminor/(n*e_charge*T)
 
         ! CALL EZspline_derivative1_array_r8(T_splines(1+iion), 1, Nr,rho_plasma_grid,dTdrho,ier)
         ! IF(ier /= 0) CALL handle_err(EZSPLINE_ERR,'interpolating: T_splines',ier) 
@@ -1146,9 +1150,8 @@ MODULE thrift_plasma_solver_mod
         ! get normalized chi
         CALL EZspline_interp(chi_normalized_splines(ispecies),Nr,rho_plasma_grid,aLT,chi_normalized,ier)
         chi_external = chi_gB * chi_normalized * (Te/T)**alpha_chi_external
-        ! print *, chi_normalized
 
-        DEALLOCATE(Bsq,chi_gB,dTdrho,T,Te,Ti,aLT,chi_normalized)
+        DEALLOCATE(chi_gB,dTdrho,T,n,Te,aLT,chi_normalized,nref,Tref,Q_gB)
         
         RETURN
 

--- a/pySTEL/libstell/plasma_solver.py
+++ b/pySTEL/libstell/plasma_solver.py
@@ -208,7 +208,7 @@ class PLASMA_SOLVER:
                     
     def set_energy_source(self,species,source_type, total_power=None, sigma_rho=None, rho_0=None, 
         fraction_alpha_heating=None, cte_source=None, time_dependent_factor=None, lambda_function_2D=None,
-        pidK=1000,pidI=10.0,pidD=1.0):
+        pidK=1.0,pidI=1.0E10,pidD=0.0,noise_level=0.00):
         """
         Sets energy sources for a given species. The source_type can be:
         'external_gaussian', 'time_dependent_gaussian', 'Coll_Heat_Exchange', 'Er', 'alpha_heating', 'constant', 'lambda_2D' and 'Bremsstrahlung' (only for electrons)
@@ -249,7 +249,8 @@ class PLASMA_SOLVER:
                 else:
                     self.energy_sources[species][source_type] = {'total_power' : total_power, 'rho_0' : rho_0, 
                     'sigma_rho' : sigma_rho, 'time_factor': time_dependent_factor,
-                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0 }
+                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0 ,
+                    'noise_level' : noise_level, 'previous_error' : 0.0}
             #
             case 'Coll_Heat_Exchange':
                 self.energy_sources[species][source_type] = {}
@@ -290,7 +291,7 @@ class PLASMA_SOLVER:
                 
     def set_particle_source(self,species,source_type, injected_particles_per_sec=None, rho_0=None, sigma_rho=None, 
         cte_source=None, time_dependent_factor=None, lambda_function_2D=None,
-        pidK=1000,pidI=10.0,pidD=1.0):
+        pidK=1.0,pidI=1.0E10,pidD=0.0,noise_level=0.0):
         """
         Sets particle sources for a given species. The source_type can be:
         'external_gaussian', 'time_dependent_gaussian', 'constant', 'lambda_2D',
@@ -321,14 +322,24 @@ class PLASMA_SOLVER:
                 else:
                     self.particle_sources[species][source_type] = {'injected_particles_per_sec' : injected_particles_per_sec, 'rho_0' : rho_0, 
                     'sigma_rho' : sigma_rho, 'time_factor': time_dependent_factor,
-                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0 }
+                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0,
+                    'noise_level' : noise_level, 'previous_error' : 0.0}
             case 'PID_pfuse_gaussian':
                 if((rho_0 is None) or (sigma_rho is None) or (time_dependent_factor is None)):
                     raise ValueError('ERROR: Need to provide injected_particles_per_sec, rho_0, sigma_rho and a time depenedent factor for PID total fusion power gaussian')
                 else:
                     self.particle_sources[species][source_type] = {'injected_particles_per_sec' : injected_particles_per_sec, 'rho_0' : rho_0, 
                     'sigma_rho' : sigma_rho, 'time_factor': time_dependent_factor,
-                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0 }
+                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0,
+                    'noise_level' : noise_level, 'previous_error' : 0.0}
+            case 'PID_pradfrac_gaussian':
+                if((rho_0 is None) or (sigma_rho is None) or (time_dependent_factor is None)):
+                    raise ValueError('ERROR: Need to provide injected_particles_per_sec, rho_0, sigma_rho and a time depenedent factor for PID radiated fraction gaussian')
+                else:
+                    self.particle_sources[species][source_type] = {'injected_particles_per_sec' : injected_particles_per_sec, 'rho_0' : rho_0, 
+                    'sigma_rho' : sigma_rho, 'time_factor': time_dependent_factor,
+                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0,
+                    'noise_level' : noise_level, 'previous_error' : 0.0}
             #
             case 'fast_alphas_source':
                 # check we are solving fast alphas
@@ -739,6 +750,7 @@ class PLASMA_SOLVER:
         Returns 1D-array of same size as rho_grid
         """
         from libstell.fusion import FUSION  
+        from numpy.random import rand
         fusion = FUSION()
 
         rho_grid = self.rho_grid
@@ -819,38 +831,34 @@ class PLASMA_SOLVER:
                     # These define the gaussian
                     rho_0 = self.energy_sources[species]['PID_etemp_gaussian']['rho_0']
                     sigma_rho = self.energy_sources[species]['PID_etemp_gaussian']['sigma_rho']
-                    time_fact = self.energy_sources[species]['PID_etemp_gaussian']['time_factor']
                     pid_K     = self.energy_sources[species]['PID_etemp_gaussian']['pid_K']
                     pid_Ti    = self.energy_sources[species]['PID_etemp_gaussian']['pid_Ti']
                     pid_Td    = self.energy_sources[species]['PID_etemp_gaussian']['pid_Td']
                     Ival      = self.energy_sources[species]['PID_etemp_gaussian']['pid_I']
-                    P_IN      = self.energy_sources[species]['PID_etemp_gaussian']['total_power']
-                    # time_fact is the target density
-                    t = self.time[it]
-                    SP = time_fact(t) # Set Point
+                    P_IN      = self.energy_sources[species]['PID_etemp_gaussian']['total_power']# time_fact is the target density
+                    noise     = self.energy_sources[species]['PID_etemp_gaussian']['noise_level']
+                    error_old = self.energy_sources[species]['PID_etemp_gaussian']['previous_error']
+                    t              = self.time[it]
+                    setpoint       = self.energy_sources[species]['PID_etemp_gaussian']['time_factor'](t) # Set Point
+                    it1            = max(it - 1,2)
+                    dt             = self.dt
+                    p_val          = self.T['electrons'][it1,0] * (1.0 + (rand()-0.5)*2.0*noise)
+                    # Run PID algo
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
                     #
-                    it1 = max(it - 1,2)
-                    it2 = max(it - 2,1)
-                    dt = self.time[it1]-self.time[it2]
-                    e1 = SP - self.T['electrons'][it1,0]
-                    e2 = SP - self.T['electrons'][it2,0]
-                    Ival = Ival + e1*dt
                     self.energy_sources[species]['PID_etemp_gaussian']['pid_I'] = Ival
-                    d = (e1-e2)/(self.time[it1]-self.time[it2])
-                    U = pid_K*(e1 + Ival / pid_Ti + pid_Td * d)
-                    # Adjust U 
-                    U = np.round(U,-6) # round to nearest MW
-                    U = max(U,0)
-                    U = min(U,P_IN)
+                    self.energy_sources[species]['PID_etemp_gaussian']['previous_error'] = error
+                    # Threshold control
+                    control = np.round(control,-6) # round to nearest MW
+                    control = max(control,0)
+                    control = min(control,P_IN)
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()
                     # 
-                    cte = max(U,0) / np.trapezoid(integrand,self.r_grid)
+                    cte = control / np.trapezoid(integrand,self.r_grid)
                     #
                     aux_source = cte * np.exp(-(rho_grid-rho_0)**2/sigma_rho**2)
-
-
 
                 case _:
                     print(f'ERROR: Source type {source_type} not defined....')
@@ -865,6 +873,7 @@ class PLASMA_SOLVER:
         Returns 1D-array of same size as rho_grid
         """
         from libstell.fusion import FUSION
+        from numpy.random import rand
         fusion = FUSION()
         
         rho_grid = self.rho_grid
@@ -924,30 +933,30 @@ class PLASMA_SOLVER:
                     # These define the gaussian
                     rho_0 = self.particle_sources[species]['PID_edense_gaussian']['rho_0']
                     sigma_rho = self.particle_sources[species]['PID_edense_gaussian']['sigma_rho']
-                    time_fact = self.particle_sources[species]['PID_edense_gaussian']['time_factor']
                     pid_K     = self.particle_sources[species]['PID_edense_gaussian']['pid_K']
                     pid_Ti    = self.particle_sources[species]['PID_edense_gaussian']['pid_Ti']
                     pid_Td    = self.particle_sources[species]['PID_edense_gaussian']['pid_Td']
                     Ival      = self.particle_sources[species]['PID_edense_gaussian']['pid_I']
                     N_IN      = self.particle_sources[species]['PID_edense_gaussian']['injected_particles_per_sec']
-                    # time_fact is the target density
-                    t = self.time[it]
-                    SP = time_fact(t) # Set Point
-                    #
-                    it1 = max(it - 1,2)
-                    it2 = max(it - 2,1)
-                    dt = self.time[it1]-self.time[it2]
-                    e1 = SP - self.N['electrons'][it1,0]
-                    e2 = SP - self.N['electrons'][it2,0]
-                    Ival = Ival + e1*dt
+                    noise     = self.particle_sources[species]['PID_edense_gaussian']['noise_level']
+                    error_old = self.particle_sources[species]['PID_edense_gaussian']['previous_error']
+                    t              = self.time[it]
+                    setpoint       = self.particle_sources[species]['PID_edense_gaussian']['time_factor'](t) # Set Point
+                    it1            = max(it - 1,2)
+                    dt             = self.dt
+                    p_val          = self.N['electrons'][it1,0] * (1.0 + (rand()-0.5)*2.0*noise)
+                    # Fix values
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
                     self.particle_sources[species]['PID_edense_gaussian']['pid_I'] = Ival
-                    d = (e1-e2)/(self.time[it1]-self.time[it2])
-                    U = pid_K*(e1 + Ival / pid_Ti + pid_Td * d)
+                    self.particle_sources[species]['PID_edense_gaussian']['previous_error'] = error
+                    # Threshold control
+                    control = max(control,0)
+                    control = min(control,N_IN)
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()
                     # 
-                    cte = max(U,0) / np.trapezoid(integrand,self.r_grid)
+                    cte = control / np.trapezoid(integrand,self.r_grid)
                     #
                     aux_source = cte * np.exp(-(rho_grid-rho_0)**2/sigma_rho**2)
                 case 'PID_pfuse_gaussian':
@@ -959,13 +968,13 @@ class PLASMA_SOLVER:
                     pid_Ti    = self.particle_sources[species]['PID_pfuse_gaussian']['pid_Ti']
                     pid_Td    = self.particle_sources[species]['PID_pfuse_gaussian']['pid_Td']
                     Ival      = self.particle_sources[species]['PID_pfuse_gaussian']['pid_I']
-                    # time_fact is the target density
-                    t = self.time[it]
-                    SP = time_fact(t) # Set Point
-                    #
-                    it1 = max(it - 1,2)
-                    it2 = max(it - 2,1)
-                    dt = self.time[1]-self.time[0]
+                    N_IN      = self.particle_sources[species]['PID_pfuse_gaussian']['injected_particles_per_sec']
+                    noise     = self.particle_sources[species]['PID_pfuse_gaussian']['noise_level']
+                    error_old = self.particle_sources[species]['PID_pfuse_gaussian']['previous_error']
+                    t              = self.time[it]
+                    setpoint       = self.particle_sources[species]['PID_pfuse_gaussian']['time_factor'](t) # Set Point
+                    it1            = max(it - 1,2)
+                    dt             = self.dt
                     # Compute fusion power
                     nD = self.N['deuterium'][it1,:]
                     nT = self.N['tritium'][it1,:]
@@ -973,35 +982,96 @@ class PLASMA_SOLVER:
                     TT = self.T['tritium'][it1,:]
                     integrand = fusion.alphaPower(nD,nT,TD,TT)*self.dVdr(rho_grid)
                     integrand = integrand.flatten()
-                    val1 = max(np.trapezoid(integrand,self.r_grid),0.0)*5.0 #alpha to neutron
-                    if np.isnan(val1): val1 = 0.0
-                    nD = self.N['deuterium'][it2,:]
-                    nT = self.N['tritium'][it2,:]
-                    TD = self.T['deuterium'][it2,:]
-                    TT = self.T['tritium'][it2,:]
-                    integrand = fusion.alphaPower(nD,nT,TD,TT)*self.dVdr(rho_grid)
-                    integrand = integrand.flatten()
-                    val2 = max(np.trapezoid(integrand,self.r_grid),0.0)*5.0 #alpha to neutron
-                    if np.isnan(val2): val2 = 0.0
-                    e1 = SP - val1
-                    e2 = SP - val2
-                    Ival = Ival + e1*dt
+                    p_val = max(np.trapezoid(integrand,self.r_grid),0.0)*5.0 #alpha to neutron
+                    if np.isnan(val1): p_val = 0.0
+                    p_val = p_val * (1.0 + (rand()-0.5)*2.0*noise)
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
                     self.particle_sources[species]['PID_pfuse_gaussian']['pid_I'] = Ival
-                    d = (e1-e2)/(self.time[it1]-self.time[it2])
-                    U = pid_K*(e1 + Ival / pid_Ti + pid_Td * d)
+                    self.particle_sources[species]['PID_pfuse_gaussian']['previous_error'] = error
                     # Adjust U 
-                    U = max(U,0)
-                    U = min(U,N_IN)
+                    control = max(control,0)
+                    control = min(control,N_IN)
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()
                     # 
-                    cte = max(U,0) / np.trapezoid(integrand,self.r_grid)
+                    cte = control / np.trapezoid(integrand,self.r_grid)
+                    #
+                    aux_source = cte * np.exp(-(rho_grid-rho_0)**2/sigma_rho**2)
+                case 'PID_pradfrac_gaussian':
+                    # These define the gaussian
+                    rho_0     = self.particle_sources[species]['PID_pradfrac_gaussian']['rho_0']
+                    sigma_rho = self.particle_sources[species]['PID_pradfrac_gaussian']['sigma_rho']
+                    time_fact = self.particle_sources[species]['PID_pradfrac_gaussian']['time_factor']
+                    pid_K     = self.particle_sources[species]['PID_pradfrac_gaussian']['pid_K']
+                    pid_Ti    = self.particle_sources[species]['PID_pradfrac_gaussian']['pid_Ti']
+                    pid_Td    = self.particle_sources[species]['PID_pradfrac_gaussian']['pid_Td']
+                    Ival      = self.particle_sources[species]['PID_pradfrac_gaussian']['pid_I']
+                    N_IN      = self.particle_sources[species]['PID_pradfrac_gaussian']['injected_particles_per_sec']
+                    noise     = self.particle_sources[species]['PID_pradfrac_gaussian']['noise_level']
+                    error_old = self.particle_sources[species]['PID_pradfrac_gaussian']['previous_error']
+                    t              = self.time[it]
+                    setpoint       = self.particle_sources[species]['PID_pradfrac_gaussian']['time_factor'](t) # Set Point
+                    it1            = max(it - 1,2)
+                    dt             = self.dt
+                    # Compute ECRH power
+                    integrand = 0.0
+                    for ttype in ['external_gaussian','time_dependent_gaussian','PID_etemp_gaussian']:
+                        if ttype in self.explicit_energy_sources['electrons'].keys():
+                            integrand += self.explicit_energy_sources['electrons'][ttype][it1,:]
+                    P_ECRH = max(np.trapezoid(integrand,self.r_grid),0.0)
+                    if np.isnan(P_ECRH): P_ECRH = 0.0
+                    # Compute Bremstahlung
+                    integrand = 0.0
+                    ne = self.N['electrons'][it1,:]
+                    Te = self.T['electrons'][it1,:]
+                    for ion in self.plasma.ion_species:
+                        zi = self.plasma.Zcharge[ion]
+                        ni = self.N[ion][it1,:]
+                        integrand += fusion.BremsstrahlungPower(zi,ni,ne,Te)
+                    P_BREM = max(np.trapezoid(integrand,self.r_grid),0.0)
+                    if np.isnan(P_BREM): P_BREM = 0.0
+                    # Compute fusion power
+                    P_ALPHA = 0.0
+                    if False:
+                        nD = self.N['deuterium'][it1,:]
+                        nT = self.N['tritium'][it1,:]
+                        TD = self.T['deuterium'][it1,:]
+                        TT = self.T['tritium'][it1,:]
+                        integrand = fusion.alphaPower(nD,nT,TD,TT)*self.dVdr(rho_grid)
+                        integrand = integrand.flatten()
+                        P_ALPHA = max(np.trapezoid(integrand,self.r_grid),0.0)*5.0 #alpha to neutron
+                        if np.isnan(P_ALPHA): P_ALPHA = 0.0
+                    # Compute Fraction
+                    p_val = P_BREM / (P_ALPHA+P_ECRH+1.0)
+                    print(p_val,P_BREM,P_ALPHA,P_ECRH)
+                    p_val = p_val * (1.0 + (rand()-0.5)*2.0*noise)
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
+                    self.particle_sources[species]['PID_pradfrac_gaussian']['pid_I'] = Ival
+                    self.particle_sources[species]['PID_pradfrac_gaussian']['previous_error'] = error
+                    # Adjust U 
+                    control = max(control,0)
+                    control = min(control,N_IN)
+                    # Compute integrand
+                    integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
+                    integrand = integrand.flatten()
+                    # 
+                    cte = control / np.trapezoid(integrand,self.r_grid)
                     #
                     aux_source = cte * np.exp(-(rho_grid-rho_0)**2/sigma_rho**2)
                     
             # bookeeping
             self.explicit_particle_sources[species][source_type][it,:] = aux_source
+
+    def pid_controller(self, setpoint, pv, kp, tau_i, tau_d, previous_error, integral, dt):
+        """
+        The PID control algorithm for feedback control.
+        """
+        error = setpoint - pv
+        integral += error * dt
+        derivative = (error - previous_error) / dt
+        control = kp * (error + integral/tau_i + tau_d * derivative)
+        return control, error, integral
             
     def compute_diffusive_heat_flux(self,it):
         """

--- a/pySTEL/libstell/plasma_solver.py
+++ b/pySTEL/libstell/plasma_solver.py
@@ -876,10 +876,9 @@ class PLASMA_SOLVER:
                     power_max  = self.energy_sources[species]['PID_pfuse_gaussian']['max_total_power']
                     noise     = self.energy_sources[species]['PID_pfuse_gaussian']['noise_level']
                     error_old = self.energy_sources[species]['PID_pfuse_gaussian']['previous_error']
-                    t              = self.time[it]
-                    setpoint       = self.energy_sources[species]['PID_pfuse_gaussian']['time_dependent_fusion_power'](t) # Set Point
-                    it1            = max(it - 1,2)
-                    dt             = self.dt
+                    t         = self.time[it]
+                    setpoint  = self.energy_sources[species]['PID_pfuse_gaussian']['time_dependent_fusion_power'](t) # Set Point
+                    it1       = it #max(it - 1,2)
                     # Compute fusion power
                     nD = self.N['deuterium'][it1,:]
                     nT = self.N['tritium'][it1,:]
@@ -890,12 +889,16 @@ class PLASMA_SOLVER:
                     p_val = max(np.trapezoid(integrand,self.r_grid),0.0)*5.0 #from alpha power to fusion power
                     if np.isnan(p_val): p_val = 0.0
                     p_val = p_val * (1.0 + (rand()-0.5)*2.0*noise)
-                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
+                    # Run PID algorithm
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, self.dt)
                     self.energy_sources[species]['PID_pfuse_gaussian']['pid_I'] = Ival
                     self.energy_sources[species]['PID_pfuse_gaussian']['previous_error'] = error
-                    # Adjust U 
+                    # Threshold control
+                    control = np.round(control,-6) # round to nearest MW
                     control = np.clip(control,0,power_max)
-                    # print(f'setpoint={setpoint/1E6}MW        pval={p_val/1E6:.2f}MW       ECRH={control/1E6}MW')
+                    # If clipped, then set previous integral to zero (anti wind-up)
+                    if np.isclose(control,0) or np.isclose(control,power_max):
+                        self.energy_sources[species]['PID_pfuse_gaussian']['pid_I'] = 0.0                  
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()
@@ -915,19 +918,20 @@ class PLASMA_SOLVER:
                     power_max = self.energy_sources[species]['PID_etemp_gaussian']['max_total_power']
                     noise     = self.energy_sources[species]['PID_etemp_gaussian']['noise_level']
                     error_old = self.energy_sources[species]['PID_etemp_gaussian']['previous_error']
-                    t              = self.time[it]
-                    setpoint       = self.energy_sources[species]['PID_etemp_gaussian']['time_dependent_electron_temp_axis'](t) # Set Point
-                    it1            = max(it - 1,2)
-                    dt             = self.dt
-                    p_val          = self.T['electrons'][it1,0] * (1.0 + (rand()-0.5)*2.0*noise)
-                    # Run PID algo
-                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
-                    #
+                    t         = self.time[it]
+                    setpoint  = self.energy_sources[species]['PID_etemp_gaussian']['time_dependent_electron_temp_axis'](t) # Set Point
+                    it1       = it #max(it - 1,2)
+                    p_val     = self.T['electrons'][it1,0] * (1.0 + (rand()-0.5)*2.0*noise)
+                    # Run PID algorithm
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, self.dt)
                     self.energy_sources[species]['PID_etemp_gaussian']['pid_I'] = Ival
                     self.energy_sources[species]['PID_etemp_gaussian']['previous_error'] = error
                     # Threshold control
                     control = np.round(control,-6) # round to nearest MW
                     control = np.clip(control,0,power_max)
+                    # If clipped, then set previous integral to zero (anti wind-up)
+                    if np.isclose(control,0) or np.isclose(control,power_max):
+                        self.energy_sources[species]['PID_etemp_gaussian']['pid_I'] = 0.0  
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()
@@ -947,19 +951,20 @@ class PLASMA_SOLVER:
                     power_max = self.energy_sources[species]['PID_itemp_gaussian']['max_total_power']
                     noise     = self.energy_sources[species]['PID_itemp_gaussian']['noise_level']
                     error_old = self.energy_sources[species]['PID_itemp_gaussian']['previous_error']
-                    t              = self.time[it]
-                    setpoint       = self.energy_sources[species]['PID_itemp_gaussian']['time_dependent_DT_temp_axis'](t) # Set Point
-                    it1            = max(it - 1,2)
-                    dt             = self.dt
+                    t         = self.time[it]
+                    setpoint  = self.energy_sources[species]['PID_itemp_gaussian']['time_dependent_DT_temp_axis'](t) # Set Point
+                    it1       = it # max(it - 1,2)
                     p_val          = 0.5*(self.T['deuterium'][it1,0]+self.T['tritium'][it1,0])* (1.0 + (rand()-0.5)*2.0*noise)
-                    # Run PID algo
-                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
-                    #
+                    # Run PID algorithm
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, self.dt)
                     self.energy_sources[species]['PID_itemp_gaussian']['pid_I'] = Ival
                     self.energy_sources[species]['PID_itemp_gaussian']['previous_error'] = error
                     # Threshold control
-                    # control = np.round(control,-6) # round to nearest MW
+                    control = np.round(control,-6) # round to nearest MW
                     control = np.clip(control,0,power_max)
+                    # If clipped, then set previous integral to zero (anti wind-up)
+                    if np.isclose(control,0) or np.isclose(control,power_max):
+                        self.energy_sources[species]['PID_itemp_gaussian']['pid_I'] = 0.0 
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()
@@ -1037,28 +1042,30 @@ class PLASMA_SOLVER:
                     lambda_function_2D = self.particle_sources[species][source_type]['lambda_function_2D'] #func(r,t)
                     #
                     aux_source = [lambda_function_2D(r,self.time[it]) for r in self.r_grid]
+                    
                 case 'PID_edense_gaussian':
-                    # These define the gaussian
                     rho_0 = self.particle_sources[species]['PID_edense_gaussian']['rho_0']
                     sigma_rho = self.particle_sources[species]['PID_edense_gaussian']['sigma_rho']
                     pid_K     = self.particle_sources[species]['PID_edense_gaussian']['pid_K']
                     pid_Ti    = self.particle_sources[species]['PID_edense_gaussian']['pid_Ti']
                     pid_Td    = self.particle_sources[species]['PID_edense_gaussian']['pid_Td']
                     Ival      = self.particle_sources[species]['PID_edense_gaussian']['pid_I']
-                    N_IN_max      = self.particle_sources[species]['PID_edense_gaussian']['max_injected_particles_per_sec']
+                    N_IN_max  = self.particle_sources[species]['PID_edense_gaussian']['max_injected_particles_per_sec']
                     noise     = self.particle_sources[species]['PID_edense_gaussian']['noise_level']
                     error_old = self.particle_sources[species]['PID_edense_gaussian']['previous_error']
-                    t              = self.time[it]
-                    setpoint       = self.particle_sources[species]['PID_edense_gaussian']['time_dependent_electron_dens_axis'](t) # Set Point
-                    it1            = max(it - 1,2)
-                    dt             = self.dt
-                    p_val          = self.N['electrons'][it1,0] * (1.0 + (rand()-0.5)*2.0*noise)
-                    # Fix values
-                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
+                    t         = self.time[it]
+                    setpoint  = self.particle_sources[species]['PID_edense_gaussian']['time_dependent_electron_dens_axis'](t) # Set Point
+                    it1       = it #max(it - 1,2)
+                    p_val     = self.N['electrons'][it1,0] * (1.0 + (rand()-0.5)*2.0*noise)
+                    # Run PID algorithm
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, self.dt)
                     self.particle_sources[species]['PID_edense_gaussian']['pid_I'] = Ival
                     self.particle_sources[species]['PID_edense_gaussian']['previous_error'] = error
                     # Threshold control
                     control = np.clip(control,0,N_IN_max)
+                    # If clipped, then set previous integral to zero (anti wind-up)
+                    if np.isclose(control,0) or np.isclose(control,N_IN_max):
+                        self.particle_sources[species]['PID_edense_gaussian']['pid_I'] = 0.0                  
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()
@@ -1066,6 +1073,7 @@ class PLASMA_SOLVER:
                     cte = control / np.trapezoid(integrand,self.r_grid)
                     #
                     aux_source = cte * np.exp(-(rho_grid-rho_0)**2/sigma_rho**2)
+                    
                 case 'PID_pfuse_gaussian':
                     # These define the gaussian
                     rho_0 = self.particle_sources[species]['PID_pfuse_gaussian']['rho_0']
@@ -1077,10 +1085,9 @@ class PLASMA_SOLVER:
                     N_IN_max  = self.particle_sources[species]['PID_pfuse_gaussian']['max_injected_particles_per_sec']
                     noise     = self.particle_sources[species]['PID_pfuse_gaussian']['noise_level']
                     error_old = self.particle_sources[species]['PID_pfuse_gaussian']['previous_error']
-                    t              = self.time[it]
-                    setpoint       = self.particle_sources[species]['PID_pfuse_gaussian']['time_dependent_fusion_power'](t) # Set Point
-                    it1            = max(it - 1,2)
-                    dt             = self.dt
+                    t         = self.time[it]
+                    setpoint  = self.particle_sources[species]['PID_pfuse_gaussian']['time_dependent_fusion_power'](t) # Set Point
+                    it1       = it #max(it - 1,2)
                     # Compute fusion power
                     nD = self.N['deuterium'][it1,:]
                     nT = self.N['tritium'][it1,:]
@@ -1091,11 +1098,15 @@ class PLASMA_SOLVER:
                     p_val = max(np.trapezoid(integrand,self.r_grid),0.0)*5.0 #from alpha power to fusion power
                     if np.isnan(p_val): p_val = 0.0
                     p_val = p_val * (1.0 + (rand()-0.5)*2.0*noise)
-                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
+                    # Run PID algorithm
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, self.dt)
                     self.particle_sources[species]['PID_pfuse_gaussian']['pid_I'] = Ival
                     self.particle_sources[species]['PID_pfuse_gaussian']['previous_error'] = error
-                    # Adjust U 
+                    # Threshold control
                     control = np.clip(control,0,N_IN_max)
+                    # If clipped, then set previous integral to zero (anti wind-up)
+                    if np.isclose(control,0) or np.isclose(control,N_IN_max):
+                        self.particle_sources[species]['PID_edense_gaussian']['pid_I'] = 0.0                  
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()
@@ -1116,16 +1127,17 @@ class PLASMA_SOLVER:
                     noise     = self.particle_sources[species]['PID_itemp_gaussian']['noise_level']
                     error_old = self.particle_sources[species]['PID_itemp_gaussian']['previous_error']
                     t         = self.time[it]
-                    setpoint       = self.particle_sources[species]['PID_itemp_gaussian']['time_dependent_DT_temp_axis'](t) # Set Point
-                    it1            = max(it - 1,2)
-                    dt             = self.dt
-                    p_val          = 0.5*(self.T['deuterium'][it1,0]+self.T['tritium'][it1,0])* (1.0 + (rand()-0.5)*2.0*noise)
-                    # Run PID algo
-                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
-                    #
+                    setpoint  = self.particle_sources[species]['PID_itemp_gaussian']['time_dependent_DT_temp_axis'](t) # Set Point
+                    it1       = it #max(it - 1,2)
+                    p_val     = 0.5*(self.T['deuterium'][it1,0]+self.T['tritium'][it1,0])* (1.0 + (rand()-0.5)*2.0*noise)
+                    # Run PID algorithm
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, self.dt)
                     self.particle_sources[species]['PID_itemp_gaussian']['pid_I'] = Ival
                     self.particle_sources[species]['PID_itemp_gaussian']['previous_error'] = error
-                    # Adjust U 
+                    # If clipped, then set previous integral to zero (anti wind-up)
+                    if np.isclose(control,0) or np.isclose(control,N_IN_max):
+                        self.particle_sources[species]['PID_edense_gaussian']['pid_I'] = 0.0                  
+                    # Threshold control
                     control = np.clip(control,0,N_IN_max)
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
@@ -2011,8 +2023,184 @@ class PLASMA_SOLVER:
                 saved_class.__dict__[attr].setdefault(species, {})
                 for type_string, arr in getattr(self, attr)[species].items():
                     saved_class.__dict__[attr][species][type_string] = arr[sl, :]
+                    
+            # Save particle PID's info (if they exist). This is useful for restarts
+            pid_keys = [k for k in self.particle_sources[species] if k.startswith("PID_")]
+            if pid_keys:
+                if not hasattr(saved_class, "particle_sources"):
+                    saved_class.particle_sources = {}
+                if species not in saved_class.particle_sources:
+                    saved_class.particle_sources[species] = {}
+            for key in pid_keys:
+                saved_class.particle_sources[species][key] = {
+                    "previous_error": self.particle_sources[species][key]["previous_error"],
+                    "pid_I": self.particle_sources[species][key]["pid_I"]}
+                
+            # Save energy PID's info (if they exist). This is useful for restarts
+            pid_keys = [k for k in self.energy_sources[species] if k.startswith("PID_")]
+            if pid_keys:
+                if not hasattr(saved_class, "energy_sources"):
+                    saved_class.energy_sources = {}
+                if species not in saved_class.energy_sources:
+                    saved_class.energy_sources[species] = {}
+            for key in pid_keys:
+                saved_class.energy_sources[species][key] = {
+                    "previous_error": self.energy_sources[species][key]["previous_error"],
+                    "pid_I": self.energy_sources[species][key]["pid_I"]}
 
         joblib.dump(saved_class, output_filename)
+        
+def merge_output_files(*output_files,concatenated_file=None):
+    """ Merges sequential joblib output files into a single one. 
+    Returns concatenated class and only saves concatenated joblib file if concatenated_file is not None"""
+    from types import SimpleNamespace
+    import joblib
+    import warnings
+    from copy import deepcopy
+    
+    ATTR_TIME_DEP = ('N','T','Dn','cn','Dp','cp','Q_NEO','Q_turb','Gamma_NEO','Gamma_turb')
+    
+    SOURCE_ATTRS = ('explicit_energy_sources', 'explicit_particle_sources')
+
+    GRID_ATTRS = ('rho_grid', 'r_grid', 'dVdr')
+
+    SCALAR_ATTRS = ('aminor', 'Rmajor', 'Baxis', 'Bref')
+    
+    OPTIONAL_ATTRS = ('iota23')
+    
+    ########################## AUX FUNCT ##################################
+    def check_same(name, ref, val):
+        if isinstance(ref, np.ndarray):
+            if not np.allclose(ref, val):
+                warnings.warn(f"Invariant mismatch in {name}")
+        else:
+            if ref != val:
+                warnings.warn(f"Invariant mismatch in {name}")
+
+   
+    ################ CHECK TIME IS SEQUENTIAL ##################################
+    time_all = []
+    for file in output_files:
+        solver = joblib.load(file)
+        time_all.append(solver.time)
+    #
+    time_all = np.concatenate(time_all)
+    is_sequential = np.all(time_all[1:] >= time_all[:-1])
+    if(not is_sequential):
+        raise ValueError('ERROR: Time is not sequential in the given files...')
+    
+    ######################## CONCATENATE DATA ##################################
+    # ------------------------------------------------------------
+    # Load first solver as reference
+    # ------------------------------------------------------------
+    ref_solver = joblib.load(output_files[0])
+    concatenated_class = deepcopy(ref_solver)
+    
+    # ------------------------------------------------------------
+    # Loop over remaining solvers
+    # ------------------------------------------------------------
+    for file in output_files[1:]:
+        solver = joblib.load(file)
+
+        # -------------------------------
+        # (1) Check invariant attributes
+        # -------------------------------
+        for attr in GRID_ATTRS:
+            check_same(attr, getattr(ref_solver, attr), getattr(solver, attr))
+
+        for attr in SCALAR_ATTRS:
+            check_same(attr, getattr(ref_solver, attr), getattr(solver, attr))
+
+        if solver.list_of_species != ref_solver.list_of_species:
+            warnings.warn("list_of_species mismatch")
+
+        # -------------------------------
+        # (2) Concatenate time
+        # -------------------------------
+        t_old = concatenated_class.time
+        t_new = solver.time
+
+        if np.isclose(t_old[-1], t_new[0]):
+            time_slice = slice(1, None)
+        else:
+            time_slice = slice(None)
+
+        concatenated_class.time = np.concatenate(
+            [t_old, t_new[time_slice]]
+        )
+
+        # -------------------------------
+        # (3) Concatenate time-dependent attributes
+        # -------------------------------
+        for attr in ATTR_TIME_DEP:
+            ref_attr = getattr(concatenated_class, attr)
+            new_attr = getattr(solver, attr)
+
+            # species in list_of_species
+            for species in ref_solver.list_of_species:
+                if species in new_attr:
+                    ref_attr[species] = np.concatenate(
+                    [ref_attr[species],
+                     new_attr[species][time_slice, :]],
+                    axis=0
+                )
+                else:
+                    warnings.warn(
+                        f"{attr}: species '{species}' missing in one solver"
+                    )
+
+            # special species: alphas_fast
+            if attr == 'N' and 'alphas_fast' in new_attr:
+                if 'alphas_fast' not in ref_attr:
+                    ref_attr['alphas_fast'] = new_attr['alphas_fast'][time_slice, :]
+                else:
+                    ref_attr['alphas_fast'] = np.concatenate(
+                        [ref_attr['alphas_fast'],
+                        new_attr['alphas_fast'][time_slice, :]],
+                        axis=0
+                    )
+                    
+        # ------------------------------------------------------------
+        # (4) Concatenate explicit source terms
+        #     Structure: sources[species][key][time, space]
+        # ------------------------------------------------------------
+        for attr in SOURCE_ATTRS:
+
+            ref_sources = getattr(concatenated_class, attr)
+            new_sources = getattr(solver, attr)
+
+            # Loop over species in the reference solver
+            for species in ref_sources.keys():
+
+                if species not in new_sources:
+                    warnings.warn(
+                        f"{attr}: species '{species}' missing in one solver"
+                    )
+                    continue
+
+                for key in ref_sources[species]:
+
+                    if key not in new_sources[species]:
+                        warnings.warn(
+                            f"{attr}[{species}]: key '{key}' missing in one solver"
+                        )
+                        continue
+
+                    ref_sources[species][key] = np.concatenate(
+                        [
+                            ref_sources[species][key],
+                            new_sources[species][key][time_slice, :]
+                        ],
+                        axis=0
+                    )
+        
+        concatenated_class.Nt = len(concatenated_class.time)
+        
+        if(concatenated_file is not None):
+            joblib.dump(concatenated_class, concatenated_file)
+        
+        return concatenated_class
+                    
         
 # def process_surfaces(surface,wout_path):
 #     import time

--- a/pySTEL/libstell/plasma_solver.py
+++ b/pySTEL/libstell/plasma_solver.py
@@ -208,6 +208,7 @@ class PLASMA_SOLVER:
                     
     def set_energy_source(self,species,source_type, total_power=None, sigma_rho=None, rho_0=None, 
         fraction_alpha_heating=None, cte_source=None, time_dependent_factor=None, lambda_function_2D=None,
+        max_total_power=None, time_dependent_fusion_power=None, time_dependent_DT_temp_axis=None, time_dependent_electron_temp_axis=None,
         pidK=1.0,pidI=1.0E10,pidD=0.0,noise_level=0.00):
         """
         Sets energy sources for a given species. The source_type can be:
@@ -243,14 +244,35 @@ class PLASMA_SOLVER:
                 else:
                     self.energy_sources[species][source_type] = {'total_power' : total_power, 'sigma_rho' : sigma_rho, 'rho_0' : rho_0, 'time_factor': time_dependent_factor }
             #
-            case 'PID_etemp_gaussian':
-                if((total_power is None) or (rho_0 is None) or (sigma_rho is None) or (time_dependent_factor is None)):
-                    raise ValueError('ERROR: Need to provide total_power, rho_0, sigma_rho and a time depenedent factor for PID electron density gaussian')
+            case 'PID_pfuse_gaussian':
+                if((rho_0 is None) or (sigma_rho is None) or (max_total_power is None) or (time_dependent_fusion_power is None)):
+                    raise ValueError('ERROR: Need to provide time_dependent_fusion_power, max_total_power, rho_0 and sigma_rho for PID electron density gaussian')
                 else:
-                    self.energy_sources[species][source_type] = {'total_power' : total_power, 'rho_0' : rho_0, 
-                    'sigma_rho' : sigma_rho, 'time_factor': time_dependent_factor,
-                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0 ,
+                    self.energy_sources[species][source_type] = {'max_total_power' : max_total_power, 'rho_0' : rho_0, 
+                    'sigma_rho' : sigma_rho, 'time_dependent_fusion_power': time_dependent_fusion_power,
+                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0,
                     'noise_level' : noise_level, 'previous_error' : 0.0}
+                    print(f'Using PID_pfuse_gaussian with pid_K={pidK}m^3/s, pid_tauI={pidI}s, pid_tauD={pidD}s and noise_level={noise_level}')
+            #
+            case 'PID_itemp_gaussian':
+                if((rho_0 is None) or (sigma_rho is None) or (max_total_power is None) or (time_dependent_DT_temp_axis is None)):
+                    raise ValueError('ERROR: Need to provide time_dependent_DT_temp_axis, max_total_power, rho_0 and sigma_rho for PID electron density gaussian')
+                else:
+                    self.energy_sources[species][source_type] = {'max_total_power' : max_total_power, 'rho_0' : rho_0, 
+                    'sigma_rho' : sigma_rho, 'time_dependent_DT_temp_axis': time_dependent_DT_temp_axis,
+                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0,
+                    'noise_level' : noise_level, 'previous_error' : 0.0}
+                    print(f'Using PID_itemp_gaussian with pid_K={pidK}m^3/s, pid_tauI={pidI}s, pid_tauD={pidD}s and noise_level={noise_level}')
+            #
+            case 'PID_etemp_gaussian':
+                if((rho_0 is None) or (sigma_rho is None) or (max_total_power is None) or (time_dependent_electron_temp_axis is None)):
+                    raise ValueError('ERROR: Need to provide time_dependent_electron_temp_axis, max_total_power, rho_0 and sigma_rho for PID electron density gaussian')
+                else:
+                    self.energy_sources[species][source_type] = {'max_total_power' : max_total_power, 'rho_0' : rho_0, 
+                    'sigma_rho' : sigma_rho, 'time_dependent_electron_temp_axis': time_dependent_electron_temp_axis,
+                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0,
+                    'noise_level' : noise_level, 'previous_error' : 0.0}
+                    print(f'Using PID_etemp_gaussian with pid_K={pidK}m^3/s, pid_tauI={pidI}s, pid_tauD={pidD}s and noise_level={noise_level}')
             #
             case 'Coll_Heat_Exchange':
                 self.energy_sources[species][source_type] = {}
@@ -291,6 +313,7 @@ class PLASMA_SOLVER:
                 
     def set_particle_source(self,species,source_type, injected_particles_per_sec=None, rho_0=None, sigma_rho=None, 
         cte_source=None, time_dependent_factor=None, lambda_function_2D=None,
+        max_injected_particles_per_sec=None, time_dependent_electron_dens_axis=None, time_dependent_fusion_power=None, time_dependent_DT_temp_axis=None,
         pidK=1.0,pidI=1.0E10,pidD=0.0,noise_level=0.0):
         """
         Sets particle sources for a given species. The source_type can be:
@@ -316,22 +339,37 @@ class PLASMA_SOLVER:
                     raise ValueError('ERROR: Need to provide injected_particles_per_sec, rho_0, sigma_rho and a time depenedent factor for time-dependent gaussian')
                 else:
                     self.particle_sources[species][source_type] = {'injected_particles_per_sec' : injected_particles_per_sec, 'rho_0' : rho_0, 'sigma_rho' : sigma_rho, 'time_factor': time_dependent_factor }
+            #
             case 'PID_edense_gaussian':
-                if((rho_0 is None) or (sigma_rho is None) or (time_dependent_factor is None)):
-                    raise ValueError('ERROR: Need to provide injected_particles_per_sec, rho_0, sigma_rho and a time depenedent factor for PID electron density gaussian')
+                if((rho_0 is None) or (sigma_rho is None) or (max_injected_particles_per_sec is None) or (time_dependent_electron_dens_axis is None)):
+                    raise ValueError('ERROR: Need to provide time_dependent_electron_dens_axis, max_injected_particles_per_sec, rho_0 and sigma_rho for PID electron density gaussian')
                 else:
-                    self.particle_sources[species][source_type] = {'injected_particles_per_sec' : injected_particles_per_sec, 'rho_0' : rho_0, 
-                    'sigma_rho' : sigma_rho, 'time_factor': time_dependent_factor,
+                    self.particle_sources[species][source_type] = {'max_injected_particles_per_sec' : max_injected_particles_per_sec, 'rho_0' : rho_0, 
+                    'sigma_rho' : sigma_rho, 'time_dependent_electron_dens_axis': time_dependent_electron_dens_axis,
                     'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0,
                     'noise_level' : noise_level, 'previous_error' : 0.0}
+                    print(f'Using PID_edense_gaussian with pid_K={pidK}m^3/s, pid_tauI={pidI}s, pid_tauD={pidD}s and noise_level={noise_level}')
+            #
             case 'PID_pfuse_gaussian':
-                if((rho_0 is None) or (sigma_rho is None) or (time_dependent_factor is None)):
-                    raise ValueError('ERROR: Need to provide injected_particles_per_sec, rho_0, sigma_rho and a time depenedent factor for PID total fusion power gaussian')
+                if((rho_0 is None) or (sigma_rho is None) or (max_injected_particles_per_sec is None) or (time_dependent_fusion_power is None)):
+                    raise ValueError('ERROR: Need to provide time_dependent_fusion_power, max_injected_particles_per_sec, rho_0 and sigma_rho for PID electron density gaussian')
                 else:
-                    self.particle_sources[species][source_type] = {'injected_particles_per_sec' : injected_particles_per_sec, 'rho_0' : rho_0, 
-                    'sigma_rho' : sigma_rho, 'time_factor': time_dependent_factor,
+                    self.particle_sources[species][source_type] = {'max_injected_particles_per_sec' : max_injected_particles_per_sec, 'rho_0' : rho_0, 
+                    'sigma_rho' : sigma_rho, 'time_dependent_fusion_power': time_dependent_fusion_power,
                     'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0,
                     'noise_level' : noise_level, 'previous_error' : 0.0}
+                    print(f'Using PID_pfuse_gaussian with pid_K={pidK}m^3/s, pid_tauI={pidI}s, pid_tauD={pidD}s and noise_level={noise_level}')
+            #
+            case 'PID_itemp_gaussian':
+                if((rho_0 is None) or (sigma_rho is None) or (max_injected_particles_per_sec is None) or (time_dependent_DT_temp_axis is None)):
+                    raise ValueError('ERROR: Need to provide time_dependent_DT_temp_axis, max_total_power, rho_0 and sigma_rho for PID electron density gaussian')
+                else:
+                    self.particle_sources[species][source_type] = {'max_injected_particles_per_sec' : max_injected_particles_per_sec , 'rho_0' : rho_0, 
+                    'sigma_rho' : sigma_rho, 'time_dependent_DT_temp_axis': time_dependent_DT_temp_axis,
+                    'pid_K' : pidK, 'pid_Ti' : pidI, 'pid_Td' : pidD, 'pid_I' : 0.0,
+                    'noise_level' : noise_level, 'previous_error' : 0.0}
+                    print(f'Using PID_itemp_gaussian with pid_K={pidK}m^3/s, pid_tauI={pidI}s, pid_tauD={pidD}s and noise_level={noise_level}')
+            #
             case 'PID_pradfrac_gaussian':
                 if((rho_0 is None) or (sigma_rho is None) or (time_dependent_factor is None)):
                     raise ValueError('ERROR: Need to provide injected_particles_per_sec, rho_0, sigma_rho and a time depenedent factor for PID radiated fraction gaussian')
@@ -827,6 +865,45 @@ class PLASMA_SOLVER:
                 case 'constant':
                     aux_source = self.energy_sources[species]['constant']['cte_source']
 
+                case 'PID_pfuse_gaussian':
+                    # These define the gaussian
+                    rho_0 = self.energy_sources[species]['PID_pfuse_gaussian']['rho_0']
+                    sigma_rho = self.energy_sources[species]['PID_pfuse_gaussian']['sigma_rho']
+                    pid_K     = self.energy_sources[species]['PID_pfuse_gaussian']['pid_K']
+                    pid_Ti    = self.energy_sources[species]['PID_pfuse_gaussian']['pid_Ti']
+                    pid_Td    = self.energy_sources[species]['PID_pfuse_gaussian']['pid_Td']
+                    Ival      = self.energy_sources[species]['PID_pfuse_gaussian']['pid_I']
+                    power_max  = self.energy_sources[species]['PID_pfuse_gaussian']['max_total_power']
+                    noise     = self.energy_sources[species]['PID_pfuse_gaussian']['noise_level']
+                    error_old = self.energy_sources[species]['PID_pfuse_gaussian']['previous_error']
+                    t              = self.time[it]
+                    setpoint       = self.energy_sources[species]['PID_pfuse_gaussian']['time_dependent_fusion_power'](t) # Set Point
+                    it1            = max(it - 1,2)
+                    dt             = self.dt
+                    # Compute fusion power
+                    nD = self.N['deuterium'][it1,:]
+                    nT = self.N['tritium'][it1,:]
+                    TD = self.T['deuterium'][it1,:]
+                    TT = self.T['tritium'][it1,:]
+                    integrand = fusion.alphaPower(nD,nT,TD,TT)*self.dVdr(rho_grid)
+                    integrand = integrand.flatten()
+                    p_val = max(np.trapezoid(integrand,self.r_grid),0.0)*5.0 #from alpha power to fusion power
+                    if np.isnan(p_val): p_val = 0.0
+                    p_val = p_val * (1.0 + (rand()-0.5)*2.0*noise)
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
+                    self.energy_sources[species]['PID_pfuse_gaussian']['pid_I'] = Ival
+                    self.energy_sources[species]['PID_pfuse_gaussian']['previous_error'] = error
+                    # Adjust U 
+                    control = np.clip(control,0,power_max)
+                    # print(f'setpoint={setpoint/1E6}MW        pval={p_val/1E6:.2f}MW       ECRH={control/1E6}MW')
+                    # Compute integrand
+                    integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
+                    integrand = integrand.flatten()
+                    # 
+                    cte = control / np.trapezoid(integrand,self.r_grid)
+                    #
+                    aux_source = cte * np.exp(-(rho_grid-rho_0)**2/sigma_rho**2)
+                    
                 case 'PID_etemp_gaussian':
                     # These define the gaussian
                     rho_0 = self.energy_sources[species]['PID_etemp_gaussian']['rho_0']
@@ -835,11 +912,11 @@ class PLASMA_SOLVER:
                     pid_Ti    = self.energy_sources[species]['PID_etemp_gaussian']['pid_Ti']
                     pid_Td    = self.energy_sources[species]['PID_etemp_gaussian']['pid_Td']
                     Ival      = self.energy_sources[species]['PID_etemp_gaussian']['pid_I']
-                    P_IN      = self.energy_sources[species]['PID_etemp_gaussian']['total_power']# time_fact is the target density
+                    power_max = self.energy_sources[species]['PID_etemp_gaussian']['max_total_power']
                     noise     = self.energy_sources[species]['PID_etemp_gaussian']['noise_level']
                     error_old = self.energy_sources[species]['PID_etemp_gaussian']['previous_error']
                     t              = self.time[it]
-                    setpoint       = self.energy_sources[species]['PID_etemp_gaussian']['time_factor'](t) # Set Point
+                    setpoint       = self.energy_sources[species]['PID_etemp_gaussian']['time_dependent_electron_temp_axis'](t) # Set Point
                     it1            = max(it - 1,2)
                     dt             = self.dt
                     p_val          = self.T['electrons'][it1,0] * (1.0 + (rand()-0.5)*2.0*noise)
@@ -850,8 +927,39 @@ class PLASMA_SOLVER:
                     self.energy_sources[species]['PID_etemp_gaussian']['previous_error'] = error
                     # Threshold control
                     control = np.round(control,-6) # round to nearest MW
-                    control = max(control,0)
-                    control = min(control,P_IN)
+                    control = np.clip(control,0,power_max)
+                    # Compute integrand
+                    integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
+                    integrand = integrand.flatten()
+                    # 
+                    cte = control / np.trapezoid(integrand,self.r_grid)
+                    #
+                    aux_source = cte * np.exp(-(rho_grid-rho_0)**2/sigma_rho**2)
+                    
+                case 'PID_itemp_gaussian':
+                    # These define the gaussian
+                    rho_0     = self.energy_sources[species]['PID_itemp_gaussian']['rho_0']
+                    sigma_rho = self.energy_sources[species]['PID_itemp_gaussian']['sigma_rho']
+                    pid_K     = self.energy_sources[species]['PID_itemp_gaussian']['pid_K']
+                    pid_Ti    = self.energy_sources[species]['PID_itemp_gaussian']['pid_Ti']
+                    pid_Td    = self.energy_sources[species]['PID_itemp_gaussian']['pid_Td']
+                    Ival      = self.energy_sources[species]['PID_itemp_gaussian']['pid_I']
+                    power_max = self.energy_sources[species]['PID_itemp_gaussian']['max_total_power']
+                    noise     = self.energy_sources[species]['PID_itemp_gaussian']['noise_level']
+                    error_old = self.energy_sources[species]['PID_itemp_gaussian']['previous_error']
+                    t              = self.time[it]
+                    setpoint       = self.energy_sources[species]['PID_itemp_gaussian']['time_dependent_DT_temp_axis'](t) # Set Point
+                    it1            = max(it - 1,2)
+                    dt             = self.dt
+                    p_val          = 0.5*(self.T['deuterium'][it1,0]+self.T['tritium'][it1,0])* (1.0 + (rand()-0.5)*2.0*noise)
+                    # Run PID algo
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
+                    #
+                    self.energy_sources[species]['PID_itemp_gaussian']['pid_I'] = Ival
+                    self.energy_sources[species]['PID_itemp_gaussian']['previous_error'] = error
+                    # Threshold control
+                    # control = np.round(control,-6) # round to nearest MW
+                    control = np.clip(control,0,power_max)
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()
@@ -937,11 +1045,11 @@ class PLASMA_SOLVER:
                     pid_Ti    = self.particle_sources[species]['PID_edense_gaussian']['pid_Ti']
                     pid_Td    = self.particle_sources[species]['PID_edense_gaussian']['pid_Td']
                     Ival      = self.particle_sources[species]['PID_edense_gaussian']['pid_I']
-                    N_IN      = self.particle_sources[species]['PID_edense_gaussian']['injected_particles_per_sec']
+                    N_IN_max      = self.particle_sources[species]['PID_edense_gaussian']['max_injected_particles_per_sec']
                     noise     = self.particle_sources[species]['PID_edense_gaussian']['noise_level']
                     error_old = self.particle_sources[species]['PID_edense_gaussian']['previous_error']
                     t              = self.time[it]
-                    setpoint       = self.particle_sources[species]['PID_edense_gaussian']['time_factor'](t) # Set Point
+                    setpoint       = self.particle_sources[species]['PID_edense_gaussian']['time_dependent_electron_dens_axis'](t) # Set Point
                     it1            = max(it - 1,2)
                     dt             = self.dt
                     p_val          = self.N['electrons'][it1,0] * (1.0 + (rand()-0.5)*2.0*noise)
@@ -950,8 +1058,7 @@ class PLASMA_SOLVER:
                     self.particle_sources[species]['PID_edense_gaussian']['pid_I'] = Ival
                     self.particle_sources[species]['PID_edense_gaussian']['previous_error'] = error
                     # Threshold control
-                    control = max(control,0)
-                    control = min(control,N_IN)
+                    control = np.clip(control,0,N_IN_max)
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()
@@ -963,16 +1070,15 @@ class PLASMA_SOLVER:
                     # These define the gaussian
                     rho_0 = self.particle_sources[species]['PID_pfuse_gaussian']['rho_0']
                     sigma_rho = self.particle_sources[species]['PID_pfuse_gaussian']['sigma_rho']
-                    time_fact = self.particle_sources[species]['PID_pfuse_gaussian']['time_factor']
                     pid_K     = self.particle_sources[species]['PID_pfuse_gaussian']['pid_K']
                     pid_Ti    = self.particle_sources[species]['PID_pfuse_gaussian']['pid_Ti']
                     pid_Td    = self.particle_sources[species]['PID_pfuse_gaussian']['pid_Td']
                     Ival      = self.particle_sources[species]['PID_pfuse_gaussian']['pid_I']
-                    N_IN      = self.particle_sources[species]['PID_pfuse_gaussian']['injected_particles_per_sec']
+                    N_IN_max  = self.particle_sources[species]['PID_pfuse_gaussian']['max_injected_particles_per_sec']
                     noise     = self.particle_sources[species]['PID_pfuse_gaussian']['noise_level']
                     error_old = self.particle_sources[species]['PID_pfuse_gaussian']['previous_error']
                     t              = self.time[it]
-                    setpoint       = self.particle_sources[species]['PID_pfuse_gaussian']['time_factor'](t) # Set Point
+                    setpoint       = self.particle_sources[species]['PID_pfuse_gaussian']['time_dependent_fusion_power'](t) # Set Point
                     it1            = max(it - 1,2)
                     dt             = self.dt
                     # Compute fusion power
@@ -982,15 +1088,14 @@ class PLASMA_SOLVER:
                     TT = self.T['tritium'][it1,:]
                     integrand = fusion.alphaPower(nD,nT,TD,TT)*self.dVdr(rho_grid)
                     integrand = integrand.flatten()
-                    p_val = max(np.trapezoid(integrand,self.r_grid),0.0)*5.0 #alpha to neutron
-                    if np.isnan(val1): p_val = 0.0
+                    p_val = max(np.trapezoid(integrand,self.r_grid),0.0)*5.0 #from alpha power to fusion power
+                    if np.isnan(p_val): p_val = 0.0
                     p_val = p_val * (1.0 + (rand()-0.5)*2.0*noise)
                     control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
                     self.particle_sources[species]['PID_pfuse_gaussian']['pid_I'] = Ival
                     self.particle_sources[species]['PID_pfuse_gaussian']['previous_error'] = error
                     # Adjust U 
-                    control = max(control,0)
-                    control = min(control,N_IN)
+                    control = np.clip(control,0,N_IN_max)
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()
@@ -998,6 +1103,38 @@ class PLASMA_SOLVER:
                     cte = control / np.trapezoid(integrand,self.r_grid)
                     #
                     aux_source = cte * np.exp(-(rho_grid-rho_0)**2/sigma_rho**2)
+                
+                case 'PID_itemp_gaussian':
+                    # These define the gaussian
+                    rho_0     = self.particle_sources[species]['PID_itemp_gaussian']['rho_0']
+                    sigma_rho = self.particle_sources[species]['PID_itemp_gaussian']['sigma_rho']
+                    pid_K     = self.particle_sources[species]['PID_itemp_gaussian']['pid_K']
+                    pid_Ti    = self.particle_sources[species]['PID_itemp_gaussian']['pid_Ti']
+                    pid_Td    = self.particle_sources[species]['PID_itemp_gaussian']['pid_Td']
+                    Ival      = self.particle_sources[species]['PID_itemp_gaussian']['pid_I']
+                    N_IN_max  = self.particle_sources[species]['PID_itemp_gaussian']['max_injected_particles_per_sec']
+                    noise     = self.particle_sources[species]['PID_itemp_gaussian']['noise_level']
+                    error_old = self.particle_sources[species]['PID_itemp_gaussian']['previous_error']
+                    t         = self.time[it]
+                    setpoint       = self.particle_sources[species]['PID_itemp_gaussian']['time_dependent_DT_temp_axis'](t) # Set Point
+                    it1            = max(it - 1,2)
+                    dt             = self.dt
+                    p_val          = 0.5*(self.T['deuterium'][it1,0]+self.T['tritium'][it1,0])* (1.0 + (rand()-0.5)*2.0*noise)
+                    # Run PID algo
+                    control, error, Ival = self.pid_controller(setpoint, p_val, pid_K, pid_Ti, pid_Td, error_old, Ival, dt)
+                    #
+                    self.particle_sources[species]['PID_itemp_gaussian']['pid_I'] = Ival
+                    self.particle_sources[species]['PID_itemp_gaussian']['previous_error'] = error
+                    # Adjust U 
+                    control = np.clip(control,0,N_IN_max)
+                    # Compute integrand
+                    integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
+                    integrand = integrand.flatten()
+                    # 
+                    cte = control / np.trapezoid(integrand,self.r_grid)
+                    #
+                    aux_source = cte * np.exp(-(rho_grid-rho_0)**2/sigma_rho**2)
+                    
                 case 'PID_pradfrac_gaussian':
                     # These define the gaussian
                     rho_0     = self.particle_sources[species]['PID_pradfrac_gaussian']['rho_0']

--- a/pySTEL/libstell/plasma_solver.py
+++ b/pySTEL/libstell/plasma_solver.py
@@ -190,9 +190,12 @@ class PLASMA_SOLVER:
                     
                     self.dVdr = CubicSpline(roa,dVdr_analytic)
                     
-                    self.B0 = np.sqrt(np.squeeze(vmec_out.bdotb)[0])   
-                    self.Bsq = CubicSpline(roa,np.squeeze(vmec_out.bdotb))
-                    self.iota23 = CubicSpline(roa,np.squeeze(vmec_out.iotaf))(2.0/3.0) # Added to do POPCON plots
+                    self.Baxis = np.sqrt(np.squeeze(vmec_out.bdotb)[0])   
+                    self.iota23 = CubicSpline(roa,np.squeeze(vmec_out.iotaf))(2.0/3.0)
+                    
+                    # stella reference magnetic field
+                    self.Bref = vmec_out.phi[-1]/ (np.pi*self.aminor**2)
+                    
             case 'cylindrical':
                 if(aminor is None or Rmajor is None or B is None):
                     print('ERROR: For a cylindrical equilibrium, Rmajor, aminor and B must be given')
@@ -203,8 +206,8 @@ class PLASMA_SOLVER:
                     dVdr = lambda rho: 4*np.pi*np.pi*Rmajor*aminor  * rho
                     rho = np.linspace(0,1,100)
                     self.dVdr = CubicSpline(rho,dVdr(rho))
-                    self.B0 = B
-                    self.Bsq = lambda rho: B*B
+                    self.Baxis = B
+                    self.Bref = B
                     
     def set_energy_source(self,species,source_type, total_power=None, sigma_rho=None, rho_0=None, 
         fraction_alpha_heating=None, cte_source=None, time_dependent_factor=None, lambda_function_2D=None,
@@ -411,10 +414,10 @@ class PLASMA_SOLVER:
             case _:
                 raise ValueError(f'ERROR: Source type {source_type} is NOT possible')
                 
-    def set_heat_fluxes(self, type: str,surfaces=None,chi=None,chi_base=None,aLT_critical=None,alpha=None,stiffness=None,chi_electrons=None,convective_fact=None):
+    def set_heat_fluxes(self, type: str,surfaces=None,chi=None,chi_base=None,aLT_critical=None,alpha=None,stiffness=None,chi_electrons=None,convective_fact=None,mass_ref_species=None):
         """
         Sets heat flux for all species. In general, the heat flux for each species is:
-        Q = -n \chi dT/dr + convective_fact*T*Gamma_turb 
+        Q = -n chi dT/dr + convective_fact*T*Gamma_turb
         The 'type' argument will set how chi is computed:
         'diffusive' : 'chi' is constant and equal to all species
         'beurskens' : 'chi_e' is constant for electrons; chi_ions are computed according to Beurskens model
@@ -441,8 +444,8 @@ class PLASMA_SOLVER:
                 self.heat_fluxes_info[type]['convective_fact'] = convective_fact
                 
             case 'beurskens':
-                if( (chi_base is None) or (aLT_critical is None) or (alpha is None) or (stiffness is None) or (chi_electrons is None) or (convective_fact is None)):
-                    raise ValueError('ERROR: chi_base, aLT_critical, alpha, stiffness, chi_electrons and convective_fact must be given!')
+                if( (chi_base is None) or (aLT_critical is None) or (alpha is None) or (stiffness is None) or (chi_electrons is None) or (convective_fact is None) or (mass_ref_species is None)):
+                    raise ValueError('ERROR: chi_base, aLT_critical, alpha, stiffness, chi_electrons, convective_fact and ref_species must be given!')
                 self.heat_fluxes_info['type'] = type
                 self.heat_fluxes_info[type]['chi_base'] = chi_base
                 self.heat_fluxes_info[type]['aLT_critical'] = aLT_critical
@@ -450,6 +453,7 @@ class PLASMA_SOLVER:
                 self.heat_fluxes_info[type]['stiffness'] = stiffness
                 self.heat_fluxes_info[type]['chi_electrons'] = chi_electrons
                 self.heat_fluxes_info[type]['convective_fact'] = convective_fact
+                self.heat_fluxes_info[type]['mass_ref_species'] = mass_ref_species        
                 
             case 'dkespenta_beurskens':
                 raise ValueError('dkespenta_beurskens heat fluxes not working')
@@ -1302,6 +1306,7 @@ class PLASMA_SOLVER:
         alpha = self.heat_fluxes_info['beurskens']['alpha']
         stiffness = self.heat_fluxes_info['beurskens']['stiffness']
         convective_fact = self.heat_fluxes_info['beurskens']['convective_fact']
+        m_ref_species = self.heat_fluxes_info['beurskens']['mass_ref_species']
         
         if callable(stiffness) and callable(aLT_critical):
             stiffness = stiffness(self.rho_grid)
@@ -1312,18 +1317,16 @@ class PLASMA_SOLVER:
             raise ValueError('ERROR: stiffnes and aLTcritical can only be a function or integer/float!')
         
         chi = {}
+        r_grid = self.r_grid
         
         ## electrons
         chi['electrons'] = chi_electrons * np.ones(self.Nr)
         T_electrons = self.T['electrons'][it,:]
-        
-        Bsq = self.Bsq(self.rho_grid)
-        
-        r_grid = self.r_grid
-        
+         
         ## IONS
         for ion in self.plasma.ion_species:
             T_ion = self.T[ion][it,:]
+            n_ion = self.N[ion][it,:]
             
             # T_polyfit = np.poly1d( np.polyfit(r_grid,T_ion,deg=12) )
             # dTdr_polyfit = np.poly1d( T_polyfit.deriv() )
@@ -1339,10 +1342,15 @@ class PLASMA_SOLVER:
             
             chi_turb = stiffness * X * np.heaviside(X,1) * (T_electrons/T_ion)**alpha
             
-            mi = self.plasma.mass[ion]
-            qi = self.plasma.charge[ion]
-    
-            chi_gB = (EC*T_ion/mi)**1.5 * mi*mi / (qi**2 * Bsq) / self.aminor
+            # gyro-Bohm heat flux
+            Tref = T_ion         # self.T[ref_species][it,:]
+            mref = m_ref_species # self.plasma.mass[ref_species]
+            # nref = self.N[ref_species][it,:] # we cannot use this one, as this poses issue to the impurities
+            nref = n_ion
+            
+            Q_gB = 2.0*np.sqrt(2)*nref*np.sqrt(mref)*(EC*Tref)**2.5 / (EC*self.Bref*self.aminor)**2
+            
+            chi_gB = Q_gB * self.aminor/(n_ion*EC*T_ion)
             
             chi_turb = chi_gB * chi_turb
             
@@ -1993,12 +2001,15 @@ class PLASMA_SOLVER:
         saved_class = SimpleNamespace()
         saved_class.rho_grid = self.rho_grid
         saved_class.r_grid = self.r_grid
-        saved_class.dVdr = self.dVdr
+        saved_class.dVdr = self.dVdr(self.rho_grid)
         saved_class.aminor = self.aminor
         saved_class.Rmajor = self.Rmajor
-        saved_class.B = self.B0
-        saved_class.iota23 = self.iota23
+        saved_class.Baxis = self.Baxis
+        saved_class.Bref  = self.Bref
         saved_class.list_of_species = self.list_of_species
+        # In case of a VMEC equilibrium
+        if hasattr(self,'iota23'):
+            saved_class.iota23 = self.iota23
         
         # only save at minimum every dt=0.1s 
         freq = max(1, round(0.1 / self.dt))

--- a/pySTEL/libstell/thrift.py
+++ b/pySTEL/libstell/thrift.py
@@ -1164,7 +1164,7 @@ class THRIFT_plasma_solver():
                 elif value.ndim == 3:
                     setattr(self,name,value[:,mask,:])        
         
-    def create_input_sources_file(self,filename,nt,nrho,tfin):
+    def create_input_sources_file(self,filename,nrho,tgrid):
         # creates 
         
         Zcharge_ions = np.array( [self.plasma_class.Zcharge[ion] for ion in self.plasma_class.ion_species], dtype=int )
@@ -1172,7 +1172,8 @@ class THRIFT_plasma_solver():
         nZ   = self.plasma_class.num_ion_species
         
         self.rho_grid_source = np.linspace(0,1,nrho)
-        self.t_grid_source = np.linspace(0,tfin,nt)
+        self.t_grid_source = tgrid
+        nt = len(tgrid)
         
         SE_out = np.zeros((nrho,nt,nZ+1))
         Sn_out = np.zeros((nrho,nt,nZ+1))
@@ -1196,9 +1197,6 @@ class THRIFT_plasma_solver():
         hf.close()
         
     def add_energy_source_to_input_file(self,filename,which_species,source_type,dVdrho=None,total_power=None,sigma_rho=None,rho_0=None,time_dependent_factor=None,cte_source=None):
-        
-        from scipy.integrate import quad
-        
         try:
             species_id = self.plasma_class.list_of_species.index(which_species) 
         except:
@@ -1210,11 +1208,6 @@ class THRIFT_plasma_solver():
                     print('ERROR: Need to provide total_power [W], dVdrho, sigma_rho and rho_0 for gaussian external source')
                     exit(1) 
                 else:
-                    # integrand = lambda rho: np.exp(-(rho-rho_0)**2/sigma_rho**2) * dVdrho(rho)
-                    # #
-                    # cte = total_power / quad(integrand,0,1)[0]
-                    # #
-                    # source = lambda t,rho: cte * np.exp(-(rho-rho_0)**2/sigma_rho**2)
                     integrand = np.exp(-(self.rho_grid_source - rho_0)**2/sigma_rho**2) * dVdrho(self.rho_grid_source)
                     integrand = integrand.flatten()
                     #
@@ -1249,9 +1242,10 @@ class THRIFT_plasma_solver():
         with h5py.File(filename, 'r+') as f:
             dset = f['S_energy']
             for it,t in enumerate(self.t_grid_source): 
-                dset[:,it,species_id] = source(t)#,self.rho_grid_source)
+                dset[:,it,species_id] = source(t)
                 
-    def add_particle_source_to_input_file(self,filename,which_species,source_type,dVdrho=None,injected_particles_per_sec=None,sigma_rho=None,rho_0=None,time_dependent_factor=None,cte_source=None):
+    def add_particle_source_to_input_file(self,filename,which_species,source_type,dVdrho=None,injected_particles_per_sec=None,
+                                          sigma_rho=None,rho_0=None,time_dependent_factor=None,cte_source=None,source_2D=None):
         
         from scipy.integrate import quad
         
@@ -1265,13 +1259,7 @@ class THRIFT_plasma_solver():
                 if((injected_particles_per_sec is None) or (sigma_rho is None) or (rho_0 is None) or (dVdrho is None)):
                     print('ERROR: Need to provide injected_particles_per_sec, dVdrho, sigma_rho and rho_0 for gaussian external source')
                     exit(1) 
-                else:
-                    # integrand = lambda rho: np.exp(-(rho-rho_0)**2/sigma_rho**2) * dVdrho(rho)
-                    # #
-                    # cte = injected_particles_per_sec / quad(integrand,0,1)[0]
-                    # #
-                    # source = lambda t,rho: cte * np.exp(-(rho-rho_0)**2/sigma_rho**2)
-                    
+                else:                    
                     integrand = np.exp(-(self.rho_grid_source - rho_0)**2/sigma_rho**2) * dVdrho(self.rho_grid_source)
                     integrand = integrand.flatten()
                     #
@@ -1291,6 +1279,20 @@ class THRIFT_plasma_solver():
                     #
                     source = lambda t: time_dependent_factor(t) * cte * np.exp(-(self.rho_grid_source - rho_0)**2/sigma_rho**2)
                     
+            case 'source_2D':
+                if(source_2D is None):
+                    raise ValueError('Need to provide the 2D arrays source_2D')
+                # Check if source_2D has the expected dimensions: nt x nrho
+                nt = len(self.t_grid_source)
+                nrho = len(self.rho_grid_source)
+                if(source_2D.shape != (nt,nrho)):
+                    raise ValueError(f'source_2D array does not have the expected ({nt},{nrho}) shape!')
+                # Save directly in file and leave
+                with h5py.File(filename, 'r+') as f:
+                    dset = f['S_particle']
+                    dset[:,:,species_id] = source_2D.T
+                return
+                            
             case 'constant':
                 if(cte_source is None):
                     print('ERROR: cte_source is needed in order to generate a constant source.')
@@ -1306,7 +1308,7 @@ class THRIFT_plasma_solver():
         with h5py.File(filename, 'r+') as f:
             dset = f['S_particle']
             for it,t in enumerate(self.t_grid_source): 
-                dset[:,it,species_id] = source(t) #,self.rho_grid_source)
+                dset[:,it,species_id] = source(t)
                 
     def convert_to_joblib(self,dt_save=0.1,filename='thrift_transport_simul',thrift_class=None):
         """ This function creates a joblib file with the transport simulation data

--- a/pySTEL/plasma_solver_util.py
+++ b/pySTEL/plasma_solver_util.py
@@ -13,11 +13,12 @@ if __name__=="__main__":
 	from libstell.fusion import FUSION,EC
 	from libstell.popcon import POPCON
 	from libstell.plasma import PLASMA
+	from libstell.plasma_solver import merge_output_files
 	from scipy.integrate import cumulative_trapezoid
 	parser = ArgumentParser(description= 
 		'''Utility for plotting 1D transport simulations.''')
-	parser.add_argument("--output", dest="output_ext",
-		help="Output joblib file name.", default = None)
+	parser.add_argument("--output", dest="output_files", nargs='+',
+		help="One or more output joblib files (without .joblib extension).", default = None)
 	parser.add_argument("-p", "--plot", dest="lplot", action='store_true',
 		help="Make plots.", default = False)
 	parser.add_argument("--plot_popcon", dest="lplot_popcon", action='store_true',
@@ -27,19 +28,21 @@ if __name__=="__main__":
 	parser.add_argument("--save", dest="lsave", action='store_true',
 		help="Save the plots with ext names.", default = False)
 	args = parser.parse_args()
-	if args.output_ext: 
-		solver = joblib.load(f'{args.output_ext}.joblib')
+	if args.output_files is not None:
+		output_files = [f"{f}.joblib" for f in args.output_files]
+		if len(output_files) == 1:
+			solver = joblib.load(output_files[0])
+		else:
+			solver = merge_output_files(*output_files)
 		nr     = len(solver.r_grid)
 		nt     = solver.Nt
-		try:     
-			Area = solver.dVdr(solver.rho_grid)
-		except:
-			Area = solver.dVdr
+		Area = solver.dVdr
+		#
 		keys = solver.explicit_energy_sources['electrons'].keys()
 		S_ECRH = np.zeros((nt,nr))
-		for ttype in ['external_gaussian','time_dependent_gaussian','PID_etemp_gaussian']:
+		for ttype in ['external_gaussian','time_dependent_gaussian','PID_etemp_gaussian','PID_itemp_gaussian','PID_pfuse_gaussian']:
 			if ttype in keys:
-				S_ECRH = solver.explicit_energy_sources['electrons'][ttype][:,:]
+				S_ECRH += solver.explicit_energy_sources['electrons'][ttype][:,:]
 		S_alpha = np.zeros((nt,nr))
 		for species in solver.list_of_species:
 			keys = solver.explicit_energy_sources[species].keys()
@@ -51,14 +54,14 @@ if __name__=="__main__":
 		P_Bremm = cumulative_trapezoid(S_Bremm*Area,solver.r_grid,axis=1,initial=0.0)
 		P_TOTAL = P_ECRH+P_alpha
 		keys = solver.explicit_particle_sources['deuterium'].keys()
-		S_fueling = None
+		S_fueling = np.zeros((nt,nr)) #None
 		for ttype in ['external_gaussian','time_dependent_gaussian','PID_edense_gaussian','PID_pfuse_gaussian']:
 			if ttype in keys:
-				if type(S_fueling) is type(None):
-					S_fueling = solver.explicit_particle_sources['deuterium'][ttype][:,:]
-				else:
-					S_fueling = S_fueling + solver.explicit_particle_sources['deuterium'][ttype][:,:]
-		pellet_content_times_freq = 5E20/0.1
+				S_fueling += solver.explicit_particle_sources['deuterium'][ttype][:,:]
+				# if type(S_fueling) is type(None):
+				# 	S_fueling = solver.explicit_particle_sources['deuterium'][ttype][:,:]
+				# else:
+				# 	S_fueling = S_fueling + solver.explicit_particle_sources['deuterium'][ttype][:,:]
 		P_fueling = np.trapezoid(S_fueling*Area, solver.r_grid, axis=1)
 		fusion  = FUSION()
 		tauiss04 = lambda a,R,P,n_avg,B,iota: 0.134 * a**2.28 * R**0.64 * (P/1e6)**-0.61 * (n_avg/1e19)**0.54 * B**0.84 * iota**0.41
@@ -67,13 +70,12 @@ if __name__=="__main__":
 		try:
 			B = solver.B[:,0] # use axes value
 		except:
-			B = solver.B
+			B = solver.Baxis
 		try:
 			ir2o3 = np.argmin(np.abs(solver.rho_grid-2/3))
 			iota = solver.iota[:,ir2o3]
 		except:
-			print('WARNING: Using iota=0.9 to compute ISS04')
-			iota = 0.9
+			iota = solver.iota23
 		n_avg = {}
 		for species in solver.list_of_species:
 			n_avg[species] = np.trapezoid(solver.N[species][:,:]*Area,solver.r_grid,axis=1) / np.trapezoid(Area,solver.r_grid)
@@ -84,7 +86,6 @@ if __name__=="__main__":
 		pressure = 0.0
 		for species in solver.list_of_species:
 			pressure += 1.5*solver.N[species][:,:]*solver.T[species][:,:]*EC
-			#pressure += (3.0/2.0)*solver.N[species][:,:]*solver.T[species][:,:]*EC
 		W_total = np.trapezoid(pressure*Area,solver.r_grid,axis=1)
 		dWdt = np.gradient(W_total,solver.time)
 		tau_E = W_total / (-dWdt+P_ECRH[:,-1]+P_alpha[:,-1])
@@ -98,35 +99,43 @@ if __name__=="__main__":
 			#fig,ax = plt.subplots(4,1,figsize=(1800*px,2400*px))
 			fig,ax = plt.subplots(4,1,figsize=(900*px,1200*px))
 			ax[0].plot(solver.time,P_TOTAL[:,-1]/1E6,linewidth=2.0,color='#5faf30',label=r'$P_{\mathrm{TOTAL}}$')
-			ax[0].plot(solver.time,10*P_ECRH[:,-1]/1E6,linewidth=2.0,color='blue',label=r'$P_{\mathrm{ECRH}}x10$')
+			# ax[0].plot(solver.time,10*P_ECRH[:,-1]/1E6,linewidth=2.0,color='blue',label=r'$P_{\mathrm{ECRH}}x10$')
+			ax[0].plot(solver.time,P_ECRH[:,-1]/1E6,linewidth=2.0,color='blue',label=r'$P_{\mathrm{ECRH}}$')
 			ax[0].plot(solver.time,P_alpha[:,-1]/1E6,linewidth=2.0,color='green',label=r'$P_{\mathrm{\alpha}}$')
+			# ax[0].plot(solver.time,5*P_alpha[:,-1]/1E6,linewidth=2.0,color='k',label=r'$P_{\mathrm{fusion}}$')
 			ax[0].plot(solver.time,-P_Bremm[:,-1]/1E6,linewidth=2.0,color='red',label=r'$P_{\mathrm{Brem.}}$')
 			ax[0].grid()
 			ax[0].legend()
-			ax[0].set_title('GIGA')
 			ax[0].set_ylabel('P [MW]')
+			Ne = np.trapezoid(solver.N['electrons'][:,:]*Area, solver.r_grid)
 			ax[1].plot(solver.time,solver.N['electrons'][:,0]/1E19,linewidth=2.0,color='#5faf30',label=r'$n_e$')
 			if 'hydrogen' in solver.N.keys():
-				ax[1].plot(solver.time,solver.N['hydrogen'][:,0]/1E19,':',linewidth=2.0,color='red',label=r'$n_D$')
+				ax[1].plot(solver.time,solver.N['hydrogen'][:,0]/1E19,':',linewidth=2.0,color='red',label=r'$n_H$')
 			if 'deuterium' in solver.N.keys():
 				ax[1].plot(solver.time,solver.N['deuterium'][:,0]/1E19,':',linewidth=2.0,color='red',label=r'$n_D$')
 			if 'tritium' in solver.N.keys():
 				ax[1].plot(solver.time,solver.N['tritium'][:,0]/1E19,linewidth=2.0,color='#004817',label=r'$n_T$')
 			if 'helium4' in solver.N.keys():
-				ax[1].plot(solver.time,solver.N['helium4'][:,0]/1E19,linewidth=2.0,color='#004817',label=r'$n_{He4}$')
+				# compute fraction of helium4
+				NHe4 = np.trapezoid(solver.N['helium4'][:,:]*Area, solver.r_grid)
+				frac = NHe4/Ne
+				ax[1].plot(solver.time,solver.N['helium4'][:,0]/1E19,linewidth=2.0,color='#004817',label=fr'$n_{{He4}}$ (f={frac[-1]*100:.2f}%)')
 			if 'alphas_fast' in solver.N.keys():
 				ax[1].plot(solver.time,solver.N['alphas_fast'][:,0]/1E19,linewidth=2.0,color='green',label=r'$n_{He4-fast}$')
 			if 'neon' in solver.N.keys():
-				ax[1].plot(solver.time,solver.N['neon'][:,0]/1E19,linewidth=2.0,color='magenta',label=r'$n_{Ne}$')
+				# compute fraction of neon
+				NNe = np.trapezoid(solver.N['neon'][:,:]*Area, solver.r_grid)
+				frac = NNe/Ne
+				ax[1].plot(solver.time,solver.N['neon'][:,0]/1E19,linewidth=2.0,color='magenta',label=fr'$n_{{Ne}}$ (f={frac[-1]*100:.2f}%)')
 			ax[1].grid()
 			ax[1].legend()
 			ax12=ax[1].twinx()
 			ax12.plot(solver.time,P_fueling/1E22,linewidth=1.0,color='black',label=r'$N$')
-			ax[1].set_ylabel(r'$n_0~[10^{19}]~m^{-3}$')
-			ax12.set_ylabel(r'$\dot{N}~[10^{22}]~part/s$')
+			ax[1].set_ylabel(r'$n_0~[10^{19}~m^{-3}]$')
+			ax12.set_ylabel(r'$\dot{N}~[10^{22}~part/s]$')
 			ax[2].plot(solver.time,solver.T['electrons'][:,0]/1E3,linewidth=2.0,color='#5faf30',label=r'$T_e$')
 			if 'hydrogen' in solver.T.keys():
-				ax[2].plot(solver.time,solver.T['hydrogen'][:,0]/1E3,':',linewidth=2.0,color='red',label=r'$T_D$')
+				ax[2].plot(solver.time,solver.T['hydrogen'][:,0]/1E3,':',linewidth=2.0,color='red',label=r'$T_H$')
 			if 'deuterium' in solver.T.keys():
 				ax[2].plot(solver.time,solver.T['deuterium'][:,0]/1E3,':',linewidth=2.0,color='red',label=r'$T_D$')
 			if 'tritium' in solver.T.keys():
@@ -138,21 +147,20 @@ if __name__=="__main__":
 			ax[2].set_ylabel(r'$T_0~[keV]$')
 			ax[2].legend()
 			ax[2].grid()
-			ax[3].plot(solver.time,W_total/1E9,linewidth=2.0,color='#5faf30',label=r'$W_{therm} [GJ]$')
+			ax[3].plot(solver.time,W_total/1E9,linewidth=2.0,color='#5faf30',label=r'$W_{therm}$')
 			ax12=ax[3].twinx()
-			ax12.plot(solver.time,tau_E/tau_ISS04,label=r'$\tau_{\mathrm{ISS04}}$',linewidth=2.0)
+			ax12.plot(solver.time,tau_E/tau_ISS04,label=r'$\tau_E/\tau_{\mathrm{ISS04}}$',linewidth=2.0)
 			ax12.set_ylim(0.5,1.5)
-			ax[3].set_ylabel(r'$W_{therm} [GJ]$')
+			ax[3].set_ylabel(r'$W_{therm}~[GJ]$')
 			ax[3].set_xlabel('Time [s]')
 			ax[3].grid()
+			ax[3].legend(loc='upper left')
+			ax12.legend(loc='upper right')
+			ax12.set_ylabel(r'$\tau_E/\tau_{\mathrm{ISS04}}$')
 			plt.tight_layout()
 			plt.show()
 			if (args.lsave): fig.savefig(f'overview_{args.output_ext}.png', dpi=fig.dpi)
 		if args.lplot_popcon:
-			te_min = min(solver.T['electrons'][:,0])
-			te_max = max(solver.T['electrons'][:,0])
-			ne_min = min(solver.N['electrons'][:,0])
-			ne_max = max(solver.N['electrons'][:,0])
 			te_min = 2.0E3; te_max = 30.0E3
 			ne_min = 1.0E19; ne_max = 3.0E20
 			nte = 32; nne=32
@@ -169,9 +177,14 @@ if __name__=="__main__":
 						ne=ntemp*solver.N[spec][0,-1]/neE
 						t0=ttemp
 						te=t0*0.01
-						plasma[i][j].set_density(spec,'polynomial',n0=n0,nedge=ne,exponent=6.0)
-						plasma[i][j].set_temperature(spec,'polynomial',T0=t0,Tedge=te,exponent=1.0)
-			popcon = POPCON(solver.B,solver.aminor,solver.Rmajor,solver.iota23,plasma, make_plot=False)
+						# plasma[i][j].set_density(spec,'polynomial',n0=n0,nedge=ne,exponent=6.0)
+						profile = solver.N[spec][-1,:] / solver.N[spec][-1,0]
+						plasma[i][j].set_density(spec,'interp',rho_vals=solver.rho_grid,n_vals=ntemp*profile)
+						profile = solver.T[spec][-1,:] / solver.T[spec][-1,0]
+						# plasma[i][j].set_temperature(spec,'polynomial',T0=t0,Tedge=te,exponent=1.0)
+						plasma[i][j].set_temperature(spec,'interp',rho_vals=solver.rho_grid,T_vals=ttemp*profile)
+			fren = tau_E[-1]/tau_ISS04[-1]
+			popcon = POPCON(solver.B,solver.aminor,solver.Rmajor,solver.iota23,plasma, iss04_fact=fren, make_plot=False, popcon_title=f'fren={fren:.2f}')
 			px = 1/plt.rcParams['figure.dpi']
 			font = {'family' : 'Arial',
 					'weight' : 'normal',
@@ -268,6 +281,7 @@ if __name__=="__main__":
 			ax[3,1].legend()
 			ax[3,1].yaxis.set_label_position("right")
 			ax[3,1].yaxis.tick_right()
+			ax[0,0].set_title(f'Profiles at t={solver.time[tdex]}s')
 			plt.show()
 			if (args.lsave): fig.savefig(f'profs_{args.output_ext}_t{np.round(args.tslice_profs*1000)}ms.png', dpi=fig.dpi)
 


### PR DESCRIPTION
With this merge:
- I have modified, for clarity, some of the variables names of the PIDs. For instance, the `total_power` is now the `max_total_power` and the `time_dependent_factor` is now `time_dependent_electron_temp_axis`, etc
- I corrected the definition of Q_gB (used to denormalize the turbulence fluxes) to be in accordance with the definition in `stella`, from which the normalized fluxes usually come from
- the `plasma_solver_util.py` has been cleaned and slightly improved

An example of a script that launches a transport simulation where density is controlled via a PID can be found [here](https://github.com/user-attachments/files/24825419/PID_with_neon.py)

To think for the future: dome functions inside the classes `plasma_solver`, `thrift`, etc, are more of "auxiliary mathematical functions" than actually essential parts of the classes. These are for instance: `akima_derivative`, `polyfit_derivative`, etc. I wonder if at some point it would make sense to have an `auxiliary_functions.py` file inside `pySTEL/libstell`.