### PR TITLE
THRIFT Improvements

### DIFF
--- a/PENTA/Sources/penta_interface_mod.f90
+++ b/PENTA/Sources/penta_interface_mod.f90
@@ -1020,9 +1020,11 @@ MODULE PENTA_INTERFACE_MOD
          Gamma_i_vs_Er(ie,:) = Gammas(2:num_species)
 
          ! Write fluxes vs Er
-         Write(str_num,*) num_ion_species + 2  ! Convert num to string
-         Write(iu_fvEr_out,'(f7.4,' // trim(adjustl(str_num)) // '(" ",e15.7))') &
-            roa_surf,Er_test/100._rknd,Gamma_e_vs_Er(ie),Gamma_i_vs_Er(ie,:)
+         IF(save_fluxes_vs_Er) THEN
+            Write(str_num,*) num_ion_species + 2  ! Convert num to string
+            Write(iu_fvEr_out,'(f7.4,' // trim(adjustl(str_num)) // '(" ",e15.7))') &
+               roa_surf,Er_test/100._rknd,Gamma_e_vs_Er(ie),Gamma_i_vs_Er(ie,:)
+         END IF
 
          ! If ( output_QoT_vs_Er .EQV. .true. ) Then
          !    QoT_e_vs_Er(ie)   = QoTs(1)

--- a/PENTA/Sources/penta_interface_mod.f90
+++ b/PENTA/Sources/penta_interface_mod.f90
@@ -1431,9 +1431,9 @@ MODULE PENTA_INTERFACE_MOD
 
       IMPLICIT NONE
 
-      INTEGER(iknd) :: i, j, idx_ion_root, idx_electron_root, one, zero, idx_closest_to_zero
+      INTEGER(iknd) :: i, j, idx_ion_root, idx_electron_root, one, zero, idx_closest_to_zero, selected_idx
       REAL(rknd), DIMENSION(num_Er_test) :: Jr
-      REAL(rknd) :: temp_sum, electron_root, ion_root, integral, Er_closest_to_zero
+      REAL(rknd) :: temp_sum, electron_root, ion_root, integral, Er_closest_to_zero, best_neg
       LOGICAL :: cond_A, cond_B
 
       ! DEPRECATED: Maxwell construction criterium
@@ -1444,6 +1444,10 @@ MODULE PENTA_INTERFACE_MOD
       !    End Do
       !    Jr(i) = temp_sum - Gamma_e_vs_Er(i)
       ! End Do
+
+      IF( mod(num_roots,2) == 0) THEN
+         STOP 'ERROR: an even number of roots was found. This is non-physical...'
+      END IF
 
       IF(ALLOCATED(root_type)) DEALLOCATE(root_type)
       ALLOCATE(root_type(num_roots))
@@ -1489,6 +1493,35 @@ MODULE PENTA_INTERFACE_MOD
             root_type(1) = .TRUE. !possibility_2
          END IF
 
+      ELSE IF(num_roots>5) THEN
+         ! Use criterium: 
+         ! The ion_root can only be root idx 1,3,5,...,num_roots-2
+         ! Out of these entries, we pick the one where Er<0 and that is closest to Er=0; 
+         ! if out of the candidates there are no negative Er, then pick the positive one closest to Er=0.
+
+         selected_idx = -1
+         best_neg = -huge(1.0_rknd)
+
+         ! Loop over allowed indices: 1,3,5,...,num_roots-2
+         ! Note that Er_roots is already sorted
+         DO i = 1, num_roots-2, 2
+            IF (Er_roots(i) < 0.0) THEN
+               ! Keep the negative closest to zero
+               IF (Er_roots(i) > best_neg) THEN
+                  best_neg = Er_roots(i)
+                  selected_idx = i
+               END IF
+            END IF
+         END DO
+         
+         ! If no idx was selected is because all possible ion roots are positive... then choose smallest positive
+         IF (selected_idx < 0) THEN
+            selected_idx = 1
+         END IF
+
+         root_type(selected_idx) = .TRUE.
+
+
          ! ! DEPRECATED: Maxwell construction criterium
          ! electron_root = MAXVAL(Er_roots(1:num_roots),1)
          ! ion_root = MINVAL(Er_roots(1:num_roots),1)
@@ -1505,7 +1538,7 @@ MODULE PENTA_INTERFACE_MOD
          ! ENDIF
 
       ELSE
-         STOP 'ERROR: number of roots different than 1,3 or 5... how is it possible??'
+         STOP 'ERROR: number of roots different than 1,3,5,7,etc how is it possible??'
       END IF
 
 

--- a/PENTA/Sources/penta_subroutines.f90
+++ b/PENTA/Sources/penta_subroutines.f90
@@ -101,15 +101,19 @@ EndDo
 If ( num_roots == 0_iknd ) Then
   Write(*,*) 'No roots found in search range'
   If (Present(flag_roots)) Then
-    flag_roots=1
-    !Stop 'Error from find_Er_roots: Please modify the Er search range'
+    flag_roots=1 ! Need to increase Er-search range
     Return
   Else
     Stop 'Error from find_Er_roots: Please modify the Er search range'
   EndIf
 ElseIf ( Mod(num_roots,2_iknd) == 0_iknd) Then
-  Write(*,*) 'Even number of roots found, choosing first root only.'
-  num_roots = 1_iknd
+  If (Present(flag_roots)) Then
+    flag_roots=1 ! Need to increase Er-search range
+    Return
+  Else
+    Write(*,*) 'Even number of roots found, choosing first root only.'
+    num_roots = 1_iknd
+  EndIf
 Endif
 
 ! Allocate variables by number of roots

--- a/THRIFT/Sources/thrift_bootsj.f90
+++ b/THRIFT/Sources/thrift_bootsj.f90
@@ -455,14 +455,20 @@
                CALL EZspline_setup(dIds_spl,dIds_temp,ier,EXACT_DIM=.true.)
                DEALLOCATE(dIds_temp,rho_temp)
 
-               ! Calculate J in s space = dI/ds * 1/(pi*a^2)
-               DO i = 1, nsj
-                  s_val = THRIFT_S(i)
-               !   rho_val = SQRT(s_val)
-               !   CALL EZspline_interp(dIds_spl,rho_val,temp,ier)
-                  CALL EZspline_interp(dIds_spl,s_val,temp,ier)
-                  THRIFT_JBOOT(i,mytimestep) = temp/(pi2/2*eq_Aminor**2) ! for some reason 'pi' is an ambigious reference
-               END DO
+               ! Calculate JBOOT := <J_BS.b> = [ <B^2>/<B> ] * (1/phi_edge) * dIds
+               CALL EZspline_interp(dIds_spl,nsj,THRIFT_S,THRIFT_JBOOT(:,mytimestep),ier)
+               THRIFT_JBOOT(:,mytimestep) = THRIFT_JBOOT(:,mytimestep)*(THRIFT_BSQAV(:,mytimestep)/THRIFT_BAV(:,mytimestep))/THRIFT_PHIEDGE(mytimestep)
+
+
+               ! ! Calculate J in s space = dI/ds * 1/(pi*a^2)
+               ! DO i = 1, nsj
+               !    s_val = THRIFT_S(i)
+               ! !   rho_val = SQRT(s_val)
+               ! !   CALL EZspline_interp(dIds_spl,rho_val,temp,ier)
+               !    CALL EZspline_interp(dIds_spl,s_val,temp,ier)
+               !    THRIFT_JBOOT(i,mytimestep) = temp/(pi2/2*eq_Aminor**2) ! for some reason 'pi' is an ambigious reference
+               ! END DO
+
                CALL EZspline_free(dIds_spl,ier)
 
             END IF

--- a/THRIFT/Sources/thrift_penta.f90
+++ b/THRIFT/Sources/thrift_penta.f90
@@ -19,7 +19,7 @@
       USE mpi_inc
       USE thrift_plasma_solver_mod, ONLY: Dn_NEO,cn_NEO,Dp_NEO,cp_NEO,&
       rho_plasma_grid,Nr_plasma_solver,mytimestep_plasma_solver,&
-      G_NEO_complet,Q_NEO_complet,Nt_total_plasma_solver
+      G_NEO_complet,Q_NEO_complet,Nt_total_plasma_solver,look_for_ambipolar
 !-----------------------------------------------------------------------
 !     Subroutine Parameters
 !        lscreen       Screen output
@@ -32,7 +32,7 @@
 !     Local Variables
 !-----------------------------------------------------------------------
       INTEGER :: ns_dkes, k, ier, j, i, ncstar, nestar, mystart, myend, &
-                 mysurf, root_max_Er, jspecies
+                 mysurf, root_max_Er, jspecies, irho
       REAL(rprec) :: s, rho, mytime
       REAL(rprec), DIMENSION(:), ALLOCATABLE :: rho_k, iota, phip, chip, btheta, bzeta, bsq, vp, &
                         te, ne, dtedrho, dnedrho, EparB, JBS_PENTA, etapar_PENTA, Er_PENTA, rho_temp, J_temp, eta_temp, Er_temp
@@ -76,7 +76,6 @@
          Dp_PENTA = 0.0; cp_PENTA = 0.0
 
          IF (myworkid == master) THEN
-
             mytime = THRIFT_T(mytimestep)
             
             ! EparB Spline
@@ -132,7 +131,8 @@
                   CALL EZSpline_interp(EparB_spl, rho, EparB(k), ier)
             END DO
             CALL EZspline_free(EparB_spl,ier)
-         END IF
+            
+      END IF
          
 #if defined(MPI_OPT)
          CALL MPI_BCAST(rho_k,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
@@ -157,6 +157,9 @@
          ! THRIFT quantities
          CALL MPI_BCAST(mytime,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
          CALL MPI_BCAST(mytimestep,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+         ! Plasma solver quantities
+         CALL MPI_BCAST(look_for_ambipolar,1,MPI_LOGICAL,master,MPI_COMM_MYWORLD,ierr_mpi)
+         CALL MPI_BCAST(mytimestep_plasma_solver,1,MPI_INTEGER,master,MPI_COMM_MYWORLD,ierr_mpi)
          
 #endif
       
@@ -180,20 +183,35 @@
             CALL PENTA_SCREEN_INFO
             CALL PENTA_ALLOCATE_DKESCOEFF
             CALL PENTA_FIT_DXX_COEF
+            CALL PENTA_FIT_RAD_TRANS
 
             WRITE(temp_str,'(i4.4)') k
             WRITE(temp1_str,'(i3.3)') mytimestep
             CALL PENTA_OPEN_OUTPUT(TRIM(temp1_str) // '_k' // TRIM(temp_str))
-            CALL PENTA_FIT_RAD_TRANS
+            CALL second0(et)
             ! Now the basic steps
-            CALL PENTA_RUN_2_EFIELD
-            CALL PENTA_RUN_3_FIND_ROOTS
+            
+            
+            
+            IF(solve_plasma_equations .AND. .NOT. look_for_ambipolar) THEN
+                  ! Get Er value from THRIFT
+                  irho =  MINLOC(ABS(SQRT(THRIFT_S) - rho_k(k)), dim=1)
+                  ! Need to define num_roots and set Er_roots
+                  num_roots = 1
+                  Er_roots(1) = THRIFT_ER(irho,mytimestep)
+                  fix_Er_time = fix_Er_time + (et-st)
+            ELSE
+                  ! Now the basic steps
+                  CALL PENTA_RUN_2_EFIELD
+                  CALL PENTA_RUN_3_FIND_ROOTS
+            END IF
             CALL PENTA_RUN_4_AMBIPOLAR
           
             ! The call to ROOT_ANALYSIS sets the array 'root_type' which decides which root to pick
-            ! The criterium is to pick the 'ion_root' whenever there are 3 or 5 roots
-            ! If num_roots = even or num_roots > 5, the code gives an error
+            ! The criterium is to pick the 'ion_root'
+            CALL second0(st)
             CALL ROOT_ANALYSIS
+
             ! Using root_type, pick the ambipolar root that will be saved by THRIFT
             DO i=1,num_roots
                   IF(root_type(i)) THEN
@@ -253,167 +271,195 @@
          
          IF (myworkid == master) THEN
 
-            IF(save_all_ambipolar_roots) CALL PENTA_MERGE_AMBIPOLAR_FILES(ns_dkes,temp1_str,mytime)
-            IF(save_fluxes_vs_Er) CALL PENTA_MERGE_FLUXES_VS_ER_FILES(ns_dkes,temp1_str,mytime)
+            IF(look_for_ambipolar) THEN
+                  IF(save_all_ambipolar_roots) CALL PENTA_MERGE_AMBIPOLAR_FILES(ns_dkes,temp1_str,mytime)
+                  IF(save_fluxes_vs_Er) CALL PENTA_MERGE_FLUXES_VS_ER_FILES(ns_dkes,temp1_str,mytime)
 
-            ! Interpolate JBS_PENTA, etapar_PENTA and Er_PENTA at rho=0 and rho=1
-            ALLOCATE(J_temp(ns_dkes+2),eta_temp(ns_dkes+2),Er_temp(ns_dkes+2),rho_temp(ns_dkes+2))
-            ALLOCATE(GNEO_temp(nion_prof+1,ns_dkes+2),QNEO_temp(nion_prof+1,ns_dkes+2))
-            rho_temp(1)        = 0.0
-            rho_temp(2:ns_dkes+1) = rho_k
-            rho_temp(ns_dkes+2)   = 1.0
-            !
-            J_temp(2:ns_dkes+1)   = JBS_PENTA
-            J_temp(1)             = J_temp(2) - (J_temp(3)-J_temp(2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
-            J_temp(ns_dkes+2)     = JBS_PENTA(ns_dkes-1) + (JBS_PENTA(ns_dkes)-JBS_PENTA(ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-            !
-            eta_temp(2:ns_dkes+1)   = etapar_PENTA
-            eta_temp(1)             = eta_temp(2) - (eta_temp(3)-eta_temp(2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
-            eta_temp(ns_dkes+2)     = etapar_PENTA(ns_dkes-1) + (etapar_PENTA(ns_dkes)-etapar_PENTA(ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-            !
-            Er_temp(2:ns_dkes+1)   = Er_PENTA
-            Er_temp(1)             = Er_temp(2) - (Er_temp(3)-Er_temp(2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
-            Er_temp(ns_dkes+2)     = Er_PENTA(ns_dkes-1) + (Er_PENTA(ns_dkes)-Er_PENTA(ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-            !
-            GNEO_temp(:,2:ns_dkes+1) = GNEO_PENTA
-            GNEO_temp(:,1)           = GNEO_temp(:,2) - (GNEO_temp(:,3)-GNEO_temp(:,2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
-            GNEO_temp(:,ns_dkes+2)   = GNEO_PENTA(:,ns_dkes-1) + (GNEO_PENTA(:,ns_dkes)-GNEO_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-            !
-            QNEO_temp(:,2:ns_dkes+1) = QNEO_PENTA
-            QNEO_temp(:,1)           = QNEO_temp(:,2) - (QNEO_temp(:,3)-QNEO_temp(:,2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
-            QNEO_temp(:,ns_dkes+2)   = QNEO_PENTA(:,ns_dkes-1) + (QNEO_PENTA(:,ns_dkes)-QNEO_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                  ! Interpolate JBS_PENTA, etapar_PENTA and Er_PENTA at rho=0 and rho=1
+                  ALLOCATE(J_temp(ns_dkes+2),eta_temp(ns_dkes+2),Er_temp(ns_dkes+2),rho_temp(ns_dkes+2))
+                  ALLOCATE(GNEO_temp(nion_prof+1,ns_dkes+2),QNEO_temp(nion_prof+1,ns_dkes+2))
+                  rho_temp(1)        = 0.0
+                  rho_temp(2:ns_dkes+1) = rho_k
+                  rho_temp(ns_dkes+2)   = 1.0
+                  !
+                  J_temp(2:ns_dkes+1)   = JBS_PENTA
+                  J_temp(1)             = J_temp(2) - (J_temp(3)-J_temp(2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
+                  J_temp(ns_dkes+2)     = JBS_PENTA(ns_dkes-1) + (JBS_PENTA(ns_dkes)-JBS_PENTA(ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                  !
+                  eta_temp(2:ns_dkes+1)   = etapar_PENTA
+                  eta_temp(1)             = eta_temp(2) - (eta_temp(3)-eta_temp(2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
+                  eta_temp(ns_dkes+2)     = etapar_PENTA(ns_dkes-1) + (etapar_PENTA(ns_dkes)-etapar_PENTA(ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                  !
+                  Er_temp(2:ns_dkes+1)   = Er_PENTA
+                  Er_temp(1)             = Er_temp(2) - (Er_temp(3)-Er_temp(2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
+                  Er_temp(ns_dkes+2)     = Er_PENTA(ns_dkes-1) + (Er_PENTA(ns_dkes)-Er_PENTA(ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                  !
+                  GNEO_temp(:,2:ns_dkes+1) = GNEO_PENTA
+                  GNEO_temp(:,1)           = GNEO_temp(:,2) - (GNEO_temp(:,3)-GNEO_temp(:,2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
+                  GNEO_temp(:,ns_dkes+2)   = GNEO_PENTA(:,ns_dkes-1) + (GNEO_PENTA(:,ns_dkes)-GNEO_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                  !
+                  QNEO_temp(:,2:ns_dkes+1) = QNEO_PENTA
+                  QNEO_temp(:,1)           = QNEO_temp(:,2) - (QNEO_temp(:,3)-QNEO_temp(:,2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
+                  QNEO_temp(:,ns_dkes+2)   = QNEO_PENTA(:,ns_dkes-1) + (QNEO_PENTA(:,ns_dkes)-QNEO_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
 
-            ! Splines
-            bcs0=(/ 0, 0/)
-            !JBS
-            CALL EZspline_init(J_spl,ns_dkes+2,bcs0,ier)
-            J_spl%x1        = rho_temp
-            J_spl%isHermite = 1
-            CALL EZspline_setup(J_spl,J_temp,ier,EXACT_DIM=.true.)
-            !etapar (make spline of log since etapar usually spans over orders of magnitude)
-            CALL EZspline_init(eta_spl,ns_dkes+2,bcs0,ier)
-            eta_spl%x1        = rho_temp
-            eta_spl%isHermite = 0
-            ! set eta_temp to very small number if negative
-            WHERE (eta_temp .LE. 0.0_rprec) eta_temp = 1.0E-20_rprec
-            !
-            CALL EZspline_setup(eta_spl,LOG(eta_temp),ier,EXACT_DIM=.true.)
-            !Er
-            CALL EZspline_init(Er_spl,ns_dkes+2,bcs0,ier)
-            Er_spl%x1        = rho_temp
-            Er_spl%isHermite = 1
-            CALL EZspline_setup(Er_spl,Er_temp,ier,EXACT_DIM=.true.)
-            !
-            DEALLOCATE(J_temp,eta_temp,Er_temp)
+                  ! Splines
+                  bcs0=(/ 0, 0/)
+                  !JBS
+                  CALL EZspline_init(J_spl,ns_dkes+2,bcs0,ier)
+                  J_spl%x1        = rho_temp
+                  J_spl%isHermite = 1
+                  CALL EZspline_setup(J_spl,J_temp,ier,EXACT_DIM=.true.)
+                  !etapar (make spline of log since etapar usually spans over orders of magnitude)
+                  CALL EZspline_init(eta_spl,ns_dkes+2,bcs0,ier)
+                  eta_spl%x1        = rho_temp
+                  eta_spl%isHermite = 0
+                  ! set eta_temp to very small number if negative
+                  WHERE (eta_temp .LE. 0.0_rprec) eta_temp = 1.0E-20_rprec
+                  !
+                  CALL EZspline_setup(eta_spl,LOG(eta_temp),ier,EXACT_DIM=.true.)
+                  !Er
+                  CALL EZspline_init(Er_spl,ns_dkes+2,bcs0,ier)
+                  Er_spl%x1        = rho_temp
+                  Er_spl%isHermite = 1
+                  CALL EZspline_setup(Er_spl,Er_temp,ier,EXACT_DIM=.true.)
+                  !
+                  DEALLOCATE(J_temp,eta_temp,Er_temp)
 
-            ! Calculate J_BS, etapara and Er in THRFIT GRID
-            CALL EZspline_interp(J_spl,nsj,SQRT(THRIFT_S),THRIFT_JBOOT(:,mytimestep),ier)
-            CALL EZspline_interp(Er_spl,nsj,SQRT(THRIFT_S),THRIFT_ER(:,mytimestep),ier)
-            IF( etapar_type == 'dkespenta') THEN
-                  CALL EZspline_interp(eta_spl,nsj,SQRT(THRIFT_S),THRIFT_ETAPARA(:,mytimestep),ier)
-                  ! Need to take the exponential, since spline of log was done
-                  THRIFT_ETAPARA(:,mytimestep) = EXP(THRIFT_ETAPARA(:,mytimestep))
-            END IF
-
-            CALL EZspline_free(J_spl,ier)
-            CALL EZspline_free(eta_spl,ier)
-            CALL EZspline_free(Er_spl,ier)
-
-            ! Spline of GNEO and QNEO; computation at THRIFT GRID
-            DO jspecies=1,(nion_prof+1)
-                  !GNEO
-                  CALL EZspline_init(GNEO_spl,ns_dkes+2,bcs0,ier)
-                  GNEO_spl%x1        = rho_temp
-                  GNEO_spl%isHermite = 1
-                  CALL EZspline_setup(GNEO_spl,GNEO_temp(jspecies,:),ier,EXACT_DIM=.true.)
-                  !QNEO
-                  CALL EZspline_init(QNEO_spl,ns_dkes+2,bcs0,ier)
-                  QNEO_spl%x1        = rho_temp
-                  QNEO_spl%isHermite = 1
-                  CALL EZspline_setup(QNEO_spl,QNEO_temp(jspecies,:),ier,EXACT_DIM=.true.)
-                  
-                  ! Compute at THRIFT GRID
-                  CALL EZspline_interp(GNEO_spl,nsj,SQRT(THRIFT_S),THRIFT_GNEO(jspecies,:,mytimestep),ier)
-                  CALL EZspline_interp(QNEO_spl,nsj,SQRT(THRIFT_S),THRIFT_QNEO(jspecies,:,mytimestep),ier)
-
-                  ! Save GNE0_complet and QNEO_complet at plasma solver grid
-                  IF(solve_plasma_equations) THEN
-                        CALL EZspline_interp(GNEO_spl,Nr_plasma_solver,rho_plasma_grid,G_NEO_complet(jspecies,mytimestep_plasma_solver,:),ier)
-                        CALL EZspline_interp(QNEO_spl,Nr_plasma_solver,rho_plasma_grid,Q_NEO_complet(jspecies,mytimestep_plasma_solver,:),ier)
+                  ! Calculate J_BS, etapara and Er in THRFIT GRID
+                  CALL EZspline_interp(J_spl,nsj,SQRT(THRIFT_S),THRIFT_JBOOT(:,mytimestep),ier)
+                  CALL EZspline_interp(Er_spl,nsj,SQRT(THRIFT_S),THRIFT_ER(:,mytimestep),ier)
+                  IF( etapar_type == 'dkespenta') THEN
+                        CALL EZspline_interp(eta_spl,nsj,SQRT(THRIFT_S),THRIFT_ETAPARA(:,mytimestep),ier)
+                        ! Need to take the exponential, since spline of log was done
+                        THRIFT_ETAPARA(:,mytimestep) = EXP(THRIFT_ETAPARA(:,mytimestep))
                   END IF
 
-                  ! Deallocate splines
-                  CALL EZspline_free(GNEO_spl,ier)
-                  CALL EZspline_free(QNEO_spl,ier)
-            END DO
+                  CALL EZspline_free(J_spl,ier)
+                  CALL EZspline_free(eta_spl,ier)
+                  CALL EZspline_free(Er_spl,ier)
 
-            ! Compute NEO coefficients in plasma grid if transport equations being solved
-            IF(solve_plasma_equations) THEN
-                  ! Interpolate JBS_PENTA, etapar_PENTA and Er_PENTA at rho=0 and rho=1
-                  ALLOCATE(Dn_temp(nion_prof+1,ns_dkes+2),cn_temp(nion_prof+1,ns_dkes+2))
-                  ALLOCATE(Dp_temp(nion_prof+1,ns_dkes+2),cp_temp(nion_prof+1,ns_dkes+2))
-                  !
-                  Dn_temp(:,2:ns_dkes+1)   = Dn_PENTA
-                  Dn_temp(:,1)             = 0.0_rprec
-                  Dn_temp(:,ns_dkes+2)     = Dn_PENTA(:,ns_dkes-1) + (Dn_PENTA(:,ns_dkes)-Dn_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-                  !
-                  cn_temp(:,2:ns_dkes+1)   = cn_PENTA
-                  cn_temp(:,1)             = 0.0_rprec
-                  cn_temp(:,ns_dkes+2)     = cn_PENTA(:,ns_dkes-1) + (cn_PENTA(:,ns_dkes)-cn_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-                  !
-                  Dp_temp(:,2:ns_dkes+1)   = Dp_PENTA
-                  Dp_temp(:,1)             = 0.0_rprec
-                  Dp_temp(:,ns_dkes+2)     = Dp_PENTA(:,ns_dkes-1) + (Dp_PENTA(:,ns_dkes)-Dp_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-                  !
-                  cp_temp(:,2:ns_dkes+1)   = cp_PENTA
-                  cp_temp(:,1)             = 0.0_rprec
-                  cp_temp(:,ns_dkes+2)     = cp_PENTA(:,ns_dkes-1) + (cp_PENTA(:,ns_dkes)-cp_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-                  !
-                  ! Spline of Dn,cn,Dp,cp; computation at plasma grid
+                  ! Spline of GNEO and QNEO; computation at THRIFT GRID
                   DO jspecies=1,(nion_prof+1)
-                        !Dn
-                        CALL EZspline_init(Dn_spl,ns_dkes+2,bcs0,ier)
-                        Dn_spl%x1        = rho_temp
-                        Dn_spl%isHermite = 1
-                        CALL EZspline_setup(Dn_spl,Dn_temp(jspecies,:),ier,EXACT_DIM=.true.)
-                        !cn
-                        CALL EZspline_init(cn_spl,ns_dkes+2,bcs0,ier)
-                        cn_spl%x1        = rho_temp
-                        cn_spl%isHermite = 1
-                        CALL EZspline_setup(cn_spl,cn_temp(jspecies,:),ier,EXACT_DIM=.true.)
-                        !Dp
-                        CALL EZspline_init(Dp_spl,ns_dkes+2,bcs0,ier)
-                        Dp_spl%x1        = rho_temp
-                        Dp_spl%isHermite = 1
-                        CALL EZspline_setup(Dp_spl,Dp_temp(jspecies,:),ier,EXACT_DIM=.true.)
-                        !cp
-                        CALL EZspline_init(cp_spl,ns_dkes+2,bcs0,ier)
-                        cp_spl%x1        = rho_temp
-                        cp_spl%isHermite = 1
-                        CALL EZspline_setup(cp_spl,cp_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                        !GNEO
+                        CALL EZspline_init(GNEO_spl,ns_dkes+2,bcs0,ier)
+                        GNEO_spl%x1        = rho_temp
+                        GNEO_spl%isHermite = 1
+                        CALL EZspline_setup(GNEO_spl,GNEO_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                        !QNEO
+                        CALL EZspline_init(QNEO_spl,ns_dkes+2,bcs0,ier)
+                        QNEO_spl%x1        = rho_temp
+                        QNEO_spl%isHermite = 1
+                        CALL EZspline_setup(QNEO_spl,QNEO_temp(jspecies,:),ier,EXACT_DIM=.true.)
                         
-                        ! Compute at plasma solver grid
-                        CALL EZspline_interp(Dn_spl,Nr_plasma_solver,rho_plasma_grid,Dn_NEO(jspecies,mytimestep_plasma_solver,:),ier)
-                        CALL EZspline_interp(cn_spl,Nr_plasma_solver,rho_plasma_grid,cn_NEO(jspecies,mytimestep_plasma_solver,:),ier)
-                        CALL EZspline_interp(Dp_spl,Nr_plasma_solver,rho_plasma_grid,Dp_NEO(jspecies,mytimestep_plasma_solver,:),ier)
-                        CALL EZspline_interp(cp_spl,Nr_plasma_solver,rho_plasma_grid,cp_NEO(jspecies,mytimestep_plasma_solver,:),ier)
+                        ! Compute at THRIFT GRID
+                        CALL EZspline_interp(GNEO_spl,nsj,SQRT(THRIFT_S),THRIFT_GNEO(jspecies,:,mytimestep),ier)
+                        CALL EZspline_interp(QNEO_spl,nsj,SQRT(THRIFT_S),THRIFT_QNEO(jspecies,:,mytimestep),ier)
 
                         ! Deallocate splines
-                        CALL EZspline_free(Dn_spl,ier)
-                        CALL EZspline_free(cn_spl,ier)
-                        CALL EZspline_free(Dp_spl,ier)
-                        CALL EZspline_free(cp_spl,ier)
+                        CALL EZspline_free(GNEO_spl,ier)
+                        CALL EZspline_free(QNEO_spl,ier)
                   END DO
-                  !
-                  DEALLOCATE(Dn_temp,cn_temp,Dp_temp,cp_temp)
+                  DEALLOCATE(rho_temp,GNEO_temp,QNEO_temp)
             END IF
 
-            DEALLOCATE(GNEO_temp,QNEO_temp,rho_temp)
-            DEALLOCATE(rho_k,iota,phip,chip,btheta,bzeta,bsq,vp,EparB)
-            DEALLOCATE(te,ne,dtedrho,dnedrho)
-            DEALLOCATE(ni,ti,dtidrho,dnidrho)
-            DEALLOCATE(JBS_PENTA,etapar_PENTA,Er_PENTA,GNEO_PENTA,QNEO_PENTA)
-            DEALLOCATE(Dn_PENTA,cn_PENTA,Dp_PENTA,cp_PENTA)
+            CALL second0(st)
+            IF( .NOT. look_for_ambipolar) THEN
+                  ! Compute NEO coefficients in plasma grid if transport equations being solved
+                  IF(solve_plasma_equations) THEN
+                        ! Interpolate JBS_PENTA, etapar_PENTA and Er_PENTA at rho=0 and rho=1
+                        ALLOCATE(rho_temp(ns_dkes+2))
+                        ALLOCATE(Dn_temp(nion_prof+1,ns_dkes+2),cn_temp(nion_prof+1,ns_dkes+2))
+                        ALLOCATE(Dp_temp(nion_prof+1,ns_dkes+2),cp_temp(nion_prof+1,ns_dkes+2))
+                        ALLOCATE(GNEO_temp(nion_prof+1,ns_dkes+2),QNEO_temp(nion_prof+1,ns_dkes+2))
+                        !
+                        rho_temp(1)        = 0.0
+                        rho_temp(2:ns_dkes+1) = rho_k
+                        rho_temp(ns_dkes+2)   = 1.0
+                        !
+                        Dn_temp(:,2:ns_dkes+1)   = Dn_PENTA
+                        Dn_temp(:,1)             = 0.0_rprec
+                        Dn_temp(:,ns_dkes+2)     = Dn_PENTA(:,ns_dkes-1) + (Dn_PENTA(:,ns_dkes)-Dn_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                        !
+                        cn_temp(:,2:ns_dkes+1)   = cn_PENTA
+                        cn_temp(:,1)             = 0.0_rprec
+                        cn_temp(:,ns_dkes+2)     = cn_PENTA(:,ns_dkes-1) + (cn_PENTA(:,ns_dkes)-cn_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                        !
+                        Dp_temp(:,2:ns_dkes+1)   = Dp_PENTA
+                        Dp_temp(:,1)             = 0.0_rprec
+                        Dp_temp(:,ns_dkes+2)     = Dp_PENTA(:,ns_dkes-1) + (Dp_PENTA(:,ns_dkes)-Dp_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                        !
+                        cp_temp(:,2:ns_dkes+1)   = cp_PENTA
+                        cp_temp(:,1)             = 0.0_rprec
+                        cp_temp(:,ns_dkes+2)     = cp_PENTA(:,ns_dkes-1) + (cp_PENTA(:,ns_dkes)-cp_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                        !
+                        GNEO_temp(:,2:ns_dkes+1) = GNEO_PENTA
+                        GNEO_temp(:,1)           = GNEO_temp(:,2) - (GNEO_temp(:,3)-GNEO_temp(:,2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
+                        GNEO_temp(:,ns_dkes+2)   = GNEO_PENTA(:,ns_dkes-1) + (GNEO_PENTA(:,ns_dkes)-GNEO_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                        !
+                        QNEO_temp(:,2:ns_dkes+1) = QNEO_PENTA
+                        QNEO_temp(:,1)           = QNEO_temp(:,2) - (QNEO_temp(:,3)-QNEO_temp(:,2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
+                        QNEO_temp(:,ns_dkes+2)   = QNEO_PENTA(:,ns_dkes-1) + (QNEO_PENTA(:,ns_dkes)-QNEO_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+
+                        ! Spline of Dn,cn,Dp,cp; computation at plasma grid
+                        DO jspecies=1,(nion_prof+1)
+                              !Dn
+                              CALL EZspline_init(Dn_spl,ns_dkes+2,bcs0,ier)
+                              Dn_spl%x1        = rho_temp
+                              Dn_spl%isHermite = 1
+                              CALL EZspline_setup(Dn_spl,Dn_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                              !cn
+                              CALL EZspline_init(cn_spl,ns_dkes+2,bcs0,ier)
+                              cn_spl%x1        = rho_temp
+                              cn_spl%isHermite = 1
+                              CALL EZspline_setup(cn_spl,cn_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                              !Dp
+                              CALL EZspline_init(Dp_spl,ns_dkes+2,bcs0,ier)
+                              Dp_spl%x1        = rho_temp
+                              Dp_spl%isHermite = 1
+                              CALL EZspline_setup(Dp_spl,Dp_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                              !cp
+                              CALL EZspline_init(cp_spl,ns_dkes+2,bcs0,ier)
+                              cp_spl%x1        = rho_temp
+                              cp_spl%isHermite = 1
+                              CALL EZspline_setup(cp_spl,cp_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                              !GNEO
+                              CALL EZspline_init(GNEO_spl,ns_dkes+2,bcs0,ier)
+                              GNEO_spl%x1        = rho_temp
+                              GNEO_spl%isHermite = 1
+                              CALL EZspline_setup(GNEO_spl,GNEO_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                              !QNEO
+                              CALL EZspline_init(QNEO_spl,ns_dkes+2,bcs0,ier)
+                              QNEO_spl%x1        = rho_temp
+                              QNEO_spl%isHermite = 1
+                              CALL EZspline_setup(QNEO_spl,QNEO_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                              
+                              ! Compute at plasma solver grid
+                              CALL EZspline_interp(Dn_spl,Nr_plasma_solver,rho_plasma_grid,Dn_NEO(jspecies,mytimestep_plasma_solver,:),ier)
+                              CALL EZspline_interp(cn_spl,Nr_plasma_solver,rho_plasma_grid,cn_NEO(jspecies,mytimestep_plasma_solver,:),ier)
+                              CALL EZspline_interp(Dp_spl,Nr_plasma_solver,rho_plasma_grid,Dp_NEO(jspecies,mytimestep_plasma_solver,:),ier)
+                              CALL EZspline_interp(cp_spl,Nr_plasma_solver,rho_plasma_grid,cp_NEO(jspecies,mytimestep_plasma_solver,:),ier)
+                              CALL EZspline_interp(GNEO_spl,Nr_plasma_solver,rho_plasma_grid,G_NEO_complet(jspecies,mytimestep_plasma_solver,:),ier)
+                              CALL EZspline_interp(QNEO_spl,Nr_plasma_solver,rho_plasma_grid,Q_NEO_complet(jspecies,mytimestep_plasma_solver,:),ier)
+
+                              ! Deallocate splines
+                              CALL EZspline_free(Dn_spl,ier)
+                              CALL EZspline_free(cn_spl,ier)
+                              CALL EZspline_free(Dp_spl,ier)
+                              CALL EZspline_free(cp_spl,ier)
+                              CALL EZspline_free(GNEO_spl,ier)
+                              CALL EZspline_free(QNEO_spl,ier)
+                        END DO
+                        !
+                        DEALLOCATE(rho_temp,Dn_temp,cn_temp,Dp_temp,cp_temp,GNEO_temp,QNEO_temp)
+                  END IF
+
+                  DEALLOCATE(rho_k,iota,phip,chip,btheta,bzeta,bsq,vp,EparB)
+                  DEALLOCATE(te,ne,dtedrho,dnedrho)
+                  DEALLOCATE(ni,ti,dtidrho,dnidrho)
+                  DEALLOCATE(JBS_PENTA,etapar_PENTA,Er_PENTA,GNEO_PENTA,QNEO_PENTA)
+                  DEALLOCATE(Dn_PENTA,cn_PENTA,Dp_PENTA,cp_PENTA)
+            END IF
+            
                         
          END IF
 

--- a/THRIFT/Sources/thrift_penta.f90
+++ b/THRIFT/Sources/thrift_penta.f90
@@ -52,32 +52,33 @@
       IF (lscreen) WRITE(6,'(a)') ' --------------------  NEOCLASSICAL BOOTSTRAP USING PENTA  -------------------'
       IF (lscreen) Write(*,*) " <r>/<a>","   Er root(s) (V/cm)"
 
-      IF (lvmec) THEN
-         ierr_mpi = 0
-         ! PENTA is parallelized over radial surfaces in this routine.
-         ns_dkes = 0
-         DO k = 1, DKES_NS_MAX
-            IF ((DKES_K(k) > 0)) ns_dkes = ns_dkes+1
-         END DO
-         ! Break up work
-         CALL MPI_CALC_MYRANGE(MPI_COMM_MYWORLD,1,ns_dkes,mystart,myend)
+      IF (.NOT. lvmec) RETURN
+      
 
-         ALLOCATE(rho_k(ns_dkes),iota(ns_dkes),phip(ns_dkes),chip(ns_dkes),btheta(ns_dkes),bzeta(ns_dkes),bsq(ns_dkes),vp(ns_dkes),EparB(ns_dkes))
-         ALLOCATE(te(ns_dkes),ne(ns_dkes),dtedrho(ns_dkes),dnedrho(ns_dkes))
-         ALLOCATE(ni(ns_dkes,nion_prof),ti(ns_dkes,nion_prof),dtidrho(ns_dkes,nion_prof),dnidrho(ns_dkes,nion_prof))
-         ALLOCATE(JBS_PENTA(ns_dkes),etapar_PENTA(ns_dkes),Er_PENTA(ns_dkes))
-         ALLOCATE(GNEO_PENTA(nion_prof+1,ns_dkes),QNEO_PENTA(nion_prof+1,ns_dkes))
-         ALLOCATE(Dn_PENTA(nion_prof+1,ns_dkes),cn_PENTA(nion_prof+1,ns_dkes))
-         ALLOCATE(Dp_PENTA(nion_prof+1,ns_dkes),cp_PENTA(nion_prof+1,ns_dkes))
+      ierr_mpi = 0
+      ! PENTA is parallelized over radial surfaces in this routine.
+      ns_dkes = 0
+      DO k = 1, DKES_NS_MAX
+      IF ((DKES_K(k) > 0)) ns_dkes = ns_dkes+1
+      END DO
+      ! Break up work
+      CALL MPI_CALC_MYRANGE(MPI_COMM_MYWORLD,1,ns_dkes,mystart,myend)
 
-         JBS_PENTA = 0.0; etapar_PENTA = 0.0; Er_PENTA = 0.0
-         GNEO_PENTA = 0.0; QNEO_PENTA = 0.0
-         Dn_PENTA = 0.0; cn_PENTA = 0.0
-         Dp_PENTA = 0.0; cp_PENTA = 0.0
+      ALLOCATE(rho_k(ns_dkes),iota(ns_dkes),phip(ns_dkes),chip(ns_dkes),btheta(ns_dkes),bzeta(ns_dkes),bsq(ns_dkes),vp(ns_dkes),EparB(ns_dkes))
+      ALLOCATE(te(ns_dkes),ne(ns_dkes),dtedrho(ns_dkes),dnedrho(ns_dkes))
+      ALLOCATE(ni(ns_dkes,nion_prof),ti(ns_dkes,nion_prof),dtidrho(ns_dkes,nion_prof),dnidrho(ns_dkes,nion_prof))
+      ALLOCATE(JBS_PENTA(ns_dkes),etapar_PENTA(ns_dkes),Er_PENTA(ns_dkes))
+      ALLOCATE(GNEO_PENTA(nion_prof+1,ns_dkes),QNEO_PENTA(nion_prof+1,ns_dkes))
+      ALLOCATE(Dn_PENTA(nion_prof+1,ns_dkes),cn_PENTA(nion_prof+1,ns_dkes))
+      ALLOCATE(Dp_PENTA(nion_prof+1,ns_dkes),cp_PENTA(nion_prof+1,ns_dkes))
 
-         IF (myworkid == master) THEN
+      JBS_PENTA = 0.0; etapar_PENTA = 0.0; Er_PENTA = 0.0
+      GNEO_PENTA = 0.0; QNEO_PENTA = 0.0
+      Dn_PENTA = 0.0; cn_PENTA = 0.0
+      Dp_PENTA = 0.0; cp_PENTA = 0.0
+
+      IF (myworkid == master) THEN
             mytime = THRIFT_T(mytimestep)
-            
             ! EparB Spline
             bcs1=(/ 0, 0/)
             CALL EZspline_init(EparB_spl,nsj,bcs1,ier)
@@ -87,7 +88,6 @@
             CALL EZspline_setup(EparB_spl,THRIFT_EPARB(:,mytimestep),ier,EXACT_DIM=.true.)
             IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'thrift_penta: eparb',ier)
             !
-
             DO k = 1, ns_dkes
                   mysurf = DKES_K(k)
                   s = DBLE(mysurf-1) / DBLE(ns_eq-1)
@@ -125,49 +125,47 @@
                         CALL get_prof_tiprime(rho, THRIFT_T(mytimestep), j, dtidrho(k,j))
                         CALL get_prof_niprime(rho, THRIFT_T(mytimestep), j, dnidrho(k,j))
                   END DO
-                  
                   ! EparB
                   ier = 0
                   CALL EZSpline_interp(EparB_spl, rho, EparB(k), ier)
             END DO
-            CALL EZspline_free(EparB_spl,ier)
-            
+            !
+            CALL EZspline_free(EparB_spl,ier)    
       END IF
-         
+            
 #if defined(MPI_OPT)
-         CALL MPI_BCAST(rho_k,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(iota,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(phip,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(btheta,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(bzeta,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(bsq,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(vp,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(te,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(ne,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(dtedrho,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(dnedrho,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(ti,ns_dkes*nion_prof,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(ni,ns_dkes*nion_prof,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(dtidrho,ns_dkes*nion_prof,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(dnidrho,ns_dkes*nion_prof,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(EparB,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         ! VMEC quantities
-         CALL MPI_BCAST(eq_Aminor,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(eq_Rmajor,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         ! THRIFT quantities
-         CALL MPI_BCAST(mytime,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(mytimestep,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
-         ! Plasma solver quantities
-         CALL MPI_BCAST(look_for_ambipolar,1,MPI_LOGICAL,master,MPI_COMM_MYWORLD,ierr_mpi)
-         CALL MPI_BCAST(mytimestep_plasma_solver,1,MPI_INTEGER,master,MPI_COMM_MYWORLD,ierr_mpi)
-         
+      CALL MPI_BCAST(rho_k,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(iota,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(phip,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(btheta,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(bzeta,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(bsq,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(vp,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(te,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(ne,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(dtedrho,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(dnedrho,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(ti,ns_dkes*nion_prof,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(ni,ns_dkes*nion_prof,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(dtidrho,ns_dkes*nion_prof,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(dnidrho,ns_dkes*nion_prof,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(EparB,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      ! VMEC quantities
+      CALL MPI_BCAST(eq_Aminor,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(eq_Rmajor,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      ! THRIFT quantities
+      CALL MPI_BCAST(mytime,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(mytimestep,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      ! Plasma solver quantities
+      CALL MPI_BCAST(look_for_ambipolar,1,MPI_LOGICAL,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(mytimestep_plasma_solver,1,MPI_INTEGER,master,MPI_COMM_MYWORLD,ierr_mpi)           
 #endif
-      
-         ! DKES Data
-         ncstar = COUNT(DKES_NUSTAR < 1E10)
-         nestar = COUNT(DKES_ERSTAR < 1E10)
 
-         DO k = mystart,myend
+      ! DKES Data
+      ncstar = COUNT(DKES_NUSTAR < 1E10)
+      nestar = COUNT(DKES_ERSTAR < 1E10)
+
+      DO k = mystart,myend
             ! PENTA
             CALL PENTA_SET_ION_PARAMS(nion_prof, DBLE(Zatom_prof), Matom_prof/p_mass)
             CALL PENTA_SET_COMMANDLINE(Er_min_Vcm,Er_max_Vcm,DKES_K(k),1,EparB(k),1,'','','')
@@ -176,7 +174,7 @@
             CALL PENTA_SET_PPROF(ne(k),dnedrho(k)/eq_Aminor,te(k),dtedrho(k)/eq_Aminor,ni(k,:),dnidrho(k,:)/eq_Aminor,ti(k,:),dtidrho(k,:)/eq_Aminor)
             ! MAKE CORRECTIONS ON D31 AND D33 -- values coming from DKES2 miss Bsq factors (see J. Lore documentation)
             CALL PENTA_SET_DKES_STAR(ncstar,nestar,DKES_NUSTAR(1:ncstar),DKES_ERSTAR(1:nestar), &
-               DKES_D11(k,:,:), DKES_D31(k,:,:)*SQRT(bsq(k)), DKES_D33(k,:,:)*bsq(k))
+                  DKES_D11(k,:,:), DKES_D31(k,:,:)*SQRT(bsq(k)), DKES_D33(k,:,:)*bsq(k))
             CALL PENTA_SET_BEAM(0.0_rprec) ! Zero becasue we don't read
             CALL PENTA_SET_U2() ! Leave blank for default value
             CALL PENTA_READ_INPUT_FILES(.FALSE.,.FALSE.,.FALSE.,.FALSE.,.FALSE.)
@@ -188,28 +186,26 @@
             WRITE(temp_str,'(i4.4)') k
             WRITE(temp1_str,'(i3.3)') mytimestep
             CALL PENTA_OPEN_OUTPUT(TRIM(temp1_str) // '_k' // TRIM(temp_str))
-            CALL second0(et)
-            ! Now the basic steps
-            
-            
-            
+
+            ! Only search new ambipolar Er solution if look_for_ambipolar = true
+            ! If not, take the current THRIFT_ER solution
+            ! The boolean look_for_ambipolar is controled in thrift_plasma_solver_mod
             IF(solve_plasma_equations .AND. .NOT. look_for_ambipolar) THEN
                   ! Get Er value from THRIFT
                   irho =  MINLOC(ABS(SQRT(THRIFT_S) - rho_k(k)), dim=1)
                   ! Need to define num_roots and set Er_roots
                   num_roots = 1
                   Er_roots(1) = THRIFT_ER(irho,mytimestep)
-                  fix_Er_time = fix_Er_time + (et-st)
             ELSE
                   ! Now the basic steps
                   CALL PENTA_RUN_2_EFIELD
                   CALL PENTA_RUN_3_FIND_ROOTS
             END IF
+
             CALL PENTA_RUN_4_AMBIPOLAR
-          
+            
             ! The call to ROOT_ANALYSIS sets the array 'root_type' which decides which root to pick
             ! The criterium is to pick the 'ion_root'
-            CALL second0(st)
             CALL ROOT_ANALYSIS
 
             ! Using root_type, pick the ambipolar root that will be saved by THRIFT
@@ -227,20 +223,17 @@
                         ! NEO heat transport coefficients
                         Dp_PENTA(:,k) = (/ (-R_T_ambi(i,j,j), j=1,nion_prof+1) /) * e_charge*Temps / dens 
                         cp_PENTA(:,k) = MATMUL(R_n_ambi(i,:,:),dndrs)/dens - MATMUL(R_T_ambi(i,:,:),(e_charge*Temps/dens)*dndrs)/dens &
-                                      + Er_PENTA(k)*SUM(R_Er_ambi(i,:,:),dim=2) / dens
+                                          + Er_PENTA(k)*SUM(R_Er_ambi(i,:,:),dim=2) / dens
                         EXIT
                   ENDIF
             END DO
-                        
+            !       
             CALL PENTA_RUN_5_CLEANUP(lscreen)
+      END DO
 
-         END DO
-
-
-         !! Bootstrap interpolation onto THRIFT grid
 #if defined(MPI_OPT)
-         CALL MPI_BARRIER(MPI_COMM_MYWORLD,ierr_mpi)
-         IF (myworkid == master) THEN
+      CALL MPI_BARRIER(MPI_COMM_MYWORLD,ierr_mpi)
+      IF (myworkid == master) THEN
             CALL MPI_REDUCE(MPI_IN_PLACE,JBS_PENTA,ns_dkes,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_MYWORLD,ierr_mpi)
             CALL MPI_REDUCE(MPI_IN_PLACE,etapar_PENTA,ns_dkes,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_MYWORLD,ierr_mpi)
             CALL MPI_REDUCE(MPI_IN_PLACE,Er_PENTA,ns_dkes,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_MYWORLD,ierr_mpi)
@@ -250,7 +243,7 @@
             CALL MPI_REDUCE(MPI_IN_PLACE,cn_PENTA,(nion_prof+1)*ns_dkes,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_MYWORLD,ierr_mpi)
             CALL MPI_REDUCE(MPI_IN_PLACE,Dp_PENTA,(nion_prof+1)*ns_dkes,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_MYWORLD,ierr_mpi)
             CALL MPI_REDUCE(MPI_IN_PLACE,cp_PENTA,(nion_prof+1)*ns_dkes,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_MYWORLD,ierr_mpi)
-         ELSE 
+      ELSE 
             CALL MPI_REDUCE(JBS_PENTA,JBS_PENTA,ns_dkes,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_MYWORLD,ierr_mpi)
             CALL MPI_REDUCE(etapar_PENTA,etapar_PENTA,ns_dkes,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_MYWORLD,ierr_mpi)
             CALL MPI_REDUCE(Er_PENTA,Er_PENTA,ns_dkes,MPI_DOUBLE_PRECISION,MPI_SUM,master,MPI_COMM_MYWORLD,ierr_mpi)
@@ -266,11 +259,10 @@
             DEALLOCATE(ni,ti,dtidrho,dnidrho)
             DEALLOCATE(JBS_PENTA,etapar_PENTA,Er_PENTA,GNEO_PENTA,QNEO_PENTA,Dn_PENTA,cn_PENTA,Dp_PENTA,cp_PENTA)
             RETURN
-         ENDIF
+      ENDIF
 #endif
-         
-         IF (myworkid == master) THEN
-
+            
+      IF (myworkid == master) THEN
             IF(look_for_ambipolar) THEN
                   IF(save_all_ambipolar_roots) CALL PENTA_MERGE_AMBIPOLAR_FILES(ns_dkes,temp1_str,mytime)
                   IF(save_fluxes_vs_Er) CALL PENTA_MERGE_FLUXES_VS_ER_FILES(ns_dkes,temp1_str,mytime)
@@ -361,112 +353,107 @@
                   END DO
                   DEALLOCATE(rho_temp,GNEO_temp,QNEO_temp)
             END IF
-
-            CALL second0(st)
-            IF( .NOT. look_for_ambipolar) THEN
-                  ! Compute NEO coefficients in plasma grid if transport equations being solved
-                  IF(solve_plasma_equations) THEN
-                        ! Interpolate JBS_PENTA, etapar_PENTA and Er_PENTA at rho=0 and rho=1
-                        ALLOCATE(rho_temp(ns_dkes+2))
-                        ALLOCATE(Dn_temp(nion_prof+1,ns_dkes+2),cn_temp(nion_prof+1,ns_dkes+2))
-                        ALLOCATE(Dp_temp(nion_prof+1,ns_dkes+2),cp_temp(nion_prof+1,ns_dkes+2))
-                        ALLOCATE(GNEO_temp(nion_prof+1,ns_dkes+2),QNEO_temp(nion_prof+1,ns_dkes+2))
-                        !
-                        rho_temp(1)        = 0.0
-                        rho_temp(2:ns_dkes+1) = rho_k
-                        rho_temp(ns_dkes+2)   = 1.0
-                        !
-                        Dn_temp(:,2:ns_dkes+1)   = Dn_PENTA
-                        Dn_temp(:,1)             = 0.0_rprec
-                        Dn_temp(:,ns_dkes+2)     = Dn_PENTA(:,ns_dkes-1) + (Dn_PENTA(:,ns_dkes)-Dn_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-                        !
-                        cn_temp(:,2:ns_dkes+1)   = cn_PENTA
-                        cn_temp(:,1)             = 0.0_rprec
-                        cn_temp(:,ns_dkes+2)     = cn_PENTA(:,ns_dkes-1) + (cn_PENTA(:,ns_dkes)-cn_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-                        !
-                        Dp_temp(:,2:ns_dkes+1)   = Dp_PENTA
-                        Dp_temp(:,1)             = 0.0_rprec
-                        Dp_temp(:,ns_dkes+2)     = Dp_PENTA(:,ns_dkes-1) + (Dp_PENTA(:,ns_dkes)-Dp_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-                        !
-                        cp_temp(:,2:ns_dkes+1)   = cp_PENTA
-                        cp_temp(:,1)             = 0.0_rprec
-                        cp_temp(:,ns_dkes+2)     = cp_PENTA(:,ns_dkes-1) + (cp_PENTA(:,ns_dkes)-cp_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-                        !
-                        GNEO_temp(:,2:ns_dkes+1) = GNEO_PENTA
-                        GNEO_temp(:,1)           = GNEO_temp(:,2) - (GNEO_temp(:,3)-GNEO_temp(:,2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
-                        GNEO_temp(:,ns_dkes+2)   = GNEO_PENTA(:,ns_dkes-1) + (GNEO_PENTA(:,ns_dkes)-GNEO_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-                        !
-                        QNEO_temp(:,2:ns_dkes+1) = QNEO_PENTA
-                        QNEO_temp(:,1)           = QNEO_temp(:,2) - (QNEO_temp(:,3)-QNEO_temp(:,2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
-                        QNEO_temp(:,ns_dkes+2)   = QNEO_PENTA(:,ns_dkes-1) + (QNEO_PENTA(:,ns_dkes)-QNEO_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
-
-                        ! Spline of Dn,cn,Dp,cp; computation at plasma grid
-                        DO jspecies=1,(nion_prof+1)
-                              !Dn
-                              CALL EZspline_init(Dn_spl,ns_dkes+2,bcs0,ier)
-                              Dn_spl%x1        = rho_temp
-                              Dn_spl%isHermite = 1
-                              CALL EZspline_setup(Dn_spl,Dn_temp(jspecies,:),ier,EXACT_DIM=.true.)
-                              !cn
-                              CALL EZspline_init(cn_spl,ns_dkes+2,bcs0,ier)
-                              cn_spl%x1        = rho_temp
-                              cn_spl%isHermite = 1
-                              CALL EZspline_setup(cn_spl,cn_temp(jspecies,:),ier,EXACT_DIM=.true.)
-                              !Dp
-                              CALL EZspline_init(Dp_spl,ns_dkes+2,bcs0,ier)
-                              Dp_spl%x1        = rho_temp
-                              Dp_spl%isHermite = 1
-                              CALL EZspline_setup(Dp_spl,Dp_temp(jspecies,:),ier,EXACT_DIM=.true.)
-                              !cp
-                              CALL EZspline_init(cp_spl,ns_dkes+2,bcs0,ier)
-                              cp_spl%x1        = rho_temp
-                              cp_spl%isHermite = 1
-                              CALL EZspline_setup(cp_spl,cp_temp(jspecies,:),ier,EXACT_DIM=.true.)
-                              !GNEO
-                              CALL EZspline_init(GNEO_spl,ns_dkes+2,bcs0,ier)
-                              GNEO_spl%x1        = rho_temp
-                              GNEO_spl%isHermite = 1
-                              CALL EZspline_setup(GNEO_spl,GNEO_temp(jspecies,:),ier,EXACT_DIM=.true.)
-                              !QNEO
-                              CALL EZspline_init(QNEO_spl,ns_dkes+2,bcs0,ier)
-                              QNEO_spl%x1        = rho_temp
-                              QNEO_spl%isHermite = 1
-                              CALL EZspline_setup(QNEO_spl,QNEO_temp(jspecies,:),ier,EXACT_DIM=.true.)
-                              
-                              ! Compute at plasma solver grid
-                              CALL EZspline_interp(Dn_spl,Nr_plasma_solver,rho_plasma_grid,Dn_NEO(jspecies,mytimestep_plasma_solver,:),ier)
-                              CALL EZspline_interp(cn_spl,Nr_plasma_solver,rho_plasma_grid,cn_NEO(jspecies,mytimestep_plasma_solver,:),ier)
-                              CALL EZspline_interp(Dp_spl,Nr_plasma_solver,rho_plasma_grid,Dp_NEO(jspecies,mytimestep_plasma_solver,:),ier)
-                              CALL EZspline_interp(cp_spl,Nr_plasma_solver,rho_plasma_grid,cp_NEO(jspecies,mytimestep_plasma_solver,:),ier)
-                              CALL EZspline_interp(GNEO_spl,Nr_plasma_solver,rho_plasma_grid,G_NEO_complet(jspecies,mytimestep_plasma_solver,:),ier)
-                              CALL EZspline_interp(QNEO_spl,Nr_plasma_solver,rho_plasma_grid,Q_NEO_complet(jspecies,mytimestep_plasma_solver,:),ier)
-
-                              ! Deallocate splines
-                              CALL EZspline_free(Dn_spl,ier)
-                              CALL EZspline_free(cn_spl,ier)
-                              CALL EZspline_free(Dp_spl,ier)
-                              CALL EZspline_free(cp_spl,ier)
-                              CALL EZspline_free(GNEO_spl,ier)
-                              CALL EZspline_free(QNEO_spl,ier)
-                        END DO
-                        !
-                        DEALLOCATE(rho_temp,Dn_temp,cn_temp,Dp_temp,cp_temp,GNEO_temp,QNEO_temp)
-                  END IF
-
-                  DEALLOCATE(rho_k,iota,phip,chip,btheta,bzeta,bsq,vp,EparB)
-                  DEALLOCATE(te,ne,dtedrho,dnedrho)
-                  DEALLOCATE(ni,ti,dtidrho,dnidrho)
-                  DEALLOCATE(JBS_PENTA,etapar_PENTA,Er_PENTA,GNEO_PENTA,QNEO_PENTA)
-                  DEALLOCATE(Dn_PENTA,cn_PENTA,Dp_PENTA,cp_PENTA)
-            END IF
             
-                        
-         END IF
+            ! Compute NEO coefficients in plasma grid if transport equations being solved
+            IF( .NOT. look_for_ambipolar .AND. solve_plasma_equations) THEN
+                  ! Interpolate JBS_PENTA, etapar_PENTA and Er_PENTA at rho=0 and rho=1
+                  ALLOCATE(rho_temp(ns_dkes+2))
+                  ALLOCATE(Dn_temp(nion_prof+1,ns_dkes+2),cn_temp(nion_prof+1,ns_dkes+2))
+                  ALLOCATE(Dp_temp(nion_prof+1,ns_dkes+2),cp_temp(nion_prof+1,ns_dkes+2))
+                  ALLOCATE(GNEO_temp(nion_prof+1,ns_dkes+2),QNEO_temp(nion_prof+1,ns_dkes+2))
+                  !
+                  rho_temp(1)        = 0.0
+                  rho_temp(2:ns_dkes+1) = rho_k
+                  rho_temp(ns_dkes+2)   = 1.0
+                  !
+                  Dn_temp(:,2:ns_dkes+1)   = Dn_PENTA
+                  Dn_temp(:,1)             = 0.0_rprec
+                  Dn_temp(:,ns_dkes+2)     = Dn_PENTA(:,ns_dkes-1) + (Dn_PENTA(:,ns_dkes)-Dn_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                  !
+                  cn_temp(:,2:ns_dkes+1)   = cn_PENTA
+                  cn_temp(:,1)             = 0.0_rprec
+                  cn_temp(:,ns_dkes+2)     = cn_PENTA(:,ns_dkes-1) + (cn_PENTA(:,ns_dkes)-cn_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                  !
+                  Dp_temp(:,2:ns_dkes+1)   = Dp_PENTA
+                  Dp_temp(:,1)             = 0.0_rprec
+                  Dp_temp(:,ns_dkes+2)     = Dp_PENTA(:,ns_dkes-1) + (Dp_PENTA(:,ns_dkes)-Dp_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                  !
+                  cp_temp(:,2:ns_dkes+1)   = cp_PENTA
+                  cp_temp(:,1)             = 0.0_rprec
+                  cp_temp(:,ns_dkes+2)     = cp_PENTA(:,ns_dkes-1) + (cp_PENTA(:,ns_dkes)-cp_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                  !
+                  GNEO_temp(:,2:ns_dkes+1) = GNEO_PENTA
+                  GNEO_temp(:,1)           = GNEO_temp(:,2) - (GNEO_temp(:,3)-GNEO_temp(:,2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
+                  GNEO_temp(:,ns_dkes+2)   = GNEO_PENTA(:,ns_dkes-1) + (GNEO_PENTA(:,ns_dkes)-GNEO_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
+                  !
+                  QNEO_temp(:,2:ns_dkes+1) = QNEO_PENTA
+                  QNEO_temp(:,1)           = QNEO_temp(:,2) - (QNEO_temp(:,3)-QNEO_temp(:,2)) * rho_temp(2) / (rho_temp(3)-rho_temp(2))
+                  QNEO_temp(:,ns_dkes+2)   = QNEO_PENTA(:,ns_dkes-1) + (QNEO_PENTA(:,ns_dkes)-QNEO_PENTA(:,ns_dkes-1)) * (1-rho_k(ns_dkes-1)) / (rho_k(ns_dkes)-rho_k(ns_dkes-1))
 
-      ENDIF
+                  ! Spline of Dn,cn,Dp,cp; computation at plasma grid
+                  DO jspecies=1,(nion_prof+1)
+                        !Dn
+                        CALL EZspline_init(Dn_spl,ns_dkes+2,bcs0,ier)
+                        Dn_spl%x1        = rho_temp
+                        Dn_spl%isHermite = 1
+                        CALL EZspline_setup(Dn_spl,Dn_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                        !cn
+                        CALL EZspline_init(cn_spl,ns_dkes+2,bcs0,ier)
+                        cn_spl%x1        = rho_temp
+                        cn_spl%isHermite = 1
+                        CALL EZspline_setup(cn_spl,cn_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                        !Dp
+                        CALL EZspline_init(Dp_spl,ns_dkes+2,bcs0,ier)
+                        Dp_spl%x1        = rho_temp
+                        Dp_spl%isHermite = 1
+                        CALL EZspline_setup(Dp_spl,Dp_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                        !cp
+                        CALL EZspline_init(cp_spl,ns_dkes+2,bcs0,ier)
+                        cp_spl%x1        = rho_temp
+                        cp_spl%isHermite = 1
+                        CALL EZspline_setup(cp_spl,cp_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                        !GNEO
+                        CALL EZspline_init(GNEO_spl,ns_dkes+2,bcs0,ier)
+                        GNEO_spl%x1        = rho_temp
+                        GNEO_spl%isHermite = 1
+                        CALL EZspline_setup(GNEO_spl,GNEO_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                        !QNEO
+                        CALL EZspline_init(QNEO_spl,ns_dkes+2,bcs0,ier)
+                        QNEO_spl%x1        = rho_temp
+                        QNEO_spl%isHermite = 1
+                        CALL EZspline_setup(QNEO_spl,QNEO_temp(jspecies,:),ier,EXACT_DIM=.true.)
+                        
+                        ! Compute at plasma solver grid
+                        CALL EZspline_interp(Dn_spl,Nr_plasma_solver,rho_plasma_grid,Dn_NEO(jspecies,mytimestep_plasma_solver,:),ier)
+                        CALL EZspline_interp(cn_spl,Nr_plasma_solver,rho_plasma_grid,cn_NEO(jspecies,mytimestep_plasma_solver,:),ier)
+                        CALL EZspline_interp(Dp_spl,Nr_plasma_solver,rho_plasma_grid,Dp_NEO(jspecies,mytimestep_plasma_solver,:),ier)
+                        CALL EZspline_interp(cp_spl,Nr_plasma_solver,rho_plasma_grid,cp_NEO(jspecies,mytimestep_plasma_solver,:),ier)
+                        CALL EZspline_interp(GNEO_spl,Nr_plasma_solver,rho_plasma_grid,G_NEO_complet(jspecies,mytimestep_plasma_solver,:),ier)
+                        CALL EZspline_interp(QNEO_spl,Nr_plasma_solver,rho_plasma_grid,Q_NEO_complet(jspecies,mytimestep_plasma_solver,:),ier)
+
+                        ! Deallocate splines
+                        CALL EZspline_free(Dn_spl,ier)
+                        CALL EZspline_free(cn_spl,ier)
+                        CALL EZspline_free(Dp_spl,ier)
+                        CALL EZspline_free(cp_spl,ier)
+                        CALL EZspline_free(GNEO_spl,ier)
+                        CALL EZspline_free(QNEO_spl,ier)
+                  END DO
+                  !
+                  DEALLOCATE(rho_temp,Dn_temp,cn_temp,Dp_temp,cp_temp,GNEO_temp,QNEO_temp)
+            END IF
+
+            DEALLOCATE(rho_k,iota,phip,chip,btheta,bzeta,bsq,vp,EparB)
+            DEALLOCATE(te,ne,dtedrho,dnedrho)
+            DEALLOCATE(ni,ti,dtidrho,dnidrho)
+            DEALLOCATE(JBS_PENTA,etapar_PENTA,Er_PENTA,GNEO_PENTA,QNEO_PENTA)
+            DEALLOCATE(Dn_PENTA,cn_PENTA,Dp_PENTA,cp_PENTA)   
+                        
+      END IF
+
       IF (lscreen) WRITE(6,'(a)') ' -------------------  NEOCLASSICAL BOOTSTRAP CALCULATION DONE  ---------------------'
       RETURN
-!-----------------------------------------------------------------------
-!     END SUBROUTINE
-!-----------------------------------------------------------------------
+      !-----------------------------------------------------------------------
+      !     END SUBROUTINE
+      !-----------------------------------------------------------------------
       END SUBROUTINE thrift_penta

--- a/THRIFT/Sources/thrift_plasma_solver_mod.f90
+++ b/THRIFT/Sources/thrift_plasma_solver_mod.f90
@@ -43,6 +43,7 @@ MODULE thrift_plasma_solver_mod
     TYPE(EZspline2_r8), DIMENSION(:), ALLOCATABLE, PRIVATE :: chi_normalized_splines
     INTEGER, PRIVATE :: subiter
     CHARACTER(len=20), DIMENSION(:), ALLOCATABLE :: list_of_species
+    LOGICAL :: look_for_ambipolar = .TRUE.
 
 !-----------------------------------------------------------------------
 !     Input Namelists
@@ -185,8 +186,10 @@ MODULE thrift_plasma_solver_mod
 
                 ! Run PENTA if NEO fluxes are to be added
                 IF(add_NEO) THEN
+                    look_for_ambipolar = .false.
                     CALL thrift_paraexe('penta',proc_string,lscreen_subcodes)
                     IF (ier /= 0) STOP 'Error running PENTA inside plasma solver'
+                    look_for_ambipolar = .true.
                 END IF
   
                 DO i=1,nion_prof

--- a/THRIFT/Sources/thrift_runtime.f90
+++ b/THRIFT/Sources/thrift_runtime.f90
@@ -276,21 +276,6 @@ CONTAINS
             WRITE(6, *) '  ierr:   ', ierr
         END IF
         CALL FLUSH(6)
-#if defined(MPI_OPT)
-!        CALL MPI_BARRIER(MPI_COMM_THRIFT,ierr_mpi)
-!        ALLOCATE(error_array(1:nprocs_beams))
-!        ierr_mpi = 0
-!        CALL MPI_ALLGATHER(error_num,1,MPI_INTEGER,error_array,1,MPI_INTEGER,MPI_COMM_THRIFT,ierr_mpi)
-!        ierr_mpi = 0
-!        CALL MPI_BARRIER(MPI_COMM_THRIFT,ierr_mpi)
-!        IF (ANY(error_array .ne. 0)) CALL MPI_FINALIZE(ierr_mpi)
-!        DEALLOCATE(error_array)
-        RETURN
-#else
-        IF (error_num .eq. MPI_CHECK) RETURN
-#endif
-        PRINT *,myworkid,' calling STOP'
-        CALL FLUSH(6)
         STOP
     END SUBROUTINE handle_err
 

--- a/pySTEL/libstell/dkes.py
+++ b/pySTEL/libstell/dkes.py
@@ -435,7 +435,6 @@ class DKES:
         
         # Get the unique values and counts of efield
         unique_efields, counts = np.unique(efield, return_counts=True)
-        print(counts)
         
         if not np.all(counts == counts[0]):
             print('ERROR: Each cmul does not have the same number of efields. Cannot proceed...')
@@ -708,7 +707,8 @@ class DKES:
             cmul and efield can be floats or arrays with same size.
             
             which_coeff can be:
-            D11_star, D31_star, D33_star, D31_over_D33_corrected, D31sq_over_D33_corrected, LHS_SN_flow_eq
+            D11_star, D31_star, D33_star, D31_over_D33_corrected, D31sq_over_D33_corrected, LHS_SN_flow_eq,
+            capped_fluxes_coefficient
             
             If log_interp_coeff is True, then the log of the coefficient is used when producing the spline
             (this is particularly helpful for coeffs that vary by many orders of magnitude such as D11_star)
@@ -731,6 +731,10 @@ class DKES:
         elif(which_coeff == 'LHS_SN_flow_eq'):
             D33_corrected = (2./3.)*self.Bsq/self.cmul - self.D33_star
             coeff = (2/3)*self.Bsq/D33_corrected - self.cmul
+        elif(which_coeff == 'capped_fluxes_coefficient'):
+            D33_corrected = (2./3.)*self.Bsq/self.cmul - self.D33_star
+            coeff = self.D11_star - (2/3)*self.U2*self.cmul + self.D31_star**2 / D33_corrected
+            coeff = np.clip(coeff,a_min=0.0,a_max=None)
         else:
             print('Coeff not found...')
             exit(1)
@@ -828,7 +832,7 @@ class DKES:
         else:
             return cmul_species,Erv_species,auxiliary_integrand
         
-    def get_BS_current(self,Er_Vcm,plasma_class,Smax,inspect=False):
+    def get_BS_current(self,Er_Vcm,plasma_class,Smax,inspect=False,output=None):
         """ This function computes the SN Bootstrap Current <JBS.b> as PENTA3 does using the Sugama-Nishimura method. This amounts to 
         solve Eq. (3.2.1.1) in PENTA documentation by Jeremy Lore. The equation has one typo though: they are missing the elementary 
         charge multiplying Ta (since it was defined to be in eV)
@@ -841,10 +845,11 @@ class DKES:
         
         !! Er is given in V/cm !!
         
-        This function returns an array with <JBS.b>_species of each species
-        
         If inspect is True, then will plot inv(flow_mat)*A1 and inv(flow_mat)*A2 point-wise, to check which terms
         are contributing the most to the BS current
+        
+        By default, this function returns an array with <JBS.b>_species of each species
+        BUT, if output=='flows', then this function returns <u_parallel x B>/<B^2> for each species and j=0,...,Smax
         """
         from scipy.special import assoc_laguerre
         
@@ -942,9 +947,9 @@ class DKES:
                     flow_mat[ind1_LHS1+jval,ind1_LHS1+kval] = fact1*LHS_conv[species1][jval,kval]
                     
                     for ispec2,species2 in enumerate(plasma_class.list_of_species):
-                        # ind1_LHS2 = ( ispec1 - 1 ) * ( Smax + 1 ) + jval
+                        # ind1_LHS2 = ( ispec1 - 1 ) * ( Smax + 1 ) + jval +1
                         ind1_LHS2 = ( ispec1 ) * ( Smax + 1 ) + jval
-                        # ind2_LHS2 = ( ispec2 - 1 ) * ( Smax + 1 ) + kval
+                        # ind2_LHS2 = ( ispec2 - 1 ) * ( Smax + 1 ) + kval +1 
                         ind2_LHS2 = ( ispec2 ) * ( Smax + 1 ) + kval
                         flow_mat[ind1_LHS2,ind2_LHS2] += -fact2*lmat[ind1_LHS2,ind2_LHS2]
         
@@ -978,12 +983,14 @@ class DKES:
         ############################################################################################################################
         
         uB_over_B2 = np.linalg.solve(flow_mat,RHS)
+        if output=='flows':
+            return uB_over_B2
+        
         uB_over_B2_0 = uB_over_B2[0::Smax+1]
         
-        JBS_species = []
+        JBS_species = np.zeros(Nspecies)
         for ispecies,species in enumerate(plasma_class.list_of_species):
-            jbs = n[species]*q[species]*np.sqrt(self.Bsq)*uB_over_B2_0[ispecies]
-            JBS_species.append( jbs )
+            JBS_species[ispecies] = n[species]*q[species]*np.sqrt(self.Bsq)*uB_over_B2_0[ispecies]
             
         JBS_tot = np.sum(JBS_species)
         print(f'JBS = {JBS_tot/1E3:.1f} kA/m2')
@@ -1033,6 +1040,172 @@ class DKES:
             #     print('sanity =',n[species]*q[species]*np.sqrt(self.Bsq)*summation[ispecies] )
         
         return JBS_species
+    
+    def get_fluxes(self,Er_Vcm,plasma_class,Smax):
+        """ This function computes the neoclassical particle and heat fluxes as PENTA3 does using the Sugama-Nishimura method. This amounts to 
+        solve Eq. (3.2.3.1) in PENTA documentation by Jeremy Lore.
+        
+        !! Er is given in V/cm !!
+        
+        This function returns: Gamma, QoverT
+        where Gammma and QoverT are arrays with the fluxes for each species
+        """
+        from scipy.special import assoc_laguerre
+        
+        Er = Er_Vcm
+        # Check Er!=0
+        if(np.abs(Er) < 1E-6):
+            raise ValueError('Please Choose Er != 0, cause this brings problems when taking the log of Er')
+        
+        ############################################################################################################################
+        ####################### Setup Convolutions in the SN Flow Equation (Eq. 3.2.3.1 in PENTA's notes)  #########################
+        ############################################################################################################################
+        vth = {}
+        n = {}
+        T = {}
+        q = {}
+        m = {}
+        #
+        A1_conv_Gamma = {}
+        A1_conv_QoT = {}
+        A2_conv_Gamma = {}
+        A2_conv_QoT = {}
+        flow_conv_Gamma = {species: np.zeros((Smax+1)) for species in plasma_class.list_of_species}
+        flow_conv_QoT = {species: np.zeros((Smax+1)) for species in plasma_class.list_of_species}
+        #
+        for species in plasma_class.list_of_species:
+            vth[species] = plasma_class.get_thermal_speed(species,self.roa)
+            n[species] = plasma_class.get_density(species,self.roa)
+            T[species] = plasma_class.get_temperature(species,self.roa)
+            q[species] = plasma_class.charge[species]
+            m[species] = plasma_class.mass[species]
+            
+            #get cmul for self.K
+            cmul_K = []
+            for k in self.K:
+                vparticle = vth[species] * np.sqrt(k)
+                nu = plasma_class.get_collisionality(species,self.roa,vparticle)
+                cmul_K.append( nu / vparticle )
+                            
+            cmul_K = np.array(cmul_K)
+            efield_K = np.abs(Er)*100/(vth[species]*np.sqrt(self.K))
+            
+            D31_over_D33_corrected = self.get_interpolated_coeff('D31_over_D33_corrected',cmul_K,efield_K,log_interp_coeff=False)
+            capped_fluxes_coefficient = self.get_interpolated_coeff('capped_fluxes_coefficient',cmul_K,efield_K,log_interp_coeff=False)
+            
+            # Convolutions
+            integrand = capped_fluxes_coefficient * self.K**1.5 * np.sqrt(self.K) * np.exp(-self.K) * assoc_laguerre(self.K, 0, k=1.5)
+            A1_conv_Gamma[species] = np.trapezoid(integrand,x=self.K) * n[species] * 2 / np.sqrt(np.pi)
+            
+            integrand = capped_fluxes_coefficient * self.K**2.5 * np.sqrt(self.K) * np.exp(-self.K) * assoc_laguerre(self.K, 0, k=1.5)
+            A2_conv_Gamma[species] = np.trapezoid(integrand,x=self.K) * n[species] * 2 / np.sqrt(np.pi)
+            A1_conv_QoT[species]   = np.trapezoid(integrand,x=self.K) * n[species] * 2 / np.sqrt(np.pi)
+            
+            integrand = capped_fluxes_coefficient * self.K**3.5 * np.sqrt(self.K) * np.exp(-self.K) * assoc_laguerre(self.K, 0, k=1.5)
+            A2_conv_QoT[species] = np.trapezoid(integrand,x=self.K) * n[species] * 2 / np.sqrt(np.pi)
+            
+            #### Convolutions that multiply flows ####
+            for jval in range(Smax+1):
+
+                integrand = D31_over_D33_corrected * self.K**1.5 * np.sqrt(self.K) * np.exp(-self.K) * assoc_laguerre(self.K, jval, k=1.5)
+                flow_conv_Gamma[species][jval] =  np.trapz(integrand,x=self.K) * n[species] * 2 / np.sqrt(np.pi)
+                
+                integrand = D31_over_D33_corrected * self.K**2.5 * np.sqrt(self.K) * np.exp(-self.K) * assoc_laguerre(self.K, jval, k=1.5)
+                flow_conv_QoT[species][jval] =  np.trapz(integrand,x=self.K) * n[species] * 2 / np.sqrt(np.pi)
+                
+        
+        ############################################################################################################################
+        ##########################################  Compute A1 and A2 for each species #############################################
+        ############################################################################################################################
+        A1 = {}
+        A2 = {}
+        for species in plasma_class.list_of_species:
+            na_prime_r = plasma_class.get_density_der(species,self.roa) / self.aminor
+            Ta_prime_r = plasma_class.get_temperature_der(species,self.roa) / self.aminor
+            #
+            A1[species] = na_prime_r/n[species] - 1.5*Ta_prime_r/(T[species]) - q[species]*Er*100/(EC*T[species])
+            A2[species] = Ta_prime_r/(T[species])
+            
+        ############################################################################################################################
+        ###############################################  Compute lmat ##############################################################
+        ############################################################################################################################
+        # Calculate Coulomb logarithm as in PENTA
+        if ( T['electrons'] > 50 ):
+            loglambda = 25.3 - 1.15*np.log10(n['electrons']/1.E6) + 2.3*np.log10(T['electrons'])
+        else:
+            loglambda = 23.4 - 1.15*np.log10(n['electrons']/1.E6) + 3.45*np.log10(T['electrons'])
+        #
+        lmat = define_friction_coeffs(masses=np.fromiter(m.values(), dtype=float), 
+                                     charges=np.fromiter(q.values(), dtype=float), 
+                                     v_ths = np.fromiter(vth.values(), dtype=float), 
+                                     Temps = np.fromiter(T.values(), dtype=float), 
+                                     dens  = np.fromiter(n.values(), dtype=float),
+                                     loglambda = loglambda, 
+                                     num_species=len(plasma_class.list_of_species), 
+                                     Smax=Smax)
+            
+        ############################################################################################################################
+        ######################################################  Compute PS term ####################################################
+        ############################################################################################################################
+        
+        PS_term_Gamma = {}
+        PS_term_QoT = {}
+        
+        for ispec1,speciesa in enumerate(plasma_class.list_of_species):
+            
+            PS_term_Gamma[speciesa] = 0.0
+            PS_term_QoT[speciesa] = 0.0
+            
+            for ispec2,speciesb in enumerate(plasma_class.list_of_species):
+                nb_prime_r = plasma_class.get_density_der(speciesb,self.roa) / self.aminor
+                Tb_prime_r = plasma_class.get_temperature_der(speciesb,self.roa) / self.aminor
+                
+                # lmat_ind1 = ( ispec1 - 1 ) * ( Smax + 1 ) + 1
+                lmat_ind1 = ( ispec1 ) * ( Smax + 1 )
+                # lmat_ind2 = ( ispec2 - 1 ) * ( Smax + 1 ) + 1
+                lmat_ind2 = ( ispec2 ) * ( Smax + 1 )
+                
+                l_ab_11 = lmat[lmat_ind1    , lmat_ind2]
+                l_ab_21 = lmat[lmat_ind1+1  , lmat_ind2]
+                l_ab_12 = lmat[lmat_ind1    , lmat_ind2+1]
+                l_ab_22 = lmat[lmat_ind1+1  , lmat_ind2+1]
+                
+                PS_term_Gamma[speciesa] += (nb_prime_r*T[speciesb]*EC + n[speciesb]*Tb_prime_r*EC) / (q[speciesb]*n[speciesb]) * l_ab_11 \
+                                            - Tb_prime_r*EC/q[speciesb] * l_ab_12
+                
+                PS_term_QoT[speciesa] += (nb_prime_r*T[speciesb]*EC + n[speciesb]*Tb_prime_r*EC) / (q[speciesb]*n[speciesb]) * \
+                                            ( (5/2)*l_ab_11 - l_ab_21 ) \
+                                        - Tb_prime_r*EC/q[speciesb] * ( (5/2)*l_ab_12 - l_ab_22 )
+                
+            PS_term_Gamma[speciesa] *= self.U2/q[speciesa]
+            PS_term_QoT[speciesa] *= self.U2/q[speciesa]
+            
+        ############################################################################################################################
+        ###################################################  Compute fluxes ########################################################
+        ############################################################################################################################         
+            
+        uB_over_B2 = self.get_BS_current(Er,plasma_class,Smax,output='flows')
+        
+        num_species = len(plasma_class.list_of_species)
+        
+        Gamma = np.zeros(num_species)
+        QoverT = np.zeros(num_species
+                         )
+        for ispecies,species in enumerate(plasma_class.list_of_species):
+            
+            mono_flux_1 = - (m[species]**2 * vth[species]**3) / (2*q[species]**2)*A1_conv_Gamma[species]*A1[species]
+            mono_flux_2 = - (m[species]**2 * vth[species]**3) / (2*q[species]**2)*A2_conv_Gamma[species]*A2[species]
+            flux_Ua = -(2/3)*self.Bsq*m[species]*vth[species]/q[species] * np.dot(flow_conv_Gamma[species][:],uB_over_B2[ispecies*(Smax+1):ispecies*(Smax+1)+(Smax+1)])
+            
+            Gamma[ispecies]  = mono_flux_1 + mono_flux_2 + flux_Ua + PS_term_Gamma[species]
+            
+            part1 = - (m[species]**2 * vth[species]**3) / (2*q[species]**2)*A1_conv_QoT[species]*A1[species]
+            part2 = - (m[species]**2 * vth[species]**3) / (2*q[species]**2)*A2_conv_QoT[species]*A2[species]
+            part3 = -(2/3)*self.Bsq*m[species]*vth[species]/q[species] * np.dot(flow_conv_QoT[species][:],uB_over_B2[ispecies*(Smax+1):ispecies*(Smax+1)+(Smax+1)])
+            
+            QoverT[ispecies] = part1 + part2 + part3 + PS_term_QoT[species]
+            
+        return Gamma,QoverT
                        
     def plot_U2_estimate(self):
         

--- a/pySTEL/libstell/dkes.py
+++ b/pySTEL/libstell/dkes.py
@@ -642,7 +642,11 @@ class DKES:
             # Now plot the integrand
             ax2.plot(cmul_species[~idx_clipped], norm*integrand[~idx_clipped],'.-',color='black')
             ax2.plot(cmul_species[idx_clipped], norm*integrand[idx_clipped],'.-',color='red')
-            ax2.fill_between(cmul_species, norm*integrand, alpha=0.3, label=f'|Er|={np.abs(Er)} V/cm')          
+            ax2.fill_between(cmul_species, norm*integrand, alpha=0.3, label=f'|Er|={np.abs(Er):.2f} V/cm')  
+            #
+            #
+            idx = [np.argmin(np.abs(cmul_species-cmul)) for cmul in np.unique(self.cmul)]
+            ax2.plot(np.unique(self.cmul),norm*integrand[idx],'x',markersize=10,markeredgewidth=5)        
 
             if(log_interp_coeff): ax1.set_yscale('log')
             ax1.set_xscale('log')
@@ -651,7 +655,7 @@ class DKES:
             ax2.set_ylabel(f'{which_species} ||{which_coeff} K^{K_exp} L_{jval}||')
             ax1.grid()
             ax1.set_xlabel(r'$\nu/v$')
-            ax2.legend()
+            ax2.legend(loc='upper left')
             ax1.set_title(f'r/a={self.roa:.2f}')
             ax1.legend()
             #plt.show()
@@ -659,9 +663,13 @@ class DKES:
             _, ax4 = plt.figure(figsize=(10,8)), plt.gca()
             ax4.plot(Erv_species[~idx_clipped], norm*integrand[~idx_clipped],'.-',color='black')
             ax4.plot(Erv_species[idx_clipped], norm*integrand[idx_clipped],'.-',color='red')
+            #
+            idx = [np.argmin(np.abs(Erv_species-er)) for er in np.unique(self.efield)]
+            ax4.plot(np.unique(self.efield),norm*integrand[idx],'x',markersize=10,markeredgewidth=5)
             ax4.set_xlabel(r'$Er/v$')
             ax4.grid()
             ax4.set_xscale('log')
+            ax4.set_xlim(np.min(Erv_species),np.max(Erv_species))
             # plt.show()
 
             #now make a plot that shows how many integration points are out of range

--- a/pySTEL/libstell/dkes.py
+++ b/pySTEL/libstell/dkes.py
@@ -545,7 +545,7 @@ class DKES:
             plt.legend()
             plt.show()        
     
-    def get_PENTA3_energy_convolution(self,which_coeff,which_species,Er,plasma_class,K_exp=0,jval=0,log_interp_coeff=True,make_plot=True):
+    def get_PENTA3_energy_convolution(self,which_coeff,which_species,Er,plasma_class,K_exp=0,jval=0,log_interp_coeff=False,make_plot=True):
         """
         Plots the convolution integrand as in PENTA3:
         
@@ -633,7 +633,7 @@ class DKES:
             
             # First plot the coefficient
             for ie in range(0, self.nefield):
-                ax1.plot(np.unique(self.cmul), coeff_2d[:, ie], '.-')#, label=f'$E_r/v={np.unique(self.efield)[ie]:3.1E}$')
+                ax1.plot(np.unique(self.cmul), coeff_2d[:, ie], '.-', label=f'$E_r/v={np.unique(self.efield)[ie]:3.1E}$')
 
             # Create a second y-axis on the right
             ax2 = ax1.twinx()  # Create another axis that shares the same x-axis
@@ -653,6 +653,7 @@ class DKES:
             ax1.set_xlabel(r'$\nu/v$')
             ax2.legend()
             ax1.set_title(f'r/a={self.roa:.2f}')
+            ax1.legend()
             #plt.show()
             
             _, ax4 = plt.figure(figsize=(10,8)), plt.gca()
@@ -661,7 +662,7 @@ class DKES:
             ax4.set_xlabel(r'$Er/v$')
             ax4.grid()
             ax4.set_xscale('log')
-            plt.show()
+            # plt.show()
 
             #now make a plot that shows how many integration points are out of range
             fig, ax3 = plt.figure(figsize=(10,8)), plt.gca()

--- a/pySTEL/libstell/dkes.py
+++ b/pySTEL/libstell/dkes.py
@@ -183,16 +183,25 @@ class DKES:
         if(which_coeff == 'D11_star'):
             yplot = self.D11_star
             var_name = r'$D_{11}^*~~[m^{-1}~T^{-2}]$'
+            yscale_log = True
         elif(which_coeff == 'D31_star'):
             yplot = self.D31_star
+            yscale_log = False
             var_name = r'$D_{31}^*$'
         elif(which_coeff == 'D31_over_D33_corrected'):
             D33_corrected = (2./3.)*self.Bsq/self.cmul - self.D33_star
             yplot = self.D31_star / D33_corrected
             var_name = r'$D_{31}^*\,\,/\,\,[(2/3)(\nu/v)^{-1}-D_{33}^*]$'
+            yscale_log = False
         elif(which_coeff == 'D33_star'):
             yplot = self.D33_star
             var_name = r'$D_{33}^*$'
+            yscale_log = False
+        elif(which_coeff == 'D11_plus_D31sq_over_D33_corrected'):
+            D33_corrected = (2./3.)*self.Bsq/self.cmul - self.D33_star
+            yplot = self.D11_star + self.D31_star**2 / D33_corrected
+            var_name = r'$D_{11}^*+[D_{31}^*]^2\,\,/\,\,[(2/3)(\nu/v)^{-1}-D_{33}^*]$'
+            yscale_log = True
         else:
             print('Coeff not found...')
             exit(1)
@@ -213,6 +222,7 @@ class DKES:
             ax.set_xlabel(r'$\nu/v\,\,[\text{m}^{-1}]$')
         ax.set_ylabel(var_name)
         ax.set_xscale('log')
+        if(yscale_log): ax.set_yscale('log')
         ax.set_title(f'r/a={self.roa:.2f}')
         ax.legend(fontsize=12)
         ax.grid()

--- a/pySTEL/libstell/plasma.py
+++ b/pySTEL/libstell/plasma.py
@@ -151,8 +151,7 @@ class PLASMA:
                 if(interpolating_func is None):
                     # check rho_vals are in the range [0,1]
                     if( np.any((rho_vals<0) | (rho_vals>1))):
-                        print('ERROR: rho_vals must be in the domain [0,1]')
-                        exit(0)
+                        print('WARNING: There are rho_vals outside the domain [0,1]')
                     interpolating_func = CubicSpline(rho_vals,n_vals)
                     
             case _:
@@ -198,8 +197,7 @@ class PLASMA:
                 if(interpolating_func is None):
                     # check rho_vals are in the range [0,1]
                     if( np.any((rho_vals<0) | (rho_vals>1))):
-                        print('ERROR: rho_vals must be in the domain [0,1]')
-                        exit(0)
+                        print('WARNING: There are rho_vals outside the domain [0,1]')
                     interpolating_func = CubicSpline(rho_vals,T_vals)
                     
             case _:

--- a/pySTEL/libstell/thrift.py
+++ b/pySTEL/libstell/thrift.py
@@ -1098,8 +1098,9 @@ class THRIFT():
         B2 = self.THRIFT_BSQAV[it_select,-1]
         pp = self.THRIFT_PPRIME[it_select,-1]
         LHS[-1,:] = 0.0 
-        LHS[-1,-1] = -phia*L_inductance/(VpEtapar) - B2*dt/(phia*ds) - mu0*pp*dt/phia
-        LHS[-1,-2] = B2*dt / (phia*ds)
+        LHS[-1,-1] = -phia*L_inductance/(VpEtapar) - 1.5*B2*dt/(phia*ds) - mu0*pp*dt/phia
+        LHS[-1,-2] = 2.0*B2*dt / (phia*ds)
+        LHS[-1,-3] = -0.5*B2*dt / (phia*ds)
         LHS = LHS.tocsr()
         
         # Solve

--- a/pySTEL/libstell/thrift.py
+++ b/pySTEL/libstell/thrift.py
@@ -1033,7 +1033,7 @@ class THRIFT():
         
         it_select = np.argmin(np.abs(self.THRIFT_T-t_select))
         
-        J_SOURCE = self.THRIFT_JSOURCE[it_select,:]
+        J_SOURCE = self.THRIFT_JSOURCE[it_select,:].copy() # copy to avoid modifying original array
         if(edge_factor is not None):
             J_SOURCE[-1] *= edge_factor 
         

--- a/pySTEL/libstell/thrift.py
+++ b/pySTEL/libstell/thrift.py
@@ -1006,7 +1006,110 @@ class THRIFT():
                 )
 
         return outname
+    
+    def solve_time_dependent_current_equation_fixed_profiles(self,t_select,dt,L_inductance,edge_factor=None,tend=None):
+        """ Solves the time dependent current diffusion equation with profiles at t_select 
+            
+            Equation is written in the conservative form:
+            dI/dt = (S11/phia^2) * d/ds[ D(s)*dI/ds + P(s)*I ] + F(s)
+            where:
+            D(s) = etapar*V' * <B2>/mu0
+            P(s) = etapar*V' * p'
+            F(s) = -S11/phia^2 * d/ds[etapar*V' * phia/mu0 * <JNI*B>]
+            
+            We solve this time-dependent PDE using an implicit backward Euler time scheme:
+            (I_new - I_old)/dt = L*I_new + F
+        """
+        from scipy.sparse import diags, identity
+        from scipy.sparse.linalg import spsolve
+        mu0 = 4*np.pi*1e-7
         
+        # Define time array
+        t_init = 0.0
+        if(tend is None):
+            tend = self.THRIFT_T[-1]
+        Nt = round(1+(tend-t_init)/dt)
+        t_solver = np.linspace(t_init, tend, num=Nt)
+        
+        it_select = np.argmin(np.abs(self.THRIFT_T-t_select))
+        
+        J_SOURCE = self.THRIFT_JSOURCE[it_select,:]
+        if(edge_factor is not None):
+            J_SOURCE[-1] *= edge_factor 
+        
+        phia = self.THRIFT_PHIEDGE[it_select]
+        #
+        aux1 = self.THRIFT_S11[it_select,:]/phia**2
+        aux2 = self.THRIFT_ETAPARA[it_select,:]*self.THRIFT_VP[it_select,:]
+        aux3 = aux2 * (phia/mu0) * J_SOURCE *self.THRIFT_BAV[it_select,:]
+        #
+        D = aux2 * self.THRIFT_BSQAV[it_select,:]/mu0
+        P = aux2 * self.THRIFT_PPRIME[it_select,:]
+        F = -aux1 * np.gradient(aux3,self.THRIFT_S)
+        #
+        # rmaj = self.THRIFT_RMAJOR[it_select,-1]
+        # amin = self.THRIFT_AMINOR[it_select,-1]
+        # L_inductance = mu0*rmaj*(np.log(8*rmaj/amin)-2) # mu0 R (log(8R/a)-2)
+        
+        # Assemble L operator
+        Dminus = 0.5 * (D[0:-2] + D[1:-1])
+        Dplus  = 0.5 * (D[1:-1] + D[2:])
+        #
+        Pminus = 0.5 * (P[0:-2] + P[1:-1])
+        Pplus  = 0.5 * (P[1:-1] + P[2:])
+        #
+        Ns = len(self.THRIFT_S)
+        ds = self.THRIFT_S[1] - self.THRIFT_S[0]
+        #
+        main_diag = np.zeros(Ns)
+        upper_diag = np.zeros(Ns-1)
+        lower_diag = np.zeros(Ns-1)
+        #
+        main_diag[1:-1] = -Dplus/ds - Pplus/2 - Dminus/ds - Pminus/2
+        upper_diag[1:] = Dplus/ds + Pplus/2 
+        lower_diag[0:-1] = Dminus/ds + Pminus/2
+        #
+        L = diags([lower_diag/ds, main_diag/ds, upper_diag/ds], offsets=[-1, 0, 1], format="csr")  
+        
+        # Multiply L operator by S11/phia^2 term
+        G = diags(aux1, 0, format="csr")
+        L = G @ L
+        
+        # Create LHS matrix
+        Id = identity(Ns, format="csr")
+        LHS = Id - dt*L
+        
+        # Create RHS matrix
+        RHS_last = -phia*L_inductance / (self.THRIFT_VP[it_select,-1]*self.THRIFT_ETAPARA[it_select,-1])
+        # 
+        diag = np.ones(Ns)
+        diag[-1] = RHS_last
+        #
+        RHS = diags(diag, offsets=0, format="csr")
+        
+        # Source Vector with boundary conditions
+        SOURCE = dt*F
+        SOURCE[0] = 0.0
+        SOURCE[-1] = -J_SOURCE[-1]*self.THRIFT_BAV[it_select,-1]*dt
+        
+        # Apply edge BC on LHS
+        LHS = LHS.tolil()  # Convert to LIL for easy row modification
+        VpEtapar = self.THRIFT_VP[it_select,-1]*self.THRIFT_ETAPARA[it_select,-1]
+        B2 = self.THRIFT_BSQAV[it_select,-1]
+        pp = self.THRIFT_PPRIME[it_select,-1]
+        LHS[-1,:] = 0.0 
+        LHS[-1,-1] = -phia*L_inductance/(VpEtapar) - B2*dt/(phia*ds) - mu0*pp*dt/phia
+        LHS[-1,-2] = B2*dt / (phia*ds)
+        LHS = LHS.tocsr()
+        
+        # Solve
+        I_solution = np.zeros((Nt,Ns)) # initial condition is I(t=0,s) = 0.0
+        #
+        for i in range(1,Nt):
+            I_solution[i,:] = spsolve(LHS, RHS.dot(I_solution[i-1,:]) + SOURCE)
+            
+        return t_solver, I_solution
+    
 # THRIFT Class
 class THRIFT_plasma_solver():
     """" Class for working with plasma solver implemented in THRIFT


### PR DESCRIPTION
This merge brings the following major changes to `THRIFT`:
- Fixes `thrift_bootsj` (the sign of JBS.B was not being considered!)
- `thrift_penta` is now faster. Before, when the plasma solver was ON and add_NEO=True, the electric field was computed every dt_plasma, which would make simulations with NEO fluxes very slow and infeasible. Now, a new ambipolar solution is only computed at every dt_THRIFT
- `penta_interface_mod` is now more robust, as it allows any number of odd Er solutions (before an error was given if number of solution was larger than 5)

`pySTEL`  has also been upgraded, namely the `thrift`, `dkes` and `plasma` classes.