### PR TITLE
FIELDLINES: Implemented scaling factor for mumaterial B-fields.

### DIFF
--- a/FIELDLINES/Sources/fieldlines_init_mumat.f90
+++ b/FIELDLINES/Sources/fieldlines_init_mumat.f90
@@ -210,9 +210,9 @@
          CALL mumaterial_getbmag_scalar(x_temp, y_temp, z_temp, bx_temp, by_temp, bz_temp)
          br_temp   = bx_temp*cos(phiaxis(j)) + by_temp*sin(phiaxis(j))
          bphi_temp = by_temp*cos(phiaxis(j)) - bx_temp*sin(phiaxis(j))
-         B_R(i,j,k)   =  br_temp   + B_R(i,j,k) * mumaterital_scale
-         B_PHI(i,j,k) =  bphi_temp + B_PHI(i,j,k) * mumaterital_scale
-         B_Z(i,j,k)   =  bz_temp   + B_Z(i,j,k) * mumaterital_scale 
+         B_R(i,j,k)   =  br_temp   + B_R(i,j,k) * mumaterial_scale
+         B_PHI(i,j,k) =  bphi_temp + B_PHI(i,j,k) * mumaterial_scale
+         B_Z(i,j,k)   =  bz_temp   + B_Z(i,j,k) * mumaterial_scale 
          IF (lverb .and. (MOD(s,nr) == 0)) THEN
             CALL backspace_out(6,6)
             WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'

--- a/FIELDLINES/Sources/fieldlines_init_mumat.f90
+++ b/FIELDLINES/Sources/fieldlines_init_mumat.f90
@@ -210,9 +210,9 @@
          CALL mumaterial_getbmag_scalar(x_temp, y_temp, z_temp, bx_temp, by_temp, bz_temp)
          br_temp   = bx_temp*cos(phiaxis(j)) + by_temp*sin(phiaxis(j))
          bphi_temp = by_temp*cos(phiaxis(j)) - bx_temp*sin(phiaxis(j))
-         B_R(i,j,k)   =  br_temp   + B_R(i,j,k) 
-         B_PHI(i,j,k) =  bphi_temp + B_PHI(i,j,k)
-         B_Z(i,j,k)   =  bz_temp   + B_Z(i,j,k) 
+         B_R(i,j,k)   =  br_temp   + B_R(i,j,k) * mumaterital_scale
+         B_PHI(i,j,k) =  bphi_temp + B_PHI(i,j,k) * mumaterital_scale
+         B_Z(i,j,k)   =  bz_temp   + B_Z(i,j,k) * mumaterital_scale 
          IF (lverb .and. (MOD(s,nr) == 0)) THEN
             CALL backspace_out(6,6)
             WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'

--- a/FIELDLINES/Sources/fieldlines_runtime.f90
+++ b/FIELDLINES/Sources/fieldlines_runtime.f90
@@ -55,7 +55,7 @@
          mumaterial_lamthresh, mumaterial_tol, &
          mumaterial_lambda, mumaterial_lamfactor, &
          mumaterial_padfactor, mumaterial_convcheck,&
-         mumaterital_scale
+         mumaterial_scale
 !-----------------------------------------------------------------------
 !     Module Variables
 !          lverb         Logical to control screen output

--- a/FIELDLINES/Sources/fieldlines_runtime.f90
+++ b/FIELDLINES/Sources/fieldlines_runtime.f90
@@ -54,7 +54,8 @@
          mumaterial_niter, mumaterial_nneighbor, &
          mumaterial_lamthresh, mumaterial_tol, &
          mumaterial_lambda, mumaterial_lamfactor, &
-         mumaterial_padfactor, mumaterial_convcheck
+         mumaterial_padfactor, mumaterial_convcheck,&
+         mumaterital_scale
 !-----------------------------------------------------------------------
 !     Module Variables
 !          lverb         Logical to control screen output

--- a/LIBSTELL/Sources/Modules/fieldlines_globals.f90
+++ b/LIBSTELL/Sources/Modules/fieldlines_globals.f90
@@ -39,6 +39,7 @@
       INTEGER :: mumaterial_niter, mumaterial_nneighbor, mumaterial_lamthresh
       REAL(rprec) :: mumaterial_tol, mumaterial_lambda, mumaterial_lamfactor, &
                      mumaterial_padfactor, mumaterial_convcheck
+      REAL(rprec) :: mumaterial_scale
 
 
       CONTAINS

--- a/LIBSTELL/Sources/Modules/fieldlines_input_mod.f90
+++ b/LIBSTELL/Sources/Modules/fieldlines_input_mod.f90
@@ -67,7 +67,7 @@
                                   mumaterial_nneighbor, &
                                   mumaterial_lambda, mumaterial_lamfactor, &
                                   mumaterial_lamthresh, mumaterial_padfactor, &
-                                  mumaterial_convcheck
+                                  mumaterial_convcheck, mumaterial_scale
       
 !-----------------------------------------------------------------------
 !     Subroutines
@@ -118,6 +118,7 @@
       mumaterial_lamfactor = 0.75D+00
       mumaterial_padfactor = 1.0D+00
       mumaterial_convcheck = 99.0D+00
+      mumaterial_scale = 1.0_rprec
 
       int_type = "NAG"
       IF (TRIM(filename) == "") RETURN
@@ -195,6 +196,7 @@
       WRITE(iunit_out,outflt) 'MUMATERIAL_LAMFACTOR',mumaterial_lamfactor
       WRITE(iunit_out,outflt) 'MUMATERIAL_PADFACTOR',mumaterial_padfactor
       WRITE(iunit_out,outflt) 'MUMATERIAL_CONVCHECK',mumaterial_convcheck
+      WRITE(iunit_out,outflt) 'MUMATERIAL_SCALE',mumaterial_scale
       WRITE(iunit_out,'(A)') '!---------- Marker Tracking Parameters ------------'
       WRITE(iunit_out,outstr) 'INT_TYPE',TRIM(int_type)
       WRITE(iunit_out,outflt) 'FOLLOW_TOL',follow_tol
@@ -288,6 +290,7 @@
       CALL MPI_BCAST(mumaterial_tol,1,MPI_REAL8, local_master, MPI_COMM_FIELDLINES,istat)
       CALL MPI_BCAST(mumaterial_lambda,1,MPI_REAL8, local_master, MPI_COMM_FIELDLINES,istat)
       CALL MPI_BCAST(mumaterial_lamfactor,1,MPI_REAL8, local_master, MPI_COMM_FIELDLINES,istat)
+      CALL MPI_BCAST(mumaterial_scale,1,MPI_REAL8, local_master, MPI_COMM_FIELDLINES,istat)
 #endif
       END SUBROUTINE BCAST_FIELDLINES_INPUT
 


### PR DESCRIPTION
This pull request adds a scalar to the FIELDLINES_INPUT namelist called `mumaterial_scale` which linearly scales the B-field calculated from the magnetic material. This is done to mimic the effect of the material having less material. The default value is `1.0` so that not setting this values has the intended behavior.