### PR TITLE
Increased floating point precision in mgrid array initialisation

### DIFF
--- a/FIELDLINES/Sources/fieldlines_init_mgrid.f90
+++ b/FIELDLINES/Sources/fieldlines_init_mgrid.f90
@@ -108,8 +108,8 @@
          DO s = mystart, myend
             i = MOD(s-1,nr)+1
             j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = FLOOR(REAL(j, rprec) / REAL(nr, rprec)) + 1
+            k = CEILING(REAL(s, rprec) / REAL(nr*nphi, rprec))
             CALL mgrid_bcyl(raxis(i), phiaxis(j), zaxis(k), &
                             br, bphi, bz, ier)
             IF (ier /= 0) stop 'mgrid_bcyl error!'


### PR DESCRIPTION
This is a simple change to avoid bugs when single point precision is exceeded in high resolution grid runs. The bug was identified when performing convergence tests of xfieldlines with grid resolution.