### PR TITLE
Starting BEAMS3D markers from an ASCOT5 run.

### DIFF
--- a/BEAMS3D/BEAMS3D.dep
+++ b/BEAMS3D/BEAMS3D.dep
@@ -203,6 +203,17 @@ beams3d_init_restart.o: \
       ../../LIBSTELL/$(LOCTYPE)/mpi_params.o \
       ../../LIBSTELL/$(LOCTYPE)/mpi_inc.o \
       ../../LIBSTELL/$(LOCTYPE)/ez_hdf5.o \
+      beams3d_physics_mod.o \
+      beams3d_runtime.o \
+      beams3d_lines.o \
+      beams3d_grid.o
+      
+
+beams3d_init_ascot5_endstate.o: \
+      ../../LIBSTELL/$(LOCTYPE)/stel_kinds.o \
+      ../../LIBSTELL/$(LOCTYPE)/mpi_params.o \
+      ../../LIBSTELL/$(LOCTYPE)/mpi_inc.o \
+      ../../LIBSTELL/$(LOCTYPE)/ez_hdf5.o \
       beams3d_runtime.o \
       beams3d_lines.o \
       beams3d_grid.o

--- a/BEAMS3D/ObjectList
+++ b/BEAMS3D/ObjectList
@@ -1,4 +1,5 @@
 ObjectFiles = \
+beams3d_init_ascot5_endstate.o \
 beams3d_spline3d_setup.o \
 beams3d_init_user.o \
 beams3d_init_mumat.o \

--- a/BEAMS3D/Sources/beams3d_init.f90
+++ b/BEAMS3D/Sources/beams3d_init.f90
@@ -140,7 +140,7 @@
 #endif
 
       ! Handle particle restarting
-      IF (lrestart_particles .or. lcontinue_grid) THEN
+      IF (lrestart_particles .or. lcontinue_grid .or. lreadascotendstate) THEN
         ldepo = .false.
         lbbnbi = .false.
         lbeam = .false.
@@ -605,6 +605,8 @@
          IF (lrandomize) CALL beams3d_randomize_particles
       ELSEIF (lrestart_particles) THEN
          CALL beams3d_init_restart
+      ELSEIF (lreadascotendstate) THEN
+         CALL beams3d_init_ascot5_endstate
       ELSEIF (lfusion) THEN
          CALL beams3d_init_fusion
       ELSE

--- a/BEAMS3D/Sources/beams3d_init_ascot5_endstate.f90
+++ b/BEAMS3D/Sources/beams3d_init_ascot5_endstate.f90
@@ -1,0 +1,180 @@
+!-----------------------------------------------------------------------
+!     Module:        beams3d_init_ascot5_endstate
+!     Authors:       S. Lazerson (samuel.lazerson@gauss-fusion.com)
+!     Date:          01/23/2026
+!     Description:   This subroutine loads particle data from an ASCOT5
+!                    endstate run.
+!-----------------------------------------------------------------------
+      SUBROUTINE beams3d_init_ascot5_endstate
+!-----------------------------------------------------------------------
+!     Libraries
+!-----------------------------------------------------------------------
+      USE stel_kinds, ONLY: rprec
+      USE beams3d_globals, ONLY: a5_run_name, a5_marker_name
+      USE beams3d_runtime
+      USE beams3d_grid
+      USE beams3d_lines
+#if defined(LHDF5)
+      USE ez_hdf5
+#endif
+      USE mpi_sharmem
+      USE mpi_params
+      USE mpi_inc
+!-----------------------------------------------------------------------
+!     Local Variables
+!          ier            Error Flag
+!          npoinc_extract Which save state to extract from file.
+!-----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER :: i, k, ier
+      REAL(rprec), DIMENSION(:), ALLOCATABLE :: temp2
+      CHARACTER(10)  :: marker_id
+      INTEGER :: MPI_COMM_LOCAL
+!-----------------------------------------------------------------------
+!     Begin Subroutine
+!-----------------------------------------------------------------------
+
+
+      ! DEALLOCATE the start variables
+#if defined(MPI_OPT)
+      CALL mpidealloc(R_start, win_R_start)
+      CALL mpidealloc(PHI_start, win_PHI_start)
+      CALL mpidealloc(Z_start, win_Z_start)
+      CALL mpidealloc(vr_start, win_vr_start)
+      CALL mpidealloc(vphi_start, win_vphi_start)
+      CALL mpidealloc(vz_start, win_vz_start)
+      CALL mpidealloc(mass, win_mass)
+      CALL mpidealloc(charge, win_charge)
+      CALL mpidealloc(mu_start, win_mu_start)
+      CALL mpidealloc(Zatom, win_Zatom)
+      CALL mpidealloc(t_end, win_t_end)
+      CALL mpidealloc(vll_start, win_vll_start)
+      CALL mpidealloc(beam, win_beam)
+      CALL mpidealloc(weight, win_weight)
+      CALL mpidealloc(lgc2fo_start, win_lgc2fo_start)
+      CALL mpidealloc(end_state, win_end_state)
+#endif
+
+      IF (lverb) THEN
+         WRITE(6,'(A)')  '----- Reading Endstates from ASCOT5 File -----'
+         WRITE(6,'(A)')  '               FILE: '//TRIM(ascot_endstate_file)
+      END IF
+
+      ! Load the array size information from the old file
+      ! Now the strcuture of the files is
+      IF (myworkid == master) THEN
+         ! Read the data
+         CALL open_hdf5(TRIM(ascot_endstate_file),fid,ier,LCREATE=.false.)
+         IF (ier /= 0) CALL handle_err(HDF5_OPEN_ERR,TRIM(restart_string),ier)
+         ! First get the marker ID for the run
+         !CALL read_group_attscalar_hdf5(fid,'/results/'//TRIM(a5_run_name),'qid_marker',ier,STRVAR=marker_id)
+         !IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'qid_marker',ier)
+         !WRITE(6,*) 'id: '//TRIM(marker_id)
+         ! Now get the numer of markers
+         !WRITE(marker_name,'(A,i10.10)') 'prt_',marker_id
+         !marker_name = 'prt_'//TRIM(marker_id)
+         CALL read_scalar_hdf5(fid,'/marker/'//TRIM(a5_marker_name)//'/n',ier,INTVAR=nparticles)
+         nparticles = nparticles*2
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'nparticles',ier)
+         IF (lverb) THEN
+            WRITE(6,'(A,A)')  '      RUN_NAME: ', TRIM(a5_run_name)
+            WRITE(6,'(A,A)')  '   MARKER_NAME: ', TRIM(a5_marker_name)
+            WRITE(6,'(A,I8)') '    NPARTICLES: ', nparticles
+         END IF
+      END IF      
+#if defined(MPI_OPT)
+      CALL MPI_BCAST(nparticles, 1, MPI_INTEGER, master, MPI_COMM_BEAMS,ierr_mpi)
+
+      ! Allocate the particles
+      CALL mpialloc(end_state,    nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_end_state)
+      CALL mpialloc(R_start,      nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_R_start)
+      CALL mpialloc(PHI_start,    nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_PHI_start)
+      CALL mpialloc(Z_start,      nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_Z_start)
+      CALL mpialloc(vr_start,     nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_vr_start)
+      CALL mpialloc(vphi_start,   nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_vphi_start)
+      CALL mpialloc(vz_start,     nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_vz_start)
+      CALL mpialloc(mass,         nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_mass)
+      CALL mpialloc(charge,       nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_charge)
+      CALL mpialloc(mu_start,     nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_mu_start)
+      CALL mpialloc(Zatom,        nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_Zatom)
+      CALL mpialloc(t_end,        nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_t_end)
+      CALL mpialloc(vll_start,    nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_vll_start)
+      CALL mpialloc(beam,         nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_beam)
+      CALL mpialloc(weight,       nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_weight)
+      CALL mpialloc(lgc2fo_start, nparticles, myid_sharmem, 0, MPI_COMM_SHARMEM, win_lgc2fo_start)
+#endif
+      IF (myworkid == master) THEN
+         ALLOCATE(temp2(nparticles))
+         beam = 1
+         end_state = 0
+         lgc2fo_start = .false.
+         t_end        = MAXVAL(t_end_in)
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/mass',nparticles,ier,DBLVAR=mass)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'mass',ier)
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/charge',nparticles,ier,DBLVAR=charge)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'charge',ier)
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/znum',nparticles,ier,DBLVAR=Zatom)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'Zatom',ier)
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/weight',nparticles,ier,DBLVAR=weight)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'weight',ier)
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/rprt',nparticles,ier,DBLVAR=temp2)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'rprt',ier)
+         R_start = temp2
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/zprt',nparticles,ier,DBLVAR=temp2)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'zprt',ier)
+         Z_start = temp2
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/phiprt',nparticles,ier,DBLVAR=temp2)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'phiprt',ier)
+         PHI_start = temp2
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/ppar',nparticles,ier,DBLVAR=temp2)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'ppar',ier)
+         vll_start = temp2/mass
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/mu',nparticles,ier,DBLVAR=temp2)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'mu',ier)
+         mu_start = temp2
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/prprt',nparticles,ier,DBLVAR=temp2)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'prprt',ier)
+         vr_start = temp2/mass
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/pphiprt',nparticles,ier,DBLVAR=temp2)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'pphiprt',ier)
+         vphi_start = temp2/mass
+         CALL read_var_hdf5(fid,'/results/'//TRIM(a5_run_name)//'/endstate/pzprt',nparticles,ier,DBLVAR=temp2)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'pzprt',ier)
+         vz_start = temp2/mass
+         CALL close_hdf5(fid,ier)
+         IF (ier /= 0) CALL handle_err(HDF5_CLOSE_ERR,'beams3d_'//TRIM(restart_string)//'.h5',ier)
+         DEALLOCATE(temp2)
+      END IF
+
+#if defined(MPI_OPT)
+      CALL MPI_BARRIER(MPI_COMM_BEAMS,ierr_mpi)
+      i = MPI_UNDEFINED
+      IF (myid_sharmem == master) i = 0
+      CALL MPI_COMM_SPLIT( MPI_COMM_BEAMS,i,myworkid,MPI_COMM_LOCAL,ierr_mpi)
+      IF (myid_sharmem == master) THEN
+         CALL MPI_BCAST(     R_start, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(   PHI_start, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(     Z_start, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(   vll_start, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(    mu_start, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(    vr_start, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(  vphi_start, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(    vz_start, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(       t_end, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(        mass, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(      charge, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(       Zatom, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(      weight, nparticles,   MPI_REAL8, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(        beam, nparticles, MPI_INTEGER, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_BCAST(lgc2fo_start, nparticles, MPI_LOGICAL, master, MPI_COMM_LOCAL,ierr_mpi)
+         CALL MPI_COMM_FREE(MPI_COMM_LOCAL,ierr_mpi)
+      END IF
+      nbeams = 1
+#endif
+
+      RETURN
+
+!-----------------------------------------------------------------------
+!     End Subroutine
+!-----------------------------------------------------------------------    
+      END SUBROUTINE beams3d_init_ascot5_endstate

--- a/BEAMS3D/Sources/beams3d_interface_mod.f90
+++ b/BEAMS3D/Sources/beams3d_interface_mod.f90
@@ -185,6 +185,7 @@ CONTAINS
          lboxsim = .false.
          lfieldlines = .false.
          lbeamdensity = .true.
+         lreadascotendstate = .false.
          id_string = ''
          coil_string = ''
          mgrid_string = ''
@@ -193,6 +194,7 @@ CONTAINS
          continue_grid_string = ''
          bbnbi_string = ''
          eqdsk_string = ''
+         ascot_endstate_file = ''
 
          ! First Handle the input arguments
          CALL GETCARG(1, arg1, numargs)
@@ -213,6 +215,10 @@ CONTAINS
                 lascotfl = .true.
             case ("-ascot4")
                 lascot4 = .true.
+            case ("-ascot_input")
+                i = i + 1
+                lreadascotendstate = .true.
+                CALL GETCARG(i, ascot_endstate_file, numargs)
             case ("-fidasim")
                 lfidasim = .true.
             case ("-fidasim_cyl")
@@ -353,6 +359,7 @@ CONTAINS
                 write(6, *) '     -coil file:      Coils. File (for vacuum)'
                 write(6, *) '     -mumat file:     Magnetic Materials File'
                 write(6, *) '     -restart ext:    BEAMS3D HDF5 extension for starting particles'
+                write(6, *) '     -ascot_input ext: ASCOT5 HDF5 extension for starting particles from endstate'
                 write(6, *) '     -beamlet ext:    Beamlet file for beam geometry'
                 write(6, *) '     -beam_simple:    Monoenergetic BEAMS'
                 write(6, *) '     -ascot5:         Output data in ASCOT5 gyro-center format'
@@ -401,6 +408,8 @@ CONTAINS
       CALL MPI_BCAST(mumat_string, 256, MPI_CHARACTER, master, MPI_COMM_BEAMS, ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'beams3d_main', ierr_mpi)
       CALL MPI_BCAST(mumat_magfile, 256, MPI_CHARACTER, master, MPI_COMM_BEAMS, ierr_mpi)
+      IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'beams3d_main', ierr_mpi)
+      CALL MPI_BCAST(ascot_endstate_file, 256, MPI_CHARACTER, master, MPI_COMM_BEAMS, ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'beams3d_main', ierr_mpi)
       CALL MPI_BCAST(lvmec, 1, MPI_LOGICAL, master, MPI_COMM_BEAMS, ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR, 'beams3d_main', ierr_mpi)
@@ -479,6 +488,8 @@ CONTAINS
       CALL MPI_BCAST(lbeamdensity,1,MPI_LOGICAL, master, MPI_COMM_BEAMS,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'beams3d_main',ierr_mpi)
       CALL MPI_BCAST(luser_init,1,MPI_LOGICAL, master, MPI_COMM_BEAMS,ierr_mpi)
+      IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'beams3d_main',ierr_mpi)
+      CALL MPI_BCAST(lreadascotendstate,1,MPI_LOGICAL, master, MPI_COMM_BEAMS,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'beams3d_main',ierr_mpi)
       CALL MPI_BCAST(rminor_norm,1,MPI_DOUBLE_PRECISION, master, MPI_COMM_BEAMS,ierr_mpi)
       IF (ierr_mpi /= MPI_SUCCESS) CALL handle_err(MPI_BCAST_ERR,'beams3d_main',ierr_mpi)

--- a/BEAMS3D/Sources/beams3d_runtime.f90
+++ b/BEAMS3D/Sources/beams3d_runtime.f90
@@ -168,7 +168,7 @@ MODULE beams3d_runtime
                lascot, lascot4, lfidasim, lfidasim_cyl, lsplit, &
                lvessel_beam, lascotfl, lrandomize, leqdsk, lhint, &
                lboxsim, limas, lfieldlines, lbeamdensity, lmumat, &
-               luser_init
+               luser_init, lreadascotendstate
     INTEGER :: nextcur, nprocs_beams, ndt, ndt_max
     INTEGER :: win_beam
     INTEGER, DIMENSION(:), POINTER :: beam
@@ -187,7 +187,7 @@ MODULE beams3d_runtime
     CHARACTER(256) :: mgrid_string, coil_string, &
                       vessel_string, restart_string, &
                       continue_grid_string, bbnbi_string, &
-                      eqdsk_string, mumat_string
+                      eqdsk_string, mumat_string, ascot_endstate_file
 
     REAL(rprec), PARAMETER :: BEAMS3D_VERSION = 5.00
 

--- a/LIBSTELL/Sources/Modules/beams3d_globals.f90
+++ b/LIBSTELL/Sources/Modules/beams3d_globals.f90
@@ -42,7 +42,7 @@
       REAL(rprec), DIMENSION(MAXPARTICLES) :: r_start_in, phi_start_in, z_start_in, vll_start_in, &
                                             & mu_start_in, charge_in, Zatom_in, mass_in, t_end_in, &
                                             vr_start_in, vphi_start_in, vz_start_in, weight_in
-      CHARACTER(256) :: id_string, int_type
+      CHARACTER(256) :: id_string, int_type, a5_marker_name, a5_run_name
 
       ! moved from beams3d_lines
       INTEGER  ::  ns_prof1, ns_prof2, ns_prof3, ns_prof4, ns_prof5, nsh_prof4, nparticles

--- a/LIBSTELL/Sources/Modules/beams3d_input_mod.f90
+++ b/LIBSTELL/Sources/Modules/beams3d_input_mod.f90
@@ -92,7 +92,8 @@
                                mumaterial_tol, mumaterial_niter, &
                                mumaterial_lambda, mumaterial_lamfactor, &
                                mumaterial_lamthresh, mumaterial_padfactor, &
-                               mumaterial_convcheck
+                               mumaterial_convcheck, &
+                               a5_marker_name, a5_run_name
       
 !-----------------------------------------------------------------------
 !     Subroutines
@@ -222,6 +223,10 @@
       mumaterial_lambda = 0.7
       mumaterial_lamfactor = 0.75
       mumaterial_nneighbor = 100
+
+      ! A5 restart stuff
+      a5_marker_name = ''
+      a5_run_name = ''
 
       RETURN
       END SUBROUTINE init_beams3d_input

--- a/LIBSTELL/Sources/Modules/ez_hdf5.f90
+++ b/LIBSTELL/Sources/Modules/ez_hdf5.f90
@@ -1299,6 +1299,55 @@
       
       END SUBROUTINE read_arr6d_hdf5   
       !-----------------------------------------------------------------
+      
+      !-----------------------------------------------------------------
+      SUBROUTINE read_group_attscalar_hdf5(file_id,group,att,ierr,BOOVAR,INTVAR,FLTVAR,DBLVAR,STRVAR)
+      IMPLICIT NONE
+      INTEGER(HID_T), INTENT(in)                :: file_id
+      CHARACTER(LEN=*), INTENT(in)              :: group
+      CHARACTER(LEN=*), INTENT(in)              :: att
+      INTEGER, INTENT(out)                      :: ierr
+      LOGICAL, INTENT(out), OPTIONAL            :: BOOVAR
+      INTEGER, INTENT(out), OPTIONAL            :: INTVAR
+      REAL, INTENT(out), OPTIONAL               :: FLTVAR 
+      DOUBLE PRECISION, INTENT(out), OPTIONAL   :: DBLVAR  
+      CHARACTER(LEN=10), INTENT(out), OPTIONAL :: STRVAR  
+      INTEGER        :: boo_temp
+      INTEGER(HID_T) :: group_id
+      INTEGER(HID_T) :: attr_id  
+      INTEGER(HSIZE_T), DIMENSION(1) :: ddims = (/10/)
+      
+      ierr = 1
+      CALL h5gopen_f(file_id,TRIM(group), group_id,ierr)
+      CALL h5aopen_f(group_id,TRIM(att), attr_id, ierr)
+      IF (ierr /=0) RETURN
+      IF (PRESENT(INTVAR)) THEN
+         INTVAR = 0
+         CALL h5aread_f(attr_id, H5T_NATIVE_INTEGER, INTVAR, ddims, ierr)
+      ELSE IF (PRESENT(FLTVAR)) THEN
+         FLTVAR = 0
+         CALL h5aread_f(attr_id, H5T_NATIVE_REAL, FLTVAR, ddims, ierr)
+      ELSE IF (PRESENT(DBLVAR)) THEN
+         DBLVAR = 0
+         CALL h5aread_f(attr_id, H5T_NATIVE_DOUBLE, DBLVAR, ddims, ierr)
+      ELSE IF (PRESENT(BOOVAR)) THEN
+         boo_temp = 0
+         CALL h5aread_f(attr_id, H5T_NATIVE_INTEGER, boo_temp, ddims, ierr)
+         BOOVAR = .FALSE.
+         IF (boo_temp == 1) BOOVAR = .TRUE.
+      ELSE IF (PRESENT(STRVAR)) THEN
+         STRVAR = ''
+         CALL h5aread_f(attr_id, H5T_C_S1, STRVAR, ddims, ierr)
+      ELSE
+         ierr=-2
+      END IF
+      CALL h5aclose_f(attr_id, ierr)
+      CALL h5gclose_f(group_id, ierr)
+      IF (ierr /=0) RETURN
+
+      END SUBROUTINE read_group_attscalar_hdf5   
+      
+      !-----------------------------------------------------------------
          
 #endif
 !-----------------------------------------------------------------------


### PR DESCRIPTION
This adds the capability to initialize markers from an ASCOT5 run's endstate. It's a bit rough in it's implementation but works.  To invoke the feature, the ascot5 file needs to be passed on the command line:  

```
xbeams3d -vmec MYRUN -ascot_input ascot_RUN.h5
```

In addition the user must provide the appropriate run and marker ids via the BEAMS3D_INPUT namelist:

```fortran
!---------- ASCOT5 file parameters -------
  A5_RUN_NAME = 'run_2017671808'
  A5_MARKER_NAME = 'prt_0835850791'
```

This is because the number of markers is stored in the marker group not in the results group.

It may be better to have the routine directly figure out the number of markers from the variable length instead as the marker `n` variable may not be equal to the actual number of markers in endstate if files were combined.