### PR TITLE
Update fieldlines_input_mod.f90

### DIFF
--- a/LIBSTELL/Sources/Modules/fieldlines_input_mod.f90
+++ b/LIBSTELL/Sources/Modules/fieldlines_input_mod.f90
@@ -64,6 +64,7 @@
                                   r_hc, phi_hc, z_hc, num_hcp, delta_hc,&
                                   errorfield_amp,errorfield_phase, &
                                   mumaterial_tol, mumaterial_niter, &
+                                  mumaterial_nneighbor, &
                                   mumaterial_lambda, mumaterial_lamfactor, &
                                   mumaterial_lamthresh, mumaterial_padfactor, &
                                   mumaterial_convcheck


### PR DESCRIPTION
There was a field missing in the fieldlines_input namelist, causing the following error:

Invalid line in namelist:   MUMATERIAL_NNEIGHBOR = 100
ERROR reading namelist FIELDLINES_INPUT from file:

The field was written to the input file, but did not exist in the namelist. Adding the mumaterial_nneighbor variable to the namelist should solve the issue.