### PR TITLE
Fix DKES_D31 sign and implement diffusion+advection in transport solver

### DIFF
--- a/THRIFT/Sources/thrift_penta.f90
+++ b/THRIFT/Sources/thrift_penta.f90
@@ -173,7 +173,7 @@
             CALL PENTA_SET_PPROF(ne(k),dnedrho(k)/eq_Aminor,te(k),dtedrho(k)/eq_Aminor,ni(k,:),dnidrho(k,:)/eq_Aminor,ti(k,:),dtidrho(k,:)/eq_Aminor)
             ! MAKE CORRECTIONS ON D31 AND D33 -- values coming from DKES2 miss Bsq factors (see J. Lore documentation)
             CALL PENTA_SET_DKES_STAR(ncstar,nestar,DKES_NUSTAR(1:ncstar),DKES_ERSTAR(1:nestar), &
-               DKES_D11(k,:,:), -DKES_D31(k,:,:)*SQRT(bsq(k)), DKES_D33(k,:,:)*bsq(k))
+               DKES_D11(k,:,:), DKES_D31(k,:,:)*SQRT(bsq(k)), DKES_D33(k,:,:)*bsq(k))
             CALL PENTA_SET_BEAM(0.0_rprec) ! Zero becasue we don't read
             CALL PENTA_SET_U2() ! Leave blank for default value
             CALL PENTA_READ_INPUT_FILES(.FALSE.,.FALSE.,.FALSE.,.FALSE.,.FALSE.)

--- a/pySTEL/libstell/dkes.py
+++ b/pySTEL/libstell/dkes.py
@@ -82,8 +82,18 @@ class DKES:
         self.D31_star = self.L31 * np.sqrt(self.Bsq)
         self.D33_star = self.L33 * self.Bsq
         
-        # We need to take the negative value in order to get, at the end, the correct sign of JBS.B
-        self.D13_star = -self.D31_star
+        # We need to take D13* = +D31* in order to get the correct sign of JBS.B (this has been confirmed by comparing with experiments)
+        # It has also been confirmed by running a tokamak case, where the bootstrap must always run in the same direction as the already
+        # existing ohmic current (assuming that the density and temperature gradients are negative! See Freidberg)
+        # Note that D13_star is used in this class ONLY to create PENTA Dstar input files
+        self.D13_star = self.D31_star
+        
+        # Inside PENTA, D31_star is computed by taking the negative of D13_star, so we should make the same here otherwise when computing
+        # bootstrap with self.get_BS_current() the sign is different from that given by PENTA
+        self.D31_star = -self.D13_star
+        
+        # Compute <U2> as in PENTA: by looking at D11_star at maximum nu/v and minimum Er/v (ideally 0)
+        self.U2 = 1.5 * self.D11_star[self.ncmul-1] / self.cmul[self.ncmul-1]
         
     def check_convergence(self):
     

--- a/pySTEL/libstell/plasma.py
+++ b/pySTEL/libstell/plasma.py
@@ -875,8 +875,36 @@ class PLASMA:
         print(f'AM_AUX_S = {s_VMEC}')
         print(f'AM_AUX_F = {pres}')
         
-        return AM,PRES_SCALE       
+        return AM,PRES_SCALE
+    
+    def get_akima_spline_coefficients(self,num_points=32):
+        """
+        Computes the Pressure Parameters for VMEC assuming PMASS_TYPE='akima_spline'
+        """  
+        AM_AUX_S = np.linspace(0,1,num_points)
+        rho = np.sqrt(AM_AUX_S)
         
+        pressure=0
+        for species in self.list_of_species:
+            
+            n = self.get_density(species,rho)
+            T = self.get_temperature(species,rho) 
+            
+            # total pressure polynomial in Pascal units
+            pressure += n*T*EC
+        
+        def print_array(name, arr, ncol=3):
+            print(f"{name} =")
+            for i in range(0, len(arr), ncol):
+                print("  " + "  ".join(f"{x:.12E}" for x in arr[i:i+ncol]))
+            
+        print("PMASS_TYPE = 'cubic_spline' ")
+        print(f'PRES_SCALE = {1.0:.12E}')
+        print_array("AM_AUX_S", AM_AUX_S, ncol=4)
+        print_array("AM_AUX_F", pressure, ncol=4)
+        
+        return AM_AUX_S, pressure
+            
     def print_SFINCS_list_namelist(self,roa_list,folder_path,wout_file):
         # saves input.namlist inside folder_path/surface_k
         

--- a/pySTEL/libstell/plasma_solver.py
+++ b/pySTEL/libstell/plasma_solver.py
@@ -493,6 +493,27 @@ class PLASMA_SOLVER:
                 self.particle_fluxes_info['type'] = type
                 self.particle_fluxes_info[type]['Dn'] = Dn
                 
+            case 'diffusive_advective':
+                #checks that Dn and cn are provided. Dn and cn can be floats or functions of rho
+                if(Dn is None or cn is None):
+                    raise ValueError('ERROR: Dn and cn must be provided!')
+                # If are functions, check they are 1D functions
+                if( callable(Dn) ):
+                    import inspect
+                    num_args = len(inspect.signature(Dn).parameters)
+                    if( num_args != 1 ):
+                        raise ValueError('ERROR: Dn must be a 1D function of rho')
+                #
+                if( callable(cn) ):
+                    import inspect
+                    num_args = len(inspect.signature(cn).parameters)
+                    if( num_args != 1 ):
+                        raise ValueError('ERROR: cn must be a 1D function of rho')
+                #  
+                self.particle_fluxes_info['type'] = type
+                self.particle_fluxes_info[type]['Dn'] = Dn
+                self.particle_fluxes_info[type]['cn'] = cn
+                
             case 'normalized_Dn_cn_rho_aLn_dependent':
                 if( (Dn is None) or (cn is None) or (mass_ref_species is None)):
                     raise ValueError('ERROR: Dn, cn and mass_ref_species must be given!')
@@ -780,6 +801,8 @@ class PLASMA_SOLVER:
         # Particle flux function
         if ptype == 'diffusive':
             self.particle_flux_func = self.compute_diffusive_particle_flux
+        elif ptype == 'diffusive_advective':
+            self.particle_flux_func = self.compute_diffusive_advective_particle_flux
         elif ptype == 'dkespenta':
             self.particle_flux_func = self.compute_NEO_particle_flux
         elif ptype == 'normalized_Dn_cn_rho_aLn_dependent':
@@ -1312,6 +1335,50 @@ class PLASMA_SOLVER:
                         
             # this is used in heat flux (Q=-n\chi*dT/dr + convective_fact*T*Gamma_turb)
             self.Gamma_turb[species][it,:] = -Dn * dndr
+            
+    def compute_diffusive_advective_particle_flux(self,it):
+        """
+        Computes the coefficient Dn (diffusion) and cn (convection) which are used to fill the LHS_density matrices. 
+        The coefficient is computed such that the particle flux is
+        Gamma = -Dn*dn/dr + cn*n. Dn and cn can be constants or functions of rho
+        """
+        from scipy.interpolate import CubicSpline
+        
+        r_grid = self.r_grid
+        
+        Dn = self.particle_fluxes_info['diffusive_advective']['Dn']
+        cn = self.particle_fluxes_info['diffusive_advective']['cn']
+        
+        if callable(Dn):
+            Dn = Dn(self.rho_grid)
+        elif isinstance(Dn, (float, int)):
+            pass
+        else:
+            raise ValueError('ERROR: Dn can only be a function of rho or an integer/float!')
+        
+        if callable(cn):
+            cn = cn(self.rho_grid)
+        elif isinstance(cn, (float, int)):
+            pass
+        else:
+            raise ValueError('ERROR: cn can only be a function of rho or an integer/float!')
+        
+        for species in self.list_of_species:
+            
+            # n_r = CubicSpline(r_grid,self.N[species][it,:])
+            n_r = self.N[species][it,:]
+            # dndr = n_r.derivative()
+            # dndr = dndr(r_grid)
+            dndr = akima_derivative(r_grid,n_r)
+            
+            self.Dn[species][it,:] = Dn
+            self.cn[species][it,:] = cn
+            
+            # Force cn(rho=0.0) to be 0.0
+            self.cn[species][it,0] = 0.0
+                        
+            # this is used in heat flux (Q=-n\chi*dT/dr + convective_fact*T*Gamma_turb)
+            self.Gamma_turb[species][it,:] = -Dn * dndr + cn * n_r
             
     def compute_normalized_Dn_cn_rho_aLn_dependent_particle_flux(self,it):
         """

--- a/pySTEL/libstell/plasma_solver.py
+++ b/pySTEL/libstell/plasma_solver.py
@@ -445,7 +445,7 @@ class PLASMA_SOLVER:
                 
             case 'beurskens':
                 if( (chi_base is None) or (aLT_critical is None) or (alpha is None) or (stiffness is None) or (chi_electrons is None) or (convective_fact is None) or (mass_ref_species is None)):
-                    raise ValueError('ERROR: chi_base, aLT_critical, alpha, stiffness, chi_electrons, convective_fact and ref_species must be given!')
+                    raise ValueError('ERROR: chi_base, aLT_critical, alpha, stiffness, chi_electrons, convective_fact and mass_ref_species must be given!')
                 self.heat_fluxes_info['type'] = type
                 self.heat_fluxes_info[type]['chi_base'] = chi_base
                 self.heat_fluxes_info[type]['aLT_critical'] = aLT_critical
@@ -469,7 +469,7 @@ class PLASMA_SOLVER:
                 # self.heat_fluxes_info[type]['chi_electrons'] = chi_electrons
                 # self.heat_fluxes_info[type]['convective_fact'] = convective_fact
                 
-    def set_particle_fluxes(self, type: str, surfaces=None,Dn=None):
+    def set_particle_fluxes(self, type: str, surfaces=None, Dn=None, cn=None, mass_ref_species=None):
         """
         Sets particle flux for all species. Currently, only 'diffusive' type is implemented:
         Gamma = -Dn dn/dr with Dn constant and equal to all species
@@ -492,6 +492,26 @@ class PLASMA_SOLVER:
                     raise ValueError('ERROR: Dn must be provided!')
                 self.particle_fluxes_info['type'] = type
                 self.particle_fluxes_info[type]['Dn'] = Dn
+                
+            case 'normalized_Dn_cn_rho_aLn_dependent':
+                if( (Dn is None) or (cn is None) or (mass_ref_species is None)):
+                    raise ValueError('ERROR: Dn, cn and mass_ref_species must be given!')
+                # checks that Dn and cn are 2D function:
+                if( callable(Dn) and callable(cn) ):
+                    import inspect
+                    num_args = len(inspect.signature(Dn).parameters)
+                    if( num_args !=2 ):
+                        raise ValueError('ERROR: Dn must be a function of (rho,aLn)'   )
+                    num_args = len(inspect.signature(cn).parameters)
+                    if( num_args !=2 ):
+                        raise ValueError('ERROR: cn must be a function of (rho,aLn)'   )
+                else:
+                    raise ValueError('ERROR: Dn and cn must be functions of (rho,aLn)'   )
+                #
+                self.particle_fluxes_info['type'] = type
+                self.particle_fluxes_info[type]['Dn'] = Dn
+                self.particle_fluxes_info[type]['cn'] = cn             
+                self.particle_fluxes_info[type]['mass_ref_species'] = mass_ref_species             
                 
     def run(self,Nr,dt,tstart,tend,tolerance=1E-2,max_subiter=12,output_filename=None,restart_filename=None):
         """
@@ -762,6 +782,8 @@ class PLASMA_SOLVER:
             self.particle_flux_func = self.compute_diffusive_particle_flux
         elif ptype == 'dkespenta':
             self.particle_flux_func = self.compute_NEO_particle_flux
+        elif ptype == 'normalized_Dn_cn_rho_aLn_dependent':
+            self.particle_flux_func = self.compute_normalized_Dn_cn_rho_aLn_dependent_particle_flux
         else:
             raise ValueError('Unsupported particle flux type')
 
@@ -1266,11 +1288,9 @@ class PLASMA_SOLVER:
             
     def compute_diffusive_particle_flux(self,it):
         """
-        Computes the coefficients Dn (diffusion) and cn (convection) of
-        each species, which are then used to fill the LHS_density matrices. The
-        coefficients are computed such that the particle flux is
-        Gamma = -Dn*dn/dr + cn*n. This allows for the density to be evolved in time
-        according to LoDestro's method
+        Computes the coefficient Dn (diffusion) which is used to fill the LHS_density matrices. 
+        The coefficient is computed such that the particle flux is
+        Gamma = -Dn*dn/dr. Here we assume that advection is zero and that Dn is a constant
         """
         from scipy.interpolate import CubicSpline
         
@@ -1292,6 +1312,52 @@ class PLASMA_SOLVER:
                         
             # this is used in heat flux (Q=-n\chi*dT/dr + convective_fact*T*Gamma_turb)
             self.Gamma_turb[species][it,:] = -Dn * dndr
+            
+    def compute_normalized_Dn_cn_rho_aLn_dependent_particle_flux(self,it):
+        """
+        Computes the coefficients Dn (diffusion) and cn (convection) of
+        each species. Here Dn and cn are the normalized diffusion coefficient and advection velocity
+        which are functions of rho and a/Ln. The denormalization is:
+        
+        Dn = Dn_normalized * Gamma_gB * a/n_j
+        cn = cn_normalized * Gamma_gB / n_j
+        
+        where Gamma_gB = 2.0*sqrt(2)*n_ref*sqrt(m_ref)*(EC*T_ref)**1.5 / (EC*Bref*aminor)**2
+        
+        The particle flux is then:
+        Gamma = -Dn*dn/dr + cn*n. 
+        This allows for the density to be evolved in time according to LoDestro's method
+        """
+        
+        r_grid = self.r_grid
+        
+        Dn_normalized_func = self.particle_fluxes_info['normalized_Dn_cn_rho_aLn_dependent']['Dn'] # This is a 2D function of (rho,aLn)
+        cn_normalized_func = self.particle_fluxes_info['normalized_Dn_cn_rho_aLn_dependent']['cn'] # This is a 2D function of (rho,aLn)
+        mref = self.particle_fluxes_info['normalized_Dn_cn_rho_aLn_dependent']['mass_ref_species']
+        
+        for species in self.list_of_species:
+            
+            n_r = self.N[species][it,:]
+            dndr = polyfit_derivative_fast(r_grid,n_r,deg=12)
+            # dndr = akima_derivative(r_grid,n_r)
+            
+            a_Ln = - self.aminor * dndr / n_r
+            
+            Dn_normalized = Dn_normalized_func(self.rho_grid, a_Ln)
+            cn_normalized = cn_normalized_func(self.rho_grid, a_Ln)  
+            
+            nref = n_r
+            Tref = self.T[species][it,:]
+            
+            Gamma_gB = 2.0*np.sqrt(2)*nref*np.sqrt(mref)*(EC*Tref)**1.5 / (EC*self.Bref*self.aminor)**2       
+            
+            self.Dn[species][it,:] = Dn_normalized * Gamma_gB * self.aminor / n_r
+            self.cn[species][it,:] = cn_normalized * Gamma_gB / n_r
+            # Force cn(rho=0.0) to be 0.0
+            self.cn[species][it,0] = 0.0
+                        
+            # this is used in heat flux (Q=-n\chi*dT/dr + convective_fact*T*Gamma_turb)
+            self.Gamma_turb[species][it,:] = -self.Dn[species][it,:] * dndr + self.cn[species][it,:] * n_r
             
     def compute_beurskens_heat_flux(self,it):
         """

--- a/pySTEL/libstell/plasma_solver.py
+++ b/pySTEL/libstell/plasma_solver.py
@@ -534,7 +534,7 @@ class PLASMA_SOLVER:
                 self.particle_fluxes_info[type]['cn'] = cn             
                 self.particle_fluxes_info[type]['mass_ref_species'] = mass_ref_species             
                 
-    def run(self,Nr,dt,tstart,tend,tolerance=1E-2,max_subiter=12,output_filename=None,restart_filename=None):
+    def run(self,Nr,dt,tstart,tend,tolerance=1E-2,max_subiter=12,output_filename=None,restart_filename=None,dt_save=0.1):
         """
         Run the transport solver after setting initial profiles, BCs, fluxes types and sources
         If output_filename is not None, then results will be saved in a joblib file
@@ -623,7 +623,7 @@ class PLASMA_SOLVER:
                 subiter += 1
         
         if(output_filename is not None):
-            self.call_save_output(output_filename)  
+            self.call_save_output(output_filename,dt_save)  
             
         end_time = perf_counter()   
         print(f'Plasma Solver took {(end_time-start_time)/60:.2f}min to run.')  
@@ -2121,7 +2121,7 @@ class PLASMA_SOLVER:
     #     merge_and_delete('heatTransportCoeffs_vs_roa_surface*','heatTransportCoeffs_vs_roa')
     #     merge_and_delete('plasma_profiles_check_surface*','plasma_profiles_check')
         
-    def call_save_output(self,output_filename):
+    def call_save_output(self,output_filename,dt_save):
         """Saves simulation in output joblib file"""
         from types import SimpleNamespace
         from pathlib import Path
@@ -2144,8 +2144,8 @@ class PLASMA_SOLVER:
         if hasattr(self,'iota23'):
             saved_class.iota23 = self.iota23
         
-        # only save at minimum every dt=0.1s 
-        freq = max(1, round(0.1 / self.dt))
+        # only save at minimum every dt=dt_save
+        freq = max(1, round(dt_save / self.dt))
         sl = slice(0, None, freq)  # defines the slice once
 
         saved_class.time = self.time[sl]

--- a/pySTEL/libstell/plasma_solver.py
+++ b/pySTEL/libstell/plasma_solver.py
@@ -1132,7 +1132,7 @@ class PLASMA_SOLVER:
                     control = np.clip(control,0,N_IN_max)
                     # If clipped, then set previous integral to zero (anti wind-up)
                     if np.isclose(control,0) or np.isclose(control,N_IN_max):
-                        self.particle_sources[species]['PID_edense_gaussian']['pid_I'] = 0.0                  
+                        self.particle_sources[species]['PID_pfuse_gaussian']['pid_I'] = 0.0                  
                     # Compute integrand
                     integrand = np.exp(-(rho_grid-rho_0)**2/sigma_rho**2) * self.dVdr(rho_grid)
                     integrand = integrand.flatten()


### PR DESCRIPTION
With this merge:
- We fix the sign of DKES_D31. After comparing `JBS\cdot B>` with a W7-X discharge and with a tokamak case, I am now certain that this is the correct way to use this coefficient;
- The `pySTEL` transport solver can now run with rho- and a/Ln-dependent particle diffusion and advection coefficients. This allows to use data from `stella` to model the particle transport.
