### PR TITLE
Fix VMEC volume-current harmonics setup

### DIFF
--- a/DIAGNO/Sources/diagno_init_vmec.f90
+++ b/DIAGNO/Sources/diagno_init_vmec.f90
@@ -158,7 +158,9 @@
          END IF
          IF (lnyquist) THEN
             xm_temp = xm_nyq
-            xn_temp = -xn_nyq/nfp ! Because init_virtual_casing uses (mu+nv) not (mu-nv*nfp)
+            ! init_volint samples phi over the full torus, unlike the
+            ! one-field-period surface virtual-casing path.
+            xn_temp = -xn_nyq
             DO u = 1,mnmax_temp
                DO v = 1, mnmax
                   IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
@@ -173,7 +175,9 @@
             END DO
          ELSE
             xm_temp = xm
-            xn_temp = -xn/nfp
+            ! init_volint samples phi over the full torus, unlike the
+            ! one-field-period surface virtual-casing path.
+            xn_temp = -xn
             rmnc_temp = rmnc
             zmns_temp = zmns
          END IF

--- a/LIBSTELL/Sources/Modules/read_wout_mod.f90
+++ b/LIBSTELL/Sources/Modules/read_wout_mod.f90
@@ -219,10 +219,10 @@
         ln_bsubvmns = 'sinmn covariant v-component of B, half mesh',    &
         ln_bsubsmnc = 'cosmn covariant s-component of B, half mesh',    &
 
-        ln_currumnc = 'cosmn sqrt(g)*contravariant u-component of J, full mesh', &
-        ln_currumns = 'sinmn sqrt(g)*contravariant u-component of J, full mesh', &
-        ln_currvmnc = 'cosmn sqrt(g)*contravariant v-component of J, full mesh', &
-        ln_currvmns = 'sinmn sqrt(g)*contravariant v-component of J, full mesh', &
+        ln_currumnc = 'cosmn contravariant u-component of J, full mesh', &
+        ln_currumns = 'sinmn contravariant u-component of J, full mesh', &
+        ln_currvmnc = 'cosmn contravariant v-component of J, full mesh', &
+        ln_currvmns = 'sinmn contravariant v-component of J, full mesh', &
 
         ln_bsubumns_sur = 'sinmn covaiant u-component of B, surface',   &
         ln_bsubvmns_sur = 'sinmn covaiant v-component of B, surface',   &

--- a/LIBSTELL/Sources/Modules/read_wout_mod.f90
+++ b/LIBSTELL/Sources/Modules/read_wout_mod.f90
@@ -219,10 +219,10 @@
         ln_bsubvmns = 'sinmn covariant v-component of B, half mesh',    &
         ln_bsubsmnc = 'cosmn covariant s-component of B, half mesh',    &
 
-        ln_currumnc = 'cosmn covariant u-component of J, full mesh',    &
-        ln_currumns = 'sinmn covariant u-component of J, full mesh',    &
-        ln_currvmnc = 'cosmn covariant v-component of J, full mesh',    &
-        ln_currvmns = 'sinmn covariant v-component of J, full mesh',    &
+        ln_currumnc = 'cosmn sqrt(g)*contravariant u-component of J, full mesh', &
+        ln_currumns = 'sinmn sqrt(g)*contravariant u-component of J, full mesh', &
+        ln_currvmnc = 'cosmn sqrt(g)*contravariant v-component of J, full mesh', &
+        ln_currvmns = 'sinmn sqrt(g)*contravariant v-component of J, full mesh', &
 
         ln_bsubumns_sur = 'sinmn covaiant u-component of B, surface',   &
         ln_bsubvmns_sur = 'sinmn covaiant v-component of B, surface',   &
@@ -3161,4 +3161,3 @@
       END SUBROUTINE LoadRZL
 
       END MODULE read_wout_mod
-

--- a/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
+++ b/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
@@ -41,7 +41,7 @@
 !                    xn_temp = -xn_nyq/nfp
 !                    ! Copy rmnc/zmns into matching rows of the Nyquist basis;
 !                    ! leave geometry rows with no matching VMEC mode at zero.
-!                    ! currumnc/currvmnc are sqrt(g)*J^u/v on the Nyquist grid.
+!                    ! currumnc/currvmnc are contravariant current harmonics on the Nyquist grid.
 !                    jumnc_temp = isigng*currumnc
 !                    jvmnc_temp = isigng*currvmnc
 !                    CALL init_volint(mnmax_temp,nu2,nv2,ns,xm_temp,xn_temp, &

--- a/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
+++ b/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
@@ -34,16 +34,17 @@
 !
 !                    To load an equilibrium using current density from VMEC
 !
-!                    ALLOCATE(xm_temp(mnmax),xn_temp(mnmax)) ! Integer Arrays
-!                    ALLOCATE(rmnc_temp(mnmax,ns),zmns_temp(mnmax,ns)) ! DOUBLE PRECISION
-!                    ALLOCATE(jumnc_temp(mnmax,ns),jvmnc_temp(mnmax,ns)) ! DOUBLE PRECISION
-!                    xm_temp = xm
-!                    xn_temp = -xn
-!                    rmnc_temp = rmnc
-!                    zmns_temp = zmns
+!                    ALLOCATE(xm_temp(mnmax_temp),xn_temp(mnmax_temp)) ! Integer Arrays
+!                    ALLOCATE(rmnc_temp(mnmax_temp,ns),zmns_temp(mnmax_temp,ns))
+!                    ALLOCATE(jumnc_temp(mnmax_temp,ns),jvmnc_temp(mnmax_temp,ns))
+!                    xm_temp = xm_nyq
+!                    xn_temp = -xn_nyq/nfp
+!                    ! Copy rmnc/zmns into matching rows of the Nyquist basis;
+!                    ! leave geometry rows with no matching VMEC mode at zero.
+!                    ! currumnc/currvmnc are sqrt(g)*J^u/v on the Nyquist grid.
 !                    jumnc_temp = isigng*currumnc
 !                    jvmnc_temp = isigng*currvmnc
-!                    CALL init_volint(mnmax,nu2,nv2,ns,xm_temp,xn_temp, &
+!                    CALL init_volint(mnmax_temp,nu2,nv2,ns,xm_temp,xn_temp, &
 !                                     rmnc_temp,zmns_temp,nfp,&
 !                                     JUMNC=jumnc_temp, JVMNC=jvmnc_temp)
 !

--- a/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
+++ b/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
@@ -38,7 +38,7 @@
 !                    ALLOCATE(rmnc_temp(mnmax_temp,ns),zmns_temp(mnmax_temp,ns))
 !                    ALLOCATE(jumnc_temp(mnmax_temp,ns),jvmnc_temp(mnmax_temp,ns))
 !                    xm_temp = xm_nyq
-!                    xn_temp = -xn_nyq/nfp
+!                    xn_temp = -xn_nyq
 !                    ! Copy rmnc/zmns into matching rows of the Nyquist basis;
 !                    ! leave geometry rows with no matching VMEC mode at zero.
 !                    ! currumnc/currvmnc are contravariant current harmonics on the Nyquist grid.
@@ -2019,10 +2019,12 @@
             FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -zmnc(mn,:)*xn(mn)
             CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,zv,1,0)
          END IF
+         ! init_volint reconstructs a full torus, so rv/zv are already
+         ! derivatives with respect to the full-torus toroidal coordinate.
          ! Calculate jr, jphi, jz, jx, jy
-         jr   = ju_temp*ru+jv_temp*rv*nfp
+         jr   = ju_temp*ru+jv_temp*rv
          jphi = r_temp * jv_temp
-         jz   = ju_temp*zu+jv_temp*zv*nfp
+         jz   = ju_temp*zu+jv_temp*zv
          DO u = 1, nu
             DO v = 1, nvp
                cop = DCOS(pi2*xv(v))
@@ -2203,7 +2205,7 @@
       ! non Hermite Quatitites
       cx = xparam*(xp2-1); cxi = xpi*(xpi2-1); hx2 = hx*hx
       cy = yparam*(yp2-1); cyi = ypi*(ypi2-1); hy2 = hy*hy
-      cy = zparam*(zp2-1); czi = zpi*(zpi2-1); hz2 = hz*hz
+      cz = zparam*(zp2-1); czi = zpi*(zpi2-1); hz2 = hz*hz
       xs  =  evaltri3D(xparam, xpi, xp2, xpi2, cx, cxi, hx2, &
                        yparam, ypi, yp2, ypi2, cy, cyi, hy2, &
                        zparam, zpi, zp2, zpi2, cz, czi, hz2, &
@@ -2292,7 +2294,7 @@
       ! non Hermite Quatitites
       cx = xparam*(xp2-1); cxi = xpi*(xpi2-1); hx2 = hx*hx
       cy = yparam*(yp2-1); cyi = ypi*(ypi2-1); hy2 = hy*hy
-      cy = zparam*(zp2-1); czi = zpi*(zpi2-1); hz2 = hz*hz
+      cz = zparam*(zp2-1); czi = zpi*(zpi2-1); hz2 = hz*hz
       xs  =  evaltri3D(xparam, xpi, xp2, xpi2, cx, cxi, hx2, &
                        yparam, ypi, yp2, ypi2, cy, cyi, hy2, &
                        zparam, zpi, zp2, zpi2, cz, czi, hz2, &

--- a/TORLINES/Sources/torlines_init_wout.f90
+++ b/TORLINES/Sources/torlines_init_wout.f90
@@ -410,7 +410,7 @@
          END IF
          IF (lnyquist) THEN
             xm_temp = xm_nyq
-            xn_temp = -xn_nyq/nfp
+            xn_temp = -xn_nyq/nfp ! init_volint uses (m*u+n*v), not VMEC's (m*u-n*v*NFP)
             DO u = 1, mnmax_temp
                DO v = 1, mnmax
                   IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
@@ -425,7 +425,7 @@
             END DO
          ELSE
             xm_temp = xm
-            xn_temp = -xn/nfp
+            xn_temp = -xn/nfp ! init_volint uses (m*u+n*v), not VMEC's (m*u-n*v*NFP)
             rmnc_temp = rmnc
             zmns_temp = zmns
             IF (lasym) THEN

--- a/TORLINES/Sources/torlines_init_wout.f90
+++ b/TORLINES/Sources/torlines_init_wout.f90
@@ -53,9 +53,10 @@
 !-----------------------------------------------------------------------
       IMPLICIT NONE
       INTEGER :: iunit, ier, mn, im, in, ik , i, j, ns1, k1,mn0,&
-                 u,v
+                 mnmax_temp, u,v
       INTEGER :: bcs1(2)
       INTEGER, ALLOCATABLE :: xn_temp(:), xm_temp(:)
+      LOGICAL :: lnyquist
       REAL(rprec) :: val1, val2, dval, scale, rhomax, dr, f0_temp, dz,&
                      alvb, b1, c1, re, ae, r1, alub
       REAL(rprec), ALLOCATABLE :: mfact(:,:)
@@ -69,6 +70,8 @@
       REAL(rprec), ALLOCATABLE :: bsmns_temp(:,:)
       REAL(rprec), ALLOCATABLE :: bumnc_temp(:,:), bvmnc_temp(:,:)
       REAL(rprec), ALLOCATABLE :: bmnc_temp(:,:), bmns_temp(:,:)
+      REAL(rprec), ALLOCATABLE :: jumnc_temp(:,:), jvmnc_temp(:,:)
+      REAL(rprec), ALLOCATABLE :: jumns_temp(:,:), jvmns_temp(:,:)
       DOUBLE PRECISION, ALLOCATABLE :: rmnc_tempr(:,:), zmns_tempr(:,:)
       DOUBLE PRECISION, ALLOCATABLE :: rmns_tempr(:,:), zmnc_tempr(:,:)
       DOUBLE PRECISION, ALLOCATABLE :: bsupumnc_tempr(:,:), bsupvmnc_tempr(:,:)
@@ -130,7 +133,7 @@
 
       ! Now do grid
       DO ik = 2, ns-1
-         WHERE (MOD(NINT(REAL(xm_temp(:))),2) .eq. 0)
+         WHERE (MOD(NINT(REAL(xm_nyq(:))),2) .eq. 0)
             mfact(:,1)= 0.5
             mfact(:,2)= 0.5
          ELSEWHERE
@@ -142,15 +145,15 @@
       END DO
 
       ! Now do edgek = ns_vmec
-      WHERE (MOD(NINT(REAL(xm_temp(:))),2) .eq. 0)
+      WHERE (MOD(NINT(REAL(xm_nyq(:))),2) .eq. 0)
          mfact(:,1)= 2.0 ! ns (half grid point)
          mfact(:,2)=-1.0 ! ns-1 (full grid point)
       ELSEWHERE
          mfact(:,1)= 2.0*SQRT((ns-1)/(ns-1.5))
          mfact(:,2)=-1.0*SQRT((ns-1)/(ns-2.0))
       ENDWHERE
-      bsupumnc(:,ns) = mfact(:,ns)*bsupumnc(:,ns)+mfact(:,2)*bsupumnc(:,ns-1)
-      bsupvmnc(:,ns) = mfact(:,ns)*bsupvmnc(:,ns)+mfact(:,2)*bsupvmnc(:,ns-1)
+      bsupumnc(:,ns) = mfact(:,1)*bsupumnc(:,ns)+mfact(:,2)*bsupumnc(:,ns-1)
+      bsupvmnc(:,ns) = mfact(:,1)*bsupvmnc(:,ns)+mfact(:,2)*bsupvmnc(:,ns-1)
       DEALLOCATE(mfact)
 
       ! Get fields on full mesh
@@ -382,19 +385,77 @@
          IF (adapt_rel < 0.0) adapt_tol = -1.0
          MIN_CLS = 0
       ELSE IF (.not.lvac .and. .not.lvc_field .and. (bound_separation > 1)) THEN
-         ALLOCATE(xm_temp(mnmax),xn_temp(mnmax), STAT=ier)
-         xm_temp = xm
-         xn_temp = -xn
+         IF (SIZE(xm_nyq) > SIZE(xm)) THEN
+            mnmax_temp = SIZE(xm_nyq)
+            lnyquist = .true.
+         ELSE
+            mnmax_temp = mnmax
+            lnyquist = .false.
+         END IF
+         ALLOCATE(xm_temp(mnmax_temp),xn_temp(mnmax_temp), STAT=ier)
+         IF (ier /= 0) CALL handle_err(ALLOC_ERR,'XM_TEMP XN_TEMP',ier)
+         ALLOCATE(rmnc_temp(mnmax_temp,ns),zmns_temp(mnmax_temp,ns),&
+                  jumnc_temp(mnmax_temp,ns),jvmnc_temp(mnmax_temp,ns),&
+                  STAT=ier)
+         IF (ier /= 0) CALL handle_err(ALLOC_ERR,'VOLINT VMEC TEMP',ier)
+         rmnc_temp = 0; zmns_temp = 0
+         jumnc_temp = 0; jvmnc_temp = 0
+         IF (lasym) THEN
+            ALLOCATE(rmns_temp(mnmax_temp,ns),zmnc_temp(mnmax_temp,ns),&
+                     jumns_temp(mnmax_temp,ns),jvmns_temp(mnmax_temp,ns),&
+                     STAT=ier)
+            IF (ier /= 0) CALL handle_err(ALLOC_ERR,'VOLINT VMEC ASYM TEMP',ier)
+            rmns_temp = 0; zmnc_temp = 0
+            jumns_temp = 0; jvmns_temp = 0
+         END IF
+         IF (lnyquist) THEN
+            xm_temp = xm_nyq
+            xn_temp = -xn_nyq/nfp
+            DO u = 1, mnmax_temp
+               DO v = 1, mnmax
+                  IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
+                     rmnc_temp(u,:) = rmnc(v,:)
+                     zmns_temp(u,:) = zmns(v,:)
+                     IF (lasym) THEN
+                        rmns_temp(u,:) = rmns(v,:)
+                        zmnc_temp(u,:) = zmnc(v,:)
+                     END IF
+                  END IF
+               END DO
+            END DO
+         ELSE
+            xm_temp = xm
+            xn_temp = -xn/nfp
+            rmnc_temp = rmnc
+            zmns_temp = zmns
+            IF (lasym) THEN
+               rmns_temp = rmns
+               zmnc_temp = zmnc
+            END IF
+         END IF
+         jumnc_temp = isigng*currumnc
+         jvmnc_temp = isigng*currvmnc
          MIN_CLS = 0
          IF (lasym) THEN
-             CALL init_volint(mnmax,nu_vc,nv_vc,ns,xm_temp,xn_temp,rmnc,zmns,nfp,&
-                              JUMNC=isigng*currumnc, JVMNC=isigng*currvmnc,&
-                              RMNS=rmns,ZMNC=zmnc,&
-                              JUMNS=isigng*currumns, JVMNS=isigng*currvmns)
+             jumns_temp = isigng*currumns
+             jvmns_temp = isigng*currvmns
+             CALL init_volint(mnmax_temp,nu_vc,nv_vc,ns,xm_temp,xn_temp,&
+                              rmnc_temp,zmns_temp,nfp,&
+                              JUMNC=jumnc_temp, JVMNC=jvmnc_temp,&
+                              RMNS=rmns_temp,ZMNC=zmnc_temp,&
+                              JUMNS=jumns_temp, JVMNS=jvmns_temp,&
+                              COMM=MPI_COMM_FIELDLINES)
+             DEALLOCATE(rmns_temp,zmnc_temp)
+             DEALLOCATE(jumns_temp,jvmns_temp)
          ELSE
-             CALL init_volint(mnmax,nu_vc,nv_vc,ns,xm_temp,xn_temp,rmnc,zmns,nfp,&
-                              JUMNC=isigng*currumnc, JVMNC=isigng*currvmnc)
+             CALL init_volint(mnmax_temp,nu_vc,nv_vc,ns,xm_temp,xn_temp,&
+                              rmnc_temp,zmns_temp,nfp,&
+                              JUMNC=jumnc_temp, JVMNC=jvmnc_temp,&
+                              COMM=MPI_COMM_FIELDLINES)
          END IF
+         DEALLOCATE(rmnc_temp,zmns_temp)
+         DEALLOCATE(jumnc_temp,jvmnc_temp)
+         DEALLOCATE(xm_temp,xn_temp)
          adapt_tol = 0.0
          adapt_rel = vc_adapt_tol
       END IF
@@ -440,7 +501,7 @@
       CALL MPI_BARRIER(MPI_COMM_SHARMEM,ierr_mpi)
 #endif
       DEALLOCATE(bsupumnc_temp,bsupvmnc_temp, bmnc_temp)
-      IF (ALLOCATED(rmns_temp)) DEALLOCATE(bsupumns_temp,bsupvmns_temp, bmns_temp)
+      IF (ALLOCATED(bsupumns_temp)) DEALLOCATE(bsupumns_temp,bsupvmns_temp, bmns_temp)
       ! Calculated the external surfaces
       IF (bound_separation > 1) THEN
          ! Try recalcing the exterior surfaces

--- a/TORLINES/Sources/torlines_init_wout.f90
+++ b/TORLINES/Sources/torlines_init_wout.f90
@@ -410,7 +410,8 @@
          END IF
          IF (lnyquist) THEN
             xm_temp = xm_nyq
-            xn_temp = -xn_nyq/nfp ! init_volint uses (m*u+n*v), not VMEC's (m*u-n*v*NFP)
+            ! init_volint samples phi over the full torus.
+            xn_temp = -xn_nyq
             DO u = 1, mnmax_temp
                DO v = 1, mnmax
                   IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
@@ -425,7 +426,8 @@
             END DO
          ELSE
             xm_temp = xm
-            xn_temp = -xn/nfp ! init_volint uses (m*u+n*v), not VMEC's (m*u-n*v*NFP)
+            ! init_volint samples phi over the full torus.
+            xn_temp = -xn
             rmnc_temp = rmnc
             zmns_temp = zmns
             IF (lasym) THEN


### PR DESCRIPTION
## Summary

This PR fixes the VMEC finite-beta volume-current setup used by TORLINES and the shared VMEC volume-integral path.

The TORLINES-side fix is still the original one: the finite-beta volume-current branch now uses the VMEC Nyquist current basis consistently.

- use `mnmax_nyq`, `xm_nyq`, and `xn_nyq` for `currumnc/currvmnc`
- map `rmnc/zmns` geometry harmonics from the VMEC geometry basis onto the Nyquist basis before calling `init_volint`
- pass current arrays through temporaries whose leading dimensions match `init_volint`
- pass `MPI_COMM_FIELDLINES`, matching the existing virtual-casing path

After running the DIAGNO benchmark requested in review, I found and fixed two shared volume-integral issues as well:

- `init_volint` reconstructs the full torus (`nvp = nv*nfp`, `phi = 2*pi*xv`), so DIAGNO and TORLINES must pass the full VMEC toroidal mode number (`-xn`, `-xn_nyq`) into the volume path. The one-field-period `-xn/nfp` convention remains in the surface virtual-casing path.
- the `rv/zv` basis vectors in `init_volint` are already full-torus derivatives, so the current-vector reconstruction should not multiply the `jv` contribution by another `nfp`
- the adaptive volume-integral vector-potential and B-field integrands had a typo that overwrote `cy` instead of initializing `cz`; that left the z-direction non-Hermite cubic coefficient uninitialized

This PR also keeps the current metadata/docs correction from the earlier commits: `currumnc/currvmnc` are labeled as contravariant current components, not covariant current components. I intentionally did not put `sqrt(g)` into the public netCDF label after review feedback, since `read_wout_mod` may read those arrays directly or compute them through `Compute_Currents`, depending on the wout version.

## Why This Matters

Modern VMEC wout files can store current harmonics on the Nyquist basis:

- geometry: `rmnc/zmns` use `mnmax`, `xm/xn`
- metric/current harmonics: `gmnc`, `currumnc`, `currvmnc` use `mnmax_nyq`, `xm_nyq/xn_nyq`

Before this PR, the TORLINES finite-beta volume-current branch could mislabel current modes and pass arrays whose actual leading dimension did not match the explicit-shape dummy arguments.

The DIAGNO benchmark then exposed that the shared volume-integral path was also mixing two toroidal conventions: the surface virtual-casing code reconstructs one field period and replicates it, while `init_volint` reconstructs the full torus. Those two paths should not use the same `xn/nfp` conversion.

## Verification

Local build checks on this branch:

```bash
make -C DIAGNO release \
  MACHINE=debian \
  MPI_COMPILE=/opt/fenicsx-cuda/petsc/bin/mpifort \
  MPI_COMPILE_FREE='/opt/fenicsx-cuda/petsc/bin/mpifort -ffree-form -ffree-line-length-none -ffixed-line-length-none' \
  MPI_COMPILE_C=/opt/fenicsx-cuda/petsc/bin/mpicc \
  MPI_LINK=/opt/fenicsx-cuda/petsc/bin/mpifort \
  MPI_RUN=/opt/fenicsx-cuda/petsc/bin/mpiexec \
  LHDF5=F \
  LIBS='-L/usr/lib -lopenblas' \
  NETCDF_INC='-I/usr/include' \
  NETCDF_LIB='/usr/lib/x86_64-linux-gnu/libnetcdff.so /usr/lib/x86_64-linux-gnu/libnetcdf.so -lm'
```

That rebuilds `LIBSTELL/Release/libstell.a` and `DIAGNO/Release/xdiagno` successfully. I also compiled the modified TORLINES VMEC initializer object (`TORLINES/Release/torlines_init_wout.o`) locally. A full TORLINES release build on this WSL/MPICH setup reaches the unchanged HDF5 writer code and then stops in `torlines_write.f90` with `fid` not visible from `ez_hdf5`; I did not fold that separate HDF5 build issue into this PR.

### DIAGNO bigtok

```bash
/opt/fenicsx-cuda/petsc/bin/mpiexec -n 8 DIAGNO/Release/xdiagno -vmec bigtok -bench
python3 compare_bigtok.py
```

Result: `STATUS: PASS`.

### DIAGNO NCSX

```bash
/opt/fenicsx-cuda/petsc/bin/mpiexec -n 8 DIAGNO/Release/xdiagno -vmec ncsx -bench
python3 compare_ncsx.py
```

This benchmark is improved substantially but still does not pass the repository's 1% tolerance, so I am not claiming it as a passing benchmark.

Current result after this PR:

- 75 B-field comparison points
- max B-field magnitude error: 4.20%, at the first near-boundary point `(R, phi, Z) = (1.789999962, 0, 0)`
- median B-field magnitude error: 0.089%
- mean B-field magnitude error: 0.270%
- 4/75 B-field points exceed 1%
- no B-field point exceeds 5%
- flux loop 1 differs by 5.45%
- flux loop 2 differs by 0.0155%
- flux loop 3 is skipped by the script because both values are near zero
- final script status: `STATUS: FAIL!!!!!`

For comparison, before the shared volume-integral fixes, the same NCSX benchmark had max B-field error 221.7%, median B-field error 3.94%, 68/75 B-field points over 1%, and flux loop 1 differed by 54.9%.

I also ran a temporary control with `int_type='bode'` and `int_step=1` for the flux-loop line integral. Flux loop 1 stayed at about 5.45%, so the remaining NCSX failure does not appear to be the Simpson-vs-Bode line quadrature choice.

## Remaining Scope

The remaining NCSX mismatch looks concentrated in near-boundary B-field points and in the small diamagnetic-loop net flux after a large cancellation. I would treat that as a remaining DIAGNO virtual-casing-vs-volume benchmark issue, not as fully resolved by this PR.

The W7X DIAGNO case also remains problematic and is a separate path: that wout is version 8.47 and does not contain `currumnc/currvmnc`, so `read_wout_mod` reconstructs the currents through `Compute_Currents` instead of reading stored current arrays.