### PR TITLE
Fix VMEC volume-current harmonics setup

### DIFF
--- a/DIAGNO/Sources/diagno_init_vmec.f90
+++ b/DIAGNO/Sources/diagno_init_vmec.f90
@@ -158,9 +158,9 @@
          END IF
          IF (lnyquist) THEN
             xm_temp = xm_nyq
-            ! init_volint expands field-period modes to full-torus modes
-            ! internally, matching init_virtual_casing's public convention.
-            xn_temp = -xn_nyq/nfp
+            ! init_volint reconstructs a full torus and expects full-torus
+            ! toroidal mode numbers.
+            xn_temp = -xn_nyq
             DO u = 1,mnmax_temp
                DO v = 1, mnmax
                   IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
@@ -175,9 +175,9 @@
             END DO
          ELSE
             xm_temp = xm
-            ! init_volint expands field-period modes to full-torus modes
-            ! internally, matching init_virtual_casing's public convention.
-            xn_temp = -xn/nfp
+            ! init_volint reconstructs a full torus and expects full-torus
+            ! toroidal mode numbers.
+            xn_temp = -xn
             rmnc_temp = rmnc
             zmns_temp = zmns
          END IF

--- a/DIAGNO/Sources/diagno_init_vmec.f90
+++ b/DIAGNO/Sources/diagno_init_vmec.f90
@@ -158,7 +158,9 @@
          END IF
          IF (lnyquist) THEN
             xm_temp = xm_nyq
-            xn_temp = -xn_nyq/nfp ! Because init_virtual_casing uses (mu+nv) not (mu-nv*nfp)
+            ! init_volint samples phi over the full torus, unlike the
+            ! one-field-period surface virtual-casing path.
+            xn_temp = -xn_nyq
             DO u = 1,mnmax_temp
                DO v = 1, mnmax
                   IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
@@ -173,7 +175,9 @@
             END DO
          ELSE
             xm_temp = xm
-            xn_temp = -xn/nfp
+            ! init_volint samples phi over the full torus, unlike the
+            ! one-field-period surface virtual-casing path.
+            xn_temp = -xn
             rmnc_temp = rmnc
             zmns_temp = zmns
          END IF

--- a/DIAGNO/Sources/diagno_init_vmec.f90
+++ b/DIAGNO/Sources/diagno_init_vmec.f90
@@ -158,9 +158,9 @@
          END IF
          IF (lnyquist) THEN
             xm_temp = xm_nyq
-            ! init_volint samples phi over the full torus, unlike the
-            ! one-field-period surface virtual-casing path.
-            xn_temp = -xn_nyq
+            ! init_volint expands field-period modes to full-torus modes
+            ! internally, matching init_virtual_casing's public convention.
+            xn_temp = -xn_nyq/nfp
             DO u = 1,mnmax_temp
                DO v = 1, mnmax
                   IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
@@ -175,9 +175,9 @@
             END DO
          ELSE
             xm_temp = xm
-            ! init_volint samples phi over the full torus, unlike the
-            ! one-field-period surface virtual-casing path.
-            xn_temp = -xn
+            ! init_volint expands field-period modes to full-torus modes
+            ! internally, matching init_virtual_casing's public convention.
+            xn_temp = -xn/nfp
             rmnc_temp = rmnc
             zmns_temp = zmns
          END IF

--- a/LIBSTELL/Sources/Modules/read_wout_mod.f90
+++ b/LIBSTELL/Sources/Modules/read_wout_mod.f90
@@ -219,10 +219,10 @@
         ln_bsubvmns = 'sinmn covariant v-component of B, half mesh',    &
         ln_bsubsmnc = 'cosmn covariant s-component of B, half mesh',    &
 
-        ln_currumnc = 'cosmn sqrt(g)*contravariant u-component of J, full mesh', &
-        ln_currumns = 'sinmn sqrt(g)*contravariant u-component of J, full mesh', &
-        ln_currvmnc = 'cosmn sqrt(g)*contravariant v-component of J, full mesh', &
-        ln_currvmns = 'sinmn sqrt(g)*contravariant v-component of J, full mesh', &
+        ln_currumnc = 'cosmn contravariant u-component of J, full mesh', &
+        ln_currumns = 'sinmn contravariant u-component of J, full mesh', &
+        ln_currvmnc = 'cosmn contravariant v-component of J, full mesh', &
+        ln_currvmns = 'sinmn contravariant v-component of J, full mesh', &
 
         ln_bsubumns_sur = 'sinmn covaiant u-component of B, surface',   &
         ln_bsubvmns_sur = 'sinmn covaiant v-component of B, surface',   &

--- a/LIBSTELL/Sources/Modules/read_wout_mod.f90
+++ b/LIBSTELL/Sources/Modules/read_wout_mod.f90
@@ -219,10 +219,10 @@
         ln_bsubvmns = 'sinmn covariant v-component of B, half mesh',    &
         ln_bsubsmnc = 'cosmn covariant s-component of B, half mesh',    &
 
-        ln_currumnc = 'cosmn covariant u-component of J, full mesh',    &
-        ln_currumns = 'sinmn covariant u-component of J, full mesh',    &
-        ln_currvmnc = 'cosmn covariant v-component of J, full mesh',    &
-        ln_currvmns = 'sinmn covariant v-component of J, full mesh',    &
+        ln_currumnc = 'cosmn sqrt(g)*contravariant u-component of J, full mesh', &
+        ln_currumns = 'sinmn sqrt(g)*contravariant u-component of J, full mesh', &
+        ln_currvmnc = 'cosmn sqrt(g)*contravariant v-component of J, full mesh', &
+        ln_currvmns = 'sinmn sqrt(g)*contravariant v-component of J, full mesh', &
 
         ln_bsubumns_sur = 'sinmn covaiant u-component of B, surface',   &
         ln_bsubvmns_sur = 'sinmn covaiant v-component of B, surface',   &
@@ -3161,4 +3161,3 @@
       END SUBROUTINE LoadRZL
 
       END MODULE read_wout_mod
-

--- a/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
+++ b/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
@@ -41,7 +41,7 @@
 !                    xn_temp = -xn_nyq/nfp
 !                    ! Copy rmnc/zmns into matching rows of the Nyquist basis;
 !                    ! leave geometry rows with no matching VMEC mode at zero.
-!                    ! currumnc/currvmnc are sqrt(g)*J^u/v on the Nyquist grid.
+!                    ! currumnc/currvmnc are contravariant current harmonics on the Nyquist grid.
 !                    jumnc_temp = isigng*currumnc
 !                    jvmnc_temp = isigng*currvmnc
 !                    CALL init_volint(mnmax_temp,nu2,nv2,ns,xm_temp,xn_temp, &

--- a/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
+++ b/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
@@ -34,16 +34,17 @@
 !
 !                    To load an equilibrium using current density from VMEC
 !
-!                    ALLOCATE(xm_temp(mnmax),xn_temp(mnmax)) ! Integer Arrays
-!                    ALLOCATE(rmnc_temp(mnmax,ns),zmns_temp(mnmax,ns)) ! DOUBLE PRECISION
-!                    ALLOCATE(jumnc_temp(mnmax,ns),jvmnc_temp(mnmax,ns)) ! DOUBLE PRECISION
-!                    xm_temp = xm
-!                    xn_temp = -xn
-!                    rmnc_temp = rmnc
-!                    zmns_temp = zmns
+!                    ALLOCATE(xm_temp(mnmax_temp),xn_temp(mnmax_temp)) ! Integer Arrays
+!                    ALLOCATE(rmnc_temp(mnmax_temp,ns),zmns_temp(mnmax_temp,ns))
+!                    ALLOCATE(jumnc_temp(mnmax_temp,ns),jvmnc_temp(mnmax_temp,ns))
+!                    xm_temp = xm_nyq
+!                    xn_temp = -xn_nyq/nfp
+!                    ! Copy rmnc/zmns into matching rows of the Nyquist basis;
+!                    ! leave geometry rows with no matching VMEC mode at zero.
+!                    ! currumnc/currvmnc are sqrt(g)*J^u/v on the Nyquist grid.
 !                    jumnc_temp = isigng*currumnc
 !                    jvmnc_temp = isigng*currvmnc
-!                    CALL init_volint(mnmax,nu2,nv2,ns,xm_temp,xn_temp, &
+!                    CALL init_volint(mnmax_temp,nu2,nv2,ns,xm_temp,xn_temp, &
 !                                     rmnc_temp,zmns_temp,nfp,&
 !                                     JUMNC=jumnc_temp, JVMNC=jvmnc_temp)
 !

--- a/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
+++ b/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
@@ -38,7 +38,7 @@
 !                    ALLOCATE(rmnc_temp(mnmax_temp,ns),zmns_temp(mnmax_temp,ns))
 !                    ALLOCATE(jumnc_temp(mnmax_temp,ns),jvmnc_temp(mnmax_temp,ns))
 !                    xm_temp = xm_nyq
-!                    xn_temp = -xn_nyq/nfp
+!                    xn_temp = -xn_nyq
 !                    ! Copy rmnc/zmns into matching rows of the Nyquist basis;
 !                    ! leave geometry rows with no matching VMEC mode at zero.
 !                    ! currumnc/currvmnc are contravariant current harmonics on the Nyquist grid.
@@ -2019,10 +2019,12 @@
             FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -zmnc(mn,:)*xn(mn)
             CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,zv,1,0)
          END IF
+         ! init_volint reconstructs a full torus, so rv/zv are already
+         ! derivatives with respect to the full-torus toroidal coordinate.
          ! Calculate jr, jphi, jz, jx, jy
-         jr   = ju_temp*ru+jv_temp*rv*nfp
+         jr   = ju_temp*ru+jv_temp*rv
          jphi = r_temp * jv_temp
-         jz   = ju_temp*zu+jv_temp*zv*nfp
+         jz   = ju_temp*zu+jv_temp*zv
          DO u = 1, nu
             DO v = 1, nvp
                cop = DCOS(pi2*xv(v))
@@ -2203,7 +2205,7 @@
       ! non Hermite Quatitites
       cx = xparam*(xp2-1); cxi = xpi*(xpi2-1); hx2 = hx*hx
       cy = yparam*(yp2-1); cyi = ypi*(ypi2-1); hy2 = hy*hy
-      cy = zparam*(zp2-1); czi = zpi*(zpi2-1); hz2 = hz*hz
+      cz = zparam*(zp2-1); czi = zpi*(zpi2-1); hz2 = hz*hz
       xs  =  evaltri3D(xparam, xpi, xp2, xpi2, cx, cxi, hx2, &
                        yparam, ypi, yp2, ypi2, cy, cyi, hy2, &
                        zparam, zpi, zp2, zpi2, cz, czi, hz2, &
@@ -2292,7 +2294,7 @@
       ! non Hermite Quatitites
       cx = xparam*(xp2-1); cxi = xpi*(xpi2-1); hx2 = hx*hx
       cy = yparam*(yp2-1); cyi = ypi*(ypi2-1); hy2 = hy*hy
-      cy = zparam*(zp2-1); czi = zpi*(zpi2-1); hz2 = hz*hz
+      cz = zparam*(zp2-1); czi = zpi*(zpi2-1); hz2 = hz*hz
       xs  =  evaltri3D(xparam, xpi, xp2, xpi2, cx, cxi, hx2, &
                        yparam, ypi, yp2, ypi2, cy, cyi, hy2, &
                        zparam, zpi, zp2, zpi2, cz, czi, hz2, &

--- a/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
+++ b/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
@@ -38,7 +38,7 @@
 !                    ALLOCATE(rmnc_temp(mnmax_temp,ns),zmns_temp(mnmax_temp,ns))
 !                    ALLOCATE(jumnc_temp(mnmax_temp,ns),jvmnc_temp(mnmax_temp,ns))
 !                    xm_temp = xm_nyq
-!                    xn_temp = -xn_nyq/nfp
+!                    xn_temp = -xn_nyq
 !                    ! Copy rmnc/zmns into matching rows of the Nyquist basis;
 !                    ! leave geometry rows with no matching VMEC mode at zero.
 !                    ! currumnc/currvmnc are contravariant current harmonics on the Nyquist grid.
@@ -845,8 +845,8 @@
          uv = 1
          DO v = 1, nv
             DO u = 1, nu
-               xsurf(uv)   = rreal(u,v)*dcos(phi(nv))
-               ysurf(uv)   = rreal(u,v)*dsin(phi(nv))
+               xsurf(uv)   = rreal(u,v)*dcos(phi(v))
+               ysurf(uv)   = rreal(u,v)*dsin(phi(v))
                zsurf(uv)   = zreal(u,v)
                xreal(u,v)  = xsurf(uv)
                yreal(u,v)  = ysurf(uv)
@@ -1869,7 +1869,6 @@
       DOUBLE PRECISION, ALLOCATABLE :: zu(:,:,:), zv(:,:,:)
       DOUBLE PRECISION, ALLOCATABLE :: jr(:,:,:), jphi(:,:,:), jz(:,:,:)
       DOUBLE PRECISION, ALLOCATABLE :: jx(:,:,:), jy(:,:,:)
-      INTEGER :: xn_full(1:mnmax)
       TYPE(EZspline3_r8)   :: x3d_spl, y3d_spl, z3d_spl, jx3d_spl, jy3d_spl, jz3d_spl
       ! BEGIN SUBROUTINE
       ! Initialize varaibles
@@ -1990,39 +1989,38 @@
          r_temp=zero; z_temp=zero; ju_temp=zero; jv_temp=zero
          FORALL(u=1:nu) xu(u) = DBLE(u-1)/DBLE(nu-1)
          FORALL(v=1:nvp) xv(v) = DBLE(v-1)/DBLE(nvp-1)
-         xn_full = xn*nfp
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,rmnc,xm,xn_full,r_temp,0,1)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,zmns,xm,xn_full,z_temp,1,0)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jumnc,xm,xn_full,ju_temp,0,0)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jvmnc,xm,xn_full,jv_temp,0,0)
-         IF (PRESENT(rmns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,rmns,xm,xn_full,r_temp,1,0)
-         IF (PRESENT(zmnc)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,zmnc,xm,xn_full,z_temp,0,0)
-         IF (PRESENT(jumns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jumns,xm,xn_full,ju_temp,1,0)
-         IF (PRESENT(jvmns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jvmns,xm,xn_full,jv_temp,1,0)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,rmnc,xm,xn,r_temp,0,1)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,zmns,xm,xn,z_temp,1,0)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jumnc,xm,xn,ju_temp,0,0)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jvmnc,xm,xn,jv_temp,0,0)
+         IF (PRESENT(rmns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,rmns,xm,xn,r_temp,1,0)
+         IF (PRESENT(zmnc)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,zmnc,xm,xn,z_temp,0,0)
+         IF (PRESENT(jumns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jumns,xm,xn,ju_temp,1,0)
+         IF (PRESENT(jvmns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jvmns,xm,xn,jv_temp,1,0)
          ! Now we calculate the edge metric elements
          ru = zero; zu = zero; rv = zero; zv = zero
          FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -rmnc(mn,:)*xm(mn)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,ru,1,0)
-         FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -rmnc(mn,:)*xn_full(mn)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,rv,1,0)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,ru,1,0)
+         FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -rmnc(mn,:)*xn(mn)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,rv,1,0)
          FORALL(mn = 1:mnmax) fmn_temp(mn,:) = zmns(mn,:)*xm(mn)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,zu,0,0)
-         FORALL(mn = 1:mnmax) fmn_temp(mn,:) = zmns(mn,:)*xn_full(mn)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,zv,0,0)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,zu,0,0)
+         FORALL(mn = 1:mnmax) fmn_temp(mn,:) = zmns(mn,:)*xn(mn)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,zv,0,0)
          IF (PRESENT(rmns)) THEN
             FORALL(mn = 1:mnmax) fmn_temp(mn,:) = rmns(mn,:)*xm(mn)
-            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,ru,0,0)
-            FORALL(mn = 1:mnmax) fmn_temp(mn,:) = rmns(mn,:)*xn_full(mn)
-            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,rv,0,0)
+            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,ru,0,0)
+            FORALL(mn = 1:mnmax) fmn_temp(mn,:) = rmns(mn,:)*xn(mn)
+            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,rv,0,0)
          END IF 
          IF (PRESENT(zmnc)) THEN
             FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -zmnc(mn,:)*xm(mn)
-            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,zu,1,0)
-            FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -zmnc(mn,:)*xn_full(mn)
-            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,zv,1,0)
+            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,zu,1,0)
+            FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -zmnc(mn,:)*xn(mn)
+            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,zv,1,0)
          END IF
-         ! init_volint reconstructs a full torus, so rv/zv are already
-         ! derivatives with respect to the full-torus toroidal coordinate.
+         ! xv spans the full torus here, and xn already carries the full-torus
+         ! toroidal mode number, so rv/zv must not be scaled by nfp again.
          ! Calculate jr, jphi, jz, jx, jy
          jr   = ju_temp*ru+jv_temp*rv
          jphi = r_temp * jv_temp

--- a/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
+++ b/LIBSTELL/Sources/Modules/virtual_casing_mod.f90
@@ -38,7 +38,7 @@
 !                    ALLOCATE(rmnc_temp(mnmax_temp,ns),zmns_temp(mnmax_temp,ns))
 !                    ALLOCATE(jumnc_temp(mnmax_temp,ns),jvmnc_temp(mnmax_temp,ns))
 !                    xm_temp = xm_nyq
-!                    xn_temp = -xn_nyq
+!                    xn_temp = -xn_nyq/nfp
 !                    ! Copy rmnc/zmns into matching rows of the Nyquist basis;
 !                    ! leave geometry rows with no matching VMEC mode at zero.
 !                    ! currumnc/currvmnc are contravariant current harmonics on the Nyquist grid.
@@ -1869,6 +1869,7 @@
       DOUBLE PRECISION, ALLOCATABLE :: zu(:,:,:), zv(:,:,:)
       DOUBLE PRECISION, ALLOCATABLE :: jr(:,:,:), jphi(:,:,:), jz(:,:,:)
       DOUBLE PRECISION, ALLOCATABLE :: jx(:,:,:), jy(:,:,:)
+      INTEGER :: xn_full(1:mnmax)
       TYPE(EZspline3_r8)   :: x3d_spl, y3d_spl, z3d_spl, jx3d_spl, jy3d_spl, jz3d_spl
       ! BEGIN SUBROUTINE
       ! Initialize varaibles
@@ -1989,35 +1990,36 @@
          r_temp=zero; z_temp=zero; ju_temp=zero; jv_temp=zero
          FORALL(u=1:nu) xu(u) = DBLE(u-1)/DBLE(nu-1)
          FORALL(v=1:nvp) xv(v) = DBLE(v-1)/DBLE(nvp-1)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,rmnc,xm,xn,r_temp,0,1)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,zmns,xm,xn,z_temp,1,0)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jumnc,xm,xn,ju_temp,0,0)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jvmnc,xm,xn,jv_temp,0,0)
-         IF (PRESENT(rmns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,rmns,xm,xn,r_temp,1,0)
-         IF (PRESENT(zmnc)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,zmnc,xm,xn,z_temp,0,0)
-         IF (PRESENT(jumns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jumns,xm,xn,ju_temp,1,0)
-         IF (PRESENT(jvmns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jvmns,xm,xn,jv_temp,1,0)
+         xn_full = xn*nfp
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,rmnc,xm,xn_full,r_temp,0,1)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,zmns,xm,xn_full,z_temp,1,0)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jumnc,xm,xn_full,ju_temp,0,0)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jvmnc,xm,xn_full,jv_temp,0,0)
+         IF (PRESENT(rmns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,rmns,xm,xn_full,r_temp,1,0)
+         IF (PRESENT(zmnc)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,zmnc,xm,xn_full,z_temp,0,0)
+         IF (PRESENT(jumns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jumns,xm,xn_full,ju_temp,1,0)
+         IF (PRESENT(jvmns)) CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,jvmns,xm,xn_full,jv_temp,1,0)
          ! Now we calculate the edge metric elements
          ru = zero; zu = zero; rv = zero; zv = zero
          FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -rmnc(mn,:)*xm(mn)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,ru,1,0)
-         FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -rmnc(mn,:)*xn(mn)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,rv,1,0)  
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,ru,1,0)
+         FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -rmnc(mn,:)*xn_full(mn)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,rv,1,0)
          FORALL(mn = 1:mnmax) fmn_temp(mn,:) = zmns(mn,:)*xm(mn)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,zu,0,0) 
-         FORALL(mn = 1:mnmax) fmn_temp(mn,:) = zmns(mn,:)*xn(mn)
-         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,zv,0,0)  
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,zu,0,0)
+         FORALL(mn = 1:mnmax) fmn_temp(mn,:) = zmns(mn,:)*xn_full(mn)
+         CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,zv,0,0)
          IF (PRESENT(rmns)) THEN
             FORALL(mn = 1:mnmax) fmn_temp(mn,:) = rmns(mn,:)*xm(mn)
-            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,ru,0,0)
-            FORALL(mn = 1:mnmax) fmn_temp(mn,:) = rmns(mn,:)*xn(mn)
-            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,rv,0,0)  
+            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,ru,0,0)
+            FORALL(mn = 1:mnmax) fmn_temp(mn,:) = rmns(mn,:)*xn_full(mn)
+            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,rv,0,0)
          END IF 
          IF (PRESENT(zmnc)) THEN
             FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -zmnc(mn,:)*xm(mn)
-            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,zu,1,0)  
-            FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -zmnc(mn,:)*xn(mn)
-            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn,zv,1,0)
+            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,zu,1,0)
+            FORALL(mn = 1:mnmax) fmn_temp(mn,:) = -zmnc(mn,:)*xn_full(mn)
+            CALL mntouv_local(1,ns,mnmax,nu,nvp,xu,xv,fmn_temp,xm,xn_full,zv,1,0)
          END IF
          ! init_volint reconstructs a full torus, so rv/zv are already
          ! derivatives with respect to the full-torus toroidal coordinate.

--- a/TORLINES/Sources/torlines_init_wout.f90
+++ b/TORLINES/Sources/torlines_init_wout.f90
@@ -410,7 +410,7 @@
          END IF
          IF (lnyquist) THEN
             xm_temp = xm_nyq
-            xn_temp = -xn_nyq/nfp
+            xn_temp = -xn_nyq/nfp ! init_volint uses (m*u+n*v), not VMEC's (m*u-n*v*NFP)
             DO u = 1, mnmax_temp
                DO v = 1, mnmax
                   IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
@@ -425,7 +425,7 @@
             END DO
          ELSE
             xm_temp = xm
-            xn_temp = -xn/nfp
+            xn_temp = -xn/nfp ! init_volint uses (m*u+n*v), not VMEC's (m*u-n*v*NFP)
             rmnc_temp = rmnc
             zmns_temp = zmns
             IF (lasym) THEN

--- a/TORLINES/Sources/torlines_init_wout.f90
+++ b/TORLINES/Sources/torlines_init_wout.f90
@@ -410,8 +410,9 @@
          END IF
          IF (lnyquist) THEN
             xm_temp = xm_nyq
-            ! init_volint samples phi over the full torus.
-            xn_temp = -xn_nyq
+            ! init_volint expands field-period modes to full-torus modes
+            ! internally, matching init_virtual_casing's public convention.
+            xn_temp = -xn_nyq/nfp
             DO u = 1, mnmax_temp
                DO v = 1, mnmax
                   IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
@@ -426,8 +427,9 @@
             END DO
          ELSE
             xm_temp = xm
-            ! init_volint samples phi over the full torus.
-            xn_temp = -xn
+            ! init_volint expands field-period modes to full-torus modes
+            ! internally, matching init_virtual_casing's public convention.
+            xn_temp = -xn/nfp
             rmnc_temp = rmnc
             zmns_temp = zmns
             IF (lasym) THEN

--- a/TORLINES/Sources/torlines_init_wout.f90
+++ b/TORLINES/Sources/torlines_init_wout.f90
@@ -53,9 +53,10 @@
 !-----------------------------------------------------------------------
       IMPLICIT NONE
       INTEGER :: iunit, ier, mn, im, in, ik , i, j, ns1, k1,mn0,&
-                 u,v
+                 mnmax_temp, u,v
       INTEGER :: bcs1(2)
       INTEGER, ALLOCATABLE :: xn_temp(:), xm_temp(:)
+      LOGICAL :: lnyquist
       REAL(rprec) :: val1, val2, dval, scale, rhomax, dr, f0_temp, dz,&
                      alvb, b1, c1, re, ae, r1, alub
       REAL(rprec), ALLOCATABLE :: mfact(:,:)
@@ -69,6 +70,8 @@
       REAL(rprec), ALLOCATABLE :: bsmns_temp(:,:)
       REAL(rprec), ALLOCATABLE :: bumnc_temp(:,:), bvmnc_temp(:,:)
       REAL(rprec), ALLOCATABLE :: bmnc_temp(:,:), bmns_temp(:,:)
+      REAL(rprec), ALLOCATABLE :: jumnc_temp(:,:), jvmnc_temp(:,:)
+      REAL(rprec), ALLOCATABLE :: jumns_temp(:,:), jvmns_temp(:,:)
       DOUBLE PRECISION, ALLOCATABLE :: rmnc_tempr(:,:), zmns_tempr(:,:)
       DOUBLE PRECISION, ALLOCATABLE :: rmns_tempr(:,:), zmnc_tempr(:,:)
       DOUBLE PRECISION, ALLOCATABLE :: bsupumnc_tempr(:,:), bsupvmnc_tempr(:,:)
@@ -130,7 +133,7 @@
 
       ! Now do grid
       DO ik = 2, ns-1
-         WHERE (MOD(NINT(REAL(xm_temp(:))),2) .eq. 0)
+         WHERE (MOD(NINT(REAL(xm_nyq(:))),2) .eq. 0)
             mfact(:,1)= 0.5
             mfact(:,2)= 0.5
          ELSEWHERE
@@ -142,15 +145,15 @@
       END DO
 
       ! Now do edgek = ns_vmec
-      WHERE (MOD(NINT(REAL(xm_temp(:))),2) .eq. 0)
+      WHERE (MOD(NINT(REAL(xm_nyq(:))),2) .eq. 0)
          mfact(:,1)= 2.0 ! ns (half grid point)
          mfact(:,2)=-1.0 ! ns-1 (full grid point)
       ELSEWHERE
          mfact(:,1)= 2.0*SQRT((ns-1)/(ns-1.5))
          mfact(:,2)=-1.0*SQRT((ns-1)/(ns-2.0))
       ENDWHERE
-      bsupumnc(:,ns) = mfact(:,ns)*bsupumnc(:,ns)+mfact(:,2)*bsupumnc(:,ns-1)
-      bsupvmnc(:,ns) = mfact(:,ns)*bsupvmnc(:,ns)+mfact(:,2)*bsupvmnc(:,ns-1)
+      bsupumnc(:,ns) = mfact(:,1)*bsupumnc(:,ns)+mfact(:,2)*bsupumnc(:,ns-1)
+      bsupvmnc(:,ns) = mfact(:,1)*bsupvmnc(:,ns)+mfact(:,2)*bsupvmnc(:,ns-1)
       DEALLOCATE(mfact)
 
       ! Get fields on full mesh
@@ -382,19 +385,77 @@
          IF (adapt_rel < 0.0) adapt_tol = -1.0
          MIN_CLS = 0
       ELSE IF (.not.lvac .and. .not.lvc_field .and. (bound_separation > 1)) THEN
-         ALLOCATE(xm_temp(mnmax),xn_temp(mnmax), STAT=ier)
-         xm_temp = xm
-         xn_temp = -xn
+         IF (SIZE(xm_nyq) > SIZE(xm)) THEN
+            mnmax_temp = SIZE(xm_nyq)
+            lnyquist = .true.
+         ELSE
+            mnmax_temp = mnmax
+            lnyquist = .false.
+         END IF
+         ALLOCATE(xm_temp(mnmax_temp),xn_temp(mnmax_temp), STAT=ier)
+         IF (ier /= 0) CALL handle_err(ALLOC_ERR,'XM_TEMP XN_TEMP',ier)
+         ALLOCATE(rmnc_temp(mnmax_temp,ns),zmns_temp(mnmax_temp,ns),&
+                  jumnc_temp(mnmax_temp,ns),jvmnc_temp(mnmax_temp,ns),&
+                  STAT=ier)
+         IF (ier /= 0) CALL handle_err(ALLOC_ERR,'VOLINT VMEC TEMP',ier)
+         rmnc_temp = 0; zmns_temp = 0
+         jumnc_temp = 0; jvmnc_temp = 0
+         IF (lasym) THEN
+            ALLOCATE(rmns_temp(mnmax_temp,ns),zmnc_temp(mnmax_temp,ns),&
+                     jumns_temp(mnmax_temp,ns),jvmns_temp(mnmax_temp,ns),&
+                     STAT=ier)
+            IF (ier /= 0) CALL handle_err(ALLOC_ERR,'VOLINT VMEC ASYM TEMP',ier)
+            rmns_temp = 0; zmnc_temp = 0
+            jumns_temp = 0; jvmns_temp = 0
+         END IF
+         IF (lnyquist) THEN
+            xm_temp = xm_nyq
+            xn_temp = -xn_nyq/nfp
+            DO u = 1, mnmax_temp
+               DO v = 1, mnmax
+                  IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
+                     rmnc_temp(u,:) = rmnc(v,:)
+                     zmns_temp(u,:) = zmns(v,:)
+                     IF (lasym) THEN
+                        rmns_temp(u,:) = rmns(v,:)
+                        zmnc_temp(u,:) = zmnc(v,:)
+                     END IF
+                  END IF
+               END DO
+            END DO
+         ELSE
+            xm_temp = xm
+            xn_temp = -xn/nfp
+            rmnc_temp = rmnc
+            zmns_temp = zmns
+            IF (lasym) THEN
+               rmns_temp = rmns
+               zmnc_temp = zmnc
+            END IF
+         END IF
+         jumnc_temp = isigng*currumnc
+         jvmnc_temp = isigng*currvmnc
          MIN_CLS = 0
          IF (lasym) THEN
-             CALL init_volint(mnmax,nu_vc,nv_vc,ns,xm_temp,xn_temp,rmnc,zmns,nfp,&
-                              JUMNC=isigng*currumnc, JVMNC=isigng*currvmnc,&
-                              RMNS=rmns,ZMNC=zmnc,&
-                              JUMNS=isigng*currumns, JVMNS=isigng*currvmns)
+             jumns_temp = isigng*currumns
+             jvmns_temp = isigng*currvmns
+             CALL init_volint(mnmax_temp,nu_vc,nv_vc,ns,xm_temp,xn_temp,&
+                              rmnc_temp,zmns_temp,nfp,&
+                              JUMNC=jumnc_temp, JVMNC=jvmnc_temp,&
+                              RMNS=rmns_temp,ZMNC=zmnc_temp,&
+                              JUMNS=jumns_temp, JVMNS=jvmns_temp,&
+                              COMM=MPI_COMM_FIELDLINES)
+             DEALLOCATE(rmns_temp,zmnc_temp)
+             DEALLOCATE(jumns_temp,jvmns_temp)
          ELSE
-             CALL init_volint(mnmax,nu_vc,nv_vc,ns,xm_temp,xn_temp,rmnc,zmns,nfp,&
-                              JUMNC=isigng*currumnc, JVMNC=isigng*currvmnc)
+             CALL init_volint(mnmax_temp,nu_vc,nv_vc,ns,xm_temp,xn_temp,&
+                              rmnc_temp,zmns_temp,nfp,&
+                              JUMNC=jumnc_temp, JVMNC=jvmnc_temp,&
+                              COMM=MPI_COMM_FIELDLINES)
          END IF
+         DEALLOCATE(rmnc_temp,zmns_temp)
+         DEALLOCATE(jumnc_temp,jvmnc_temp)
+         DEALLOCATE(xm_temp,xn_temp)
          adapt_tol = 0.0
          adapt_rel = vc_adapt_tol
       END IF
@@ -440,7 +501,7 @@
       CALL MPI_BARRIER(MPI_COMM_SHARMEM,ierr_mpi)
 #endif
       DEALLOCATE(bsupumnc_temp,bsupvmnc_temp, bmnc_temp)
-      IF (ALLOCATED(rmns_temp)) DEALLOCATE(bsupumns_temp,bsupvmns_temp, bmns_temp)
+      IF (ALLOCATED(bsupumns_temp)) DEALLOCATE(bsupumns_temp,bsupvmns_temp, bmns_temp)
       ! Calculated the external surfaces
       IF (bound_separation > 1) THEN
          ! Try recalcing the exterior surfaces

--- a/TORLINES/Sources/torlines_init_wout.f90
+++ b/TORLINES/Sources/torlines_init_wout.f90
@@ -410,9 +410,9 @@
          END IF
          IF (lnyquist) THEN
             xm_temp = xm_nyq
-            ! init_volint expands field-period modes to full-torus modes
-            ! internally, matching init_virtual_casing's public convention.
-            xn_temp = -xn_nyq/nfp
+            ! init_volint reconstructs a full torus and expects full-torus
+            ! toroidal mode numbers.
+            xn_temp = -xn_nyq
             DO u = 1, mnmax_temp
                DO v = 1, mnmax
                   IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
@@ -427,9 +427,9 @@
             END DO
          ELSE
             xm_temp = xm
-            ! init_volint expands field-period modes to full-torus modes
-            ! internally, matching init_virtual_casing's public convention.
-            xn_temp = -xn/nfp
+            ! init_volint reconstructs a full torus and expects full-torus
+            ! toroidal mode numbers.
+            xn_temp = -xn
             rmnc_temp = rmnc
             zmns_temp = zmns
             IF (lasym) THEN

--- a/TORLINES/Sources/torlines_init_wout.f90
+++ b/TORLINES/Sources/torlines_init_wout.f90
@@ -410,7 +410,8 @@
          END IF
          IF (lnyquist) THEN
             xm_temp = xm_nyq
-            xn_temp = -xn_nyq/nfp ! init_volint uses (m*u+n*v), not VMEC's (m*u-n*v*NFP)
+            ! init_volint samples phi over the full torus.
+            xn_temp = -xn_nyq
             DO u = 1, mnmax_temp
                DO v = 1, mnmax
                   IF ((xm(v) .eq. xm_nyq(u)) .and. (xn(v) .eq. xn_nyq(u))) THEN
@@ -425,7 +426,8 @@
             END DO
          ELSE
             xm_temp = xm
-            xn_temp = -xn/nfp ! init_volint uses (m*u+n*v), not VMEC's (m*u-n*v*NFP)
+            ! init_volint samples phi over the full torus.
+            xn_temp = -xn
             rmnc_temp = rmnc
             zmns_temp = zmns
             IF (lasym) THEN


### PR DESCRIPTION
This is the same line of work as #467, moved to an in-repository branch as requested for cleaner testing and verification.

## Summary

- make the TORLINES VMEC volume-current initialization Nyquist-aware
- map geometric `rmnc/zmns` modes onto the Nyquist basis while passing the VMEC current harmonics on their native Nyquist basis
- keep the public `virtual_casing_mod` toroidal-mode convention consistent: callers pass field-period mode numbers (`-xn/nfp`, `-xn_nyq/nfp`), while `init_volint` expands them internally for full-torus reconstruction
- fix a typo in the adaptive volume-integral integrands where the z coefficient overwrote `cy` instead of assigning `cz`
- avoid over-specifying the NetCDF current metadata while retaining the corrected contravariant-current wording

## Local checks

Built `DIAGNO/Release/xdiagno` locally after rebasing on current `origin/develop` using a consistent MPICH build/runtime:

- MPI wrapper/runtime: `/opt/fenicsx-cuda/petsc/bin/mpif90`, `/opt/fenicsx-cuda/petsc/bin/mpiexec`
- runtime ABI checked against MPICH `libmpifort.so.12` / `libmpi.so.12`
- `git diff --check origin/develop...HEAD`: pass

Rebased-branch sanity run:

- `bigtok`, `mpiexec -n 32`: PASS
- B-field max error `0.00287%`, median `0.000621%`, no probes above 1%

Additional 32-rank checks from the same corrected code path before the final rebase:

- `DIIID_m24n0s99_nfp10`: PASS, max B-field error `0.466%`
- `ncsx`: still FAIL, but improved relative to local develop: max `4.20%`, median `0.089%`, 4/75 B-field probes above 1%, flux loop 1 about `5%`
- local `develop` NCSX comparison under the same MPICH setup: max `6.14%`, median `3.62%`, flux loop 1 about `54%`
- `hsx` and `w7x` still fail locally; I am not treating those as fully resolved by this PR

The remaining NCSX/HSX/W7X discrepancies are left visible rather than hidden. The intent of this PR is to fix the Nyquist/current-harmonic setup and the shared volume-integral convention issue without claiming the full DIAGNO benchmark suite is solved.
