### PR TITLE
STELLOPT: Added function type vmec_provided

### DIFF
--- a/STELLOPTV2/Sources/General/stellopt_balloon.f90
+++ b/STELLOPTV2/Sources/General/stellopt_balloon.f90
@@ -52,7 +52,7 @@
       IF (iflag < 0) RETURN
       IF (lscreen) WRITE(6,'(a)') ' ---------------------------  BALLOONING CALCULATION  ------------------------'
       SELECT CASE(TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
             lscreen_cobra = lscreen
             sigma_balloon(1) = bigno  ! Don't do the first surface (aka magaxis)
             ! First we need to initialize the COBRA variables

--- a/STELLOPTV2/Sources/General/stellopt_bootsj.f90
+++ b/STELLOPTV2/Sources/General/stellopt_bootsj.f90
@@ -63,7 +63,7 @@
       IF (iflag < 0) RETURN
       IF (lscreen) WRITE(6,'(a)') ' --------------------  BOOTSTRAP CALCULATION USING BOOTSJ  -------------------'
       SELECT CASE(TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
             ! Get the data into bootsj
             call second0 (time1)
             timecpu = time1

--- a/STELLOPTV2/Sources/General/stellopt_cas3d.f90
+++ b/STELLOPTV2/Sources/General/stellopt_cas3d.f90
@@ -34,7 +34,7 @@
       IF (iflag < 0) RETURN
       IF (lscreen) WRITE(6,'(a)') ' ---------------------------  STABILITY (CAS3D) CALCULATION  -------------------------'
       SELECT CASE(TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','vmec2000_oneeq','vmec_provided')
             CALL safe_open(iunit_rzuv, ier, 'for_cas3d_rzuv.dat','replace','formatted')
             WRITE(iunit_rzuv,*) 
 

--- a/STELLOPTV2/Sources/General/stellopt_fcn.f90
+++ b/STELLOPTV2/Sources/General/stellopt_fcn.f90
@@ -403,6 +403,11 @@
                   CALL stellopt_prof_to_vmec(proc_string,iflag)
                   iflag = 0
                END IF
+            CASE('vmec_provided')
+               CALL read_wout_deallocate
+               CALL read_wout_file(TRIM(id_string),iflag)
+               CALL write_wout_file('wout_'//TRIM(proc_string)//'.nc',iflag)
+               CALL stellopt_prof_to_vmec(proc_string,iflag)
             CASE('spec')
             CASE('test')
                !Do Nothing

--- a/STELLOPTV2/Sources/General/stellopt_init.f90
+++ b/STELLOPTV2/Sources/General/stellopt_init.f90
@@ -82,7 +82,7 @@
       ! Read the Equilibrium input
       CALL tolower(equil_type)
       SELECT CASE (TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vmec2000_oneeq','vmec_provided')
               ltst = .false.
               tstr1 = 'parvmec_init'
               id_string = id_string(7:LEN(id_string))
@@ -121,7 +121,7 @@
       iter  = 0
       nvars = 0
       SELECT CASE (TRIM(equil_type))
-         CASE('vmec2000','flow','animec','satire','paravmec','parvmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','flow','animec','satire','paravmec','parvmec','vboot','vmec2000_oneeq','vmec_provided')
               ! Single Values
               IF (lphiedge_opt) nvars = nvars + 1
               IF (lcurtor_opt)  nvars = nvars + 1
@@ -239,7 +239,7 @@
       ! Initialize nvar_in to 0
       nvar_in=0
       SELECT CASE (TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','paravmec','parvmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','paravmec','parvmec','vboot','vmec2000_oneeq','vmec_provided')
               ! Set some defaults
               IF (ncurr /= 0 .and. ANY(lai_opt)) lai_opt(:) = .false.
               IF (ncurr /= 0 .and. ANY(lai_f_opt)) lai_f_opt(:) = .false.

--- a/STELLOPTV2/Sources/General/stellopt_kink.f90
+++ b/STELLOPTV2/Sources/General/stellopt_kink.f90
@@ -57,7 +57,7 @@
       wp_kink = 0; wk_kink = 0; growth_kink = 0; omega_kink = 0;
       IF (lscreen) WRITE(6,'(a)') ' ---------------------------  KINK STABILITY  -------------------------'
       SELECT CASE(TRIM(equil_type))
-         CASE('vmec2000','parvmec','paravmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
 !DEC$ IF DEFINED (TERPSICHORE)
             ! Setup TERPSICHORE Variables
 !DEC$ IF DEFINED (MPI_OPT)

--- a/STELLOPTV2/Sources/General/stellopt_load_equil.f90
+++ b/STELLOPTV2/Sources/General/stellopt_load_equil.f90
@@ -98,7 +98,7 @@
       IF (iflag < 0) RETURN
       ier = 0
       SELECT CASE (TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
             ! Read the VMEC output
             CALL read_wout_deallocate
             CALL read_wout_file(TRIM(proc_string),ier)

--- a/STELLOPTV2/Sources/General/stellopt_magdiags.f90
+++ b/STELLOPTV2/Sources/General/stellopt_magdiags.f90
@@ -70,7 +70,7 @@
       IF (lverb_diagno) write(6,'(A)')' - Loading equilibrium surface'
       IF (lverb_diagno) CALL FLUSH(6)
       SELECT CASE(TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
             ! Assume diagno_input namelist already read
             !id_string_diagno=TRIM(input_extension)
             CALL diagno_init_vmec

--- a/STELLOPTV2/Sources/General/stellopt_neo.f90
+++ b/STELLOPTV2/Sources/General/stellopt_neo.f90
@@ -62,7 +62,7 @@
 !DEC$ IF DEFINED (NEO_OPT)
       IF (lscreen) WRITE(6,'(a)') ' ---------------------  NEOCLASSICAL TRANSPORT CALCULATION  ------------------'
       SELECT CASE(TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
 !DEC$ IF DEFINED (MPI_OPT)
             CALL BCAST_NEOIN_INPUT(master,MPI_COMM_MYWORLD,ierr_mpi)
             CALL MPI_COMM_SIZE( MPI_COMM_MYWORLD, numprocs_local, ierr_mpi )
@@ -480,6 +480,9 @@
                  CLOSE(w_u9)
                END IF
             END IF
+            ! Do this so we always use boozer spectrum.
+            max_m_mode = 0
+            max_n_mode = 0
             CALL neo_dealloc
             no_fluxs = 0  ! For next pass through
             IF (lscreen) WRITE(6,'(A)')           '------------------------------------------------------------------'

--- a/STELLOPTV2/Sources/General/stellopt_sfincs.f90
+++ b/STELLOPTV2/Sources/General/stellopt_sfincs.f90
@@ -71,7 +71,7 @@
       IF (iflag < 0) RETURN
       IF (lscreen) WRITE(6,'(a)') ' ---------------------  BOOTSTRAP CALCULATION USING SFINCS  ------------------'
       SELECT CASE(TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
 
             base_directory_string = 'sfincs_'//TRIM(proc_string)
             IF (myworkid == master) CALL execute_command_line('mkdir -p ' //TRIM(base_directory_string)) ! The -p blocks a warning message if the directory already exists.

--- a/STELLOPTV2/Sources/General/stellopt_toboozer.f90
+++ b/STELLOPTV2/Sources/General/stellopt_toboozer.f90
@@ -57,7 +57,7 @@
       IF (iflag < 0) RETURN
       IF (lscreen) WRITE(6,'(a)') ' ---------------------------  BOOZER TRANSFORMATION  -------------------------'
       SELECT CASE(TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
             lscreen_xboozer = lscreen
             ! We need to pass mboz and nboz to the boozer routines
             mboz_xboozer = mboz

--- a/STELLOPTV2/Sources/General/stellopt_travis.f90
+++ b/STELLOPTV2/Sources/General/stellopt_travis.f90
@@ -50,7 +50,7 @@
       IF (iflag < 0) RETURN
       IF (lscreen) WRITE(6,'(a)') ' ----------------------------  ECE (TRAVIS) CALCULATION  -------------------------'
       SELECT CASE(TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
 #if defined(TRAVIS)
 
             ! Count work to be done

--- a/STELLOPTV2/Sources/General/stellopt_txport.f90
+++ b/STELLOPTV2/Sources/General/stellopt_txport.f90
@@ -135,7 +135,7 @@
       IF (ALLOCATED(txport_q)) DEALLOCATE(txport_q)
       IF (ALLOCATED(txport_q_all)) DEALLOCATE(txport_q_all)
       SELECT CASE(TRIM(equil_type))
-         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq')
+         CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
             !IF (lscreen) WRITE(6,'(A)') '     s    alpha0   iota    shear    Bref    Lref  Q_turb'
             maxPnt = nz_txport
             dtheta = pi2/maxPnt

--- a/STELLOPTV2/Sources/General/stellopt_write_eqfile.f90
+++ b/STELLOPTV2/Sources/General/stellopt_write_eqfile.f90
@@ -45,7 +45,7 @@
             CALL runvmec(vctrl_array,proc_string,.false.,MPI_COMM_SELF,'')
          CASE('parvmec','paravmec','vmec2000','vboot')
             CALL stellopt_paraexe('paravmec_write',proc_string,.false.)
-         CASE('vmec2000_oneeq')
+         CASE('vmec2000_oneeq','vmec_provided')
             CALL read_wout_deallocate
             CALL read_wout_file(TRIM(proc_string_old),ier)
             CALL write_wout_file('wout_'//TRIM(proc_string)//'.nc',ier)

--- a/STELLOPTV2/Sources/General/stellopt_write_inputfile.f90
+++ b/STELLOPTV2/Sources/General/stellopt_write_inputfile.f90
@@ -53,7 +53,7 @@
       END IF
       CALL safe_open(iunit_out,ier,TRIM('input.'//TRIM(proc_string)),'unknown','formatted')
          SELECT CASE(TRIM(equil_type))
-            CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq')
+            CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
                CALL RESCALE_BOUNDARY ! Necssary for output file to have correct RBC/ZBS
                CALL write_indata_namelist(iunit_out,ier)
             CASE('test')


### PR DESCRIPTION
This pull request adds the ability to provide STELLOPT a wout file so that it only reads this one file. This was suggested by @MaxRang as the MANGO optimizers would run VMEC every iteration when doing coil optimiziation even when one_iter was set. To use you must provide a VMEC wout file in the same directory with the same name as the input file.  Then you need to set `EQUIL_TYPE='vmec_provided'` in the `&OPTIMUM` namelist.  For example if your input file is called `input.MY_TESTCASE` you need a VMEC wout file called `wout_MY_TESTCASE.nc` or `wout.MY_TESTCASE` in the run directory.