### PR TITLE
Feature/stellopt load eq UI l

### DIFF
--- a/LIBSTELL/Sources/STELLOPT/stellopt_input_mod.f90
+++ b/LIBSTELL/Sources/STELLOPT/stellopt_input_mod.f90
@@ -380,7 +380,7 @@
                          zeta_coil_kts, zeta_coil_kts_min, zeta_coil_kts_max, &
                          nw_coil, nh_coil, width_coil, height_coil, &
                          lfix_rho_coil, lfix_theta_coil, lfix_zeta_coil, lpoincare, &
-                         nu_bnormal, nv_bnormal, &
+                         lload_equil, nu_bnormal, nv_bnormal, &
                          target_bnormal, sigma_bnormal, &
                          target_bnmns, sigma_bnmns, target_bnmnc, sigma_bnmnc,  &
                          target_coil_curvature, sigma_coil_curvature, &
@@ -417,6 +417,7 @@
       noptimizers     = -1
       refit_param     = 0.75
       rho_exp         = 4
+      lload_equil     = .TRUE.
       lcentered_differences = .FALSE.
       lexp_scale      = .FALSE.
       exp_alpha       = 0.0

--- a/LIBSTELL/Sources/STELLOPT/stellopt_vars.f90
+++ b/LIBSTELL/Sources/STELLOPT/stellopt_vars.f90
@@ -184,7 +184,8 @@
       REAL(rprec), DIMENSION(-NMAX_CS:NMAX_CS,0:MMAX_CS) :: ZBS_COILSURF_MAX
 
       ! Variables for defining the coils
-      LOGICAL :: lcreate_coils, lfix_rho_coil, lfix_theta_coil, lfix_zeta_coil, lpoincare
+      LOGICAL :: lcreate_coils, lfix_rho_coil, lfix_theta_coil, &
+        lfix_zeta_coil, lpoincare, lload_equil
       INTEGER :: nw_coil
       INTEGER :: nh_coil
       REAL(rprec) :: width_coil

--- a/STELLOPTV2/Sources/General/stellopt_load_equil.f90
+++ b/STELLOPTV2/Sources/General/stellopt_load_equil.f90
@@ -97,7 +97,7 @@
 !----------------------------------------------------------------------
       IF (iflag < 0) RETURN
       ier = 0
-      SELECT CASE (TRIM(equil_type))
+      CASE1: SELECT CASE (TRIM(equil_type))
          CASE('vmec2000','animec','flow','satire','parvmec','paravmec','vboot','vmec2000_oneeq','vmec_provided')
             ! Read the VMEC output
             CALL read_wout_deallocate
@@ -130,6 +130,7 @@
             wp      = 1.5_rprec*pi2*pi2*SUM(vp_vmec(2:nrad)*presh_vmec(2:nrad))/(nrad-1) ! Old STELLOPT Way
             rbtor   = rbtor_vmec
             Baxis   = 0.5*SUM(3*bmnc_vmec(:,2)-bmnc_vmec(:,3),1) ! Asymmetric part zero at phi=0
+            IF (.not.lload_equil) CONTINUE
             ! May need to create some radial arrays
             IF (ALLOCATED(rho)) DEALLOCATE(rho)
             IF (ALLOCATED(shat)) DEALLOCATE(shat)
@@ -352,7 +353,7 @@
          CASE('siesta')
          CASE('test')
             ! Do nothing
-      END SELECT
+      END SELECT CASE1
       ! Setup the internal STELLOPT arrays
       dex = MINLOC(phi_aux_s(2:),DIM=1)
       IF (dex > 2) CALL setup_prof_spline(phi_spl,dex,phi_aux_s(1:dex),phi_aux_f(1:dex),ier)


### PR DESCRIPTION
This adds the OPTIMUM namelist parameter `LLOAD_EQUIL` to STELLOPT. The default value is `TRUE`.  When set to `FALSE` will cause the code to skip loading arrays which are not necessary when doing coil optimization.