### PR TITLE
Bug/fix restart with neo

### DIFF
--- a/PENTA/Sources/penta_interface_mod.f90
+++ b/PENTA/Sources/penta_interface_mod.f90
@@ -1471,11 +1471,12 @@ MODULE PENTA_INTERFACE_MOD
 
    END SUBROUTINE root_analysis
 
-   SUBROUTINE interpolate_from_penta(nrho_penta,rho_penta,y_penta,nrho_out,rho_out,y_out,isHermite,useLog)
+   SUBROUTINE interpolate_from_penta(nrho_penta,rho_penta,y_penta,nrho_out,rho_out,y_out,isHermite,useLog,preventNeg)
       ! This subroutine is an aider to thrift_penta, where a bunch of splines are done from the penta grid onto
       ! the thrift and plasma solver grids
       ! ASSUMES: that rho_penta does not have rho=0 nor rho=1, and so a linear extrapolation is done
       ! useLog is useful to intepolate non-negative quantities that span several orders of magnitude
+      ! if preventNeg is .true. then all negative values are clamped to 0.0
       USE EZspline
       USE EZspline_obj
       IMPLICIT NONE
@@ -1486,6 +1487,7 @@ MODULE PENTA_INTERFACE_MOD
       REAL(rknd), DIMENSION(nrho_out), INTENT(OUT) :: y_out
       INTEGER, INTENT(IN) :: isHermite
       LOGICAL, INTENT(IN) :: useLog
+      LOGICAL, INTENT(IN), OPTIONAL :: preventNeg
       !
       INTEGER :: ier
       INTEGER :: bcs0(2)
@@ -1524,6 +1526,12 @@ MODULE PENTA_INTERFACE_MOD
       CALL EZspline_free(y_spl,ier)
 
       DEALLOCATE(rho_temp,y_temp)
+
+      IF(PRESENT(preventNeg)) THEN
+         IF(preventNeg) THEN
+            WHERE (y_out .LE. 0.0_rknd) y_out = 1.0E-20_rknd
+         END IF
+      END IF
 
    END SUBROUTINE interpolate_from_penta
 

--- a/THRIFT/ObjectList
+++ b/THRIFT/ObjectList
@@ -20,6 +20,7 @@ thrift_equil_p.o \
 thrift_equil_j.o \
 thrift_evolve.o \
 thrift_vars.o \
+thrift_restart.o \
 thrift_init.o \
 thrift_init_mpisubgroup.o \
 thrift_paraexe.o \

--- a/THRIFT/Sources/thrift_init.f90
+++ b/THRIFT/Sources/thrift_init.f90
@@ -354,6 +354,10 @@
          CALL thrift_paraexe(tstr1,tstr2,ltst)
       END IF
 
+      ! Run VMEC+booz_xform+dkes using restart profiles so DKES_D** are
+      ! available at the first thrift_penta call when add_NEO=.true.
+      IF (lrestart_from_file .AND. solve_plasma_equations) CALL thrift_restart_equil
+
       RETURN
 !----------------------------------------------------------------------
 !     END SUBROUTINE

--- a/THRIFT/Sources/thrift_init.f90
+++ b/THRIFT/Sources/thrift_init.f90
@@ -23,8 +23,6 @@
       USE mpi_params
       USE mpi_inc
       USE mpi_sharmem
-      USE EZspline
-      USE EZspline_obj
 #if defined(LHDF5)
       USE ez_hdf5
 #endif
@@ -36,12 +34,9 @@
 !-----------------------------------------------------------------------
       IMPLICIT NONE
       LOGICAL        :: ltst
-      INTEGER        :: ier, i, iunit, ntimesteps_restart, ns_restart, k, ntimesteps_ecrh, nbeams
+      INTEGER        :: ier, i, iunit, ntimesteps_ecrh, nbeams
       CHARACTER(256) :: tstr1,tstr2
       REAL(rprec)    :: dt, tend_restart
-      REAL(rprec), DIMENSION(:,:), ALLOCATABLE :: temp2d
-      REAL(rprec), DIMENSION(:), ALLOCATABLE :: temp1d
-      REAL(rprec), DIMENSION(:,:,:), ALLOCATABLE :: temp3d
 !----------------------------------------------------------------------
 !     BEGIN SUBROUTINE
 !----------------------------------------------------------------------
@@ -202,101 +197,12 @@
       END IF
 
       ! Read restart file
-      IF (lrestart_from_file) THEN
-         UGRID_RESTART = 0.0
-         IF (lverb) THEN 
-            WRITE(6,'(A)') '----- Reading Restart File -----'
-            WRITE(6,'(A)')  '   FILE: '//TRIM(restart_filename)
-         END IF
-         ! Read file 
-         IF (myid_sharmem == master) THEN
-            CALL open_hdf5(TRIM(restart_filename),fid,ier,LCREATE=.false.)
-            IF (ier /= 0) CALL handle_err(HDF5_OPEN_ERR,TRIM(restart_filename),ier)
-
-            CALL read_scalar_hdf5(fid,'ntimesteps',ier,INTVAR=ntimesteps_restart)
-            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'ntimesteps',ier)
-
-            CALL read_scalar_hdf5(fid,'nssize',ier,INTVAR=ns_restart)
-            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'nssize',ier)
-
-            !Check that ns_restart is equal to current ns
-            IF(ns_restart /= nsj) THEN
-               WRITE(6,*) '!!!!!!!!!!!!ERRROR!!!!!!!!!!!!!!'
-               WRITE(6,*) '  ns_restart different from nsj '
-               WRITE(6,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
-               STOP
-            ENDIF
-
-            ALLOCATE(temp2d(ns_restart,ntimesteps_restart),temp1d(ntimesteps_restart))
-
-            CALL read_var_hdf5(fid,'THRIFT_T',ntimesteps_restart,ier,DBLVAR=temp1d)
-            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_T',ier)
-            tend_restart = temp1d(ntimesteps_restart)
-
-            IF(lverb) WRITE(6,'(A17,F8.4)') '   TEND_RESTART: ', tend_restart
-
-            ! Check tstart > tend_restart
-            IF(tstart < tend_restart) THEN 
-               WRITE(6,*) '!!!!!!!!!!!!ERRROR!!!!!!!!!!!!!!'
-               WRITE(6,*) '          tstart < tend_resart  '
-               WRITE(6,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
-               STOP
-            ENDIF
-
-            dt_first_iter = tstart - tend_restart
-            IF(ntimesteps == 1) dt = dt_first_iter
-
-            CALL read_var_hdf5(fid,'THRIFT_UGRID',ns_restart,ntimesteps_restart,ier,DBLVAR=temp2d)
-            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_UGRID',ier)
-            UGRID_RESTART = temp2d(:,ntimesteps_restart)
-
-            CALL read_var_hdf5(fid,'THRIFT_J',ns_restart,ntimesteps_restart,ier,DBLVAR=temp2d)
-            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_J',ier)
-            J_RESTART = temp2d(:,ntimesteps_restart)
-
-            CALL read_var_hdf5(fid,'eq_Aminor',ier,DBLVAR=eq_Aminor)
-            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'eq_Aminor',ier)
-
-            CALL read_var_hdf5(fid,'THRIFT_PHIEDGE',ntimesteps_restart,ier,DBLVAR=temp1d)
-            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_PHIEDGE',ier)
-            eq_phiedge = temp1d(ntimesteps_restart)
-
-            CALL read_var_hdf5(fid,'THRIFT_VP',ns_restart,ntimesteps_restart,ier,DBLVAR=temp2d)
-            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_VP',ier)
-
-            ! dV/dPhi Spline (Volume derivative)
-            bcs1=(/ 0, 0/)
-            IF (EZspline_allocated(vp_spl)) CALL EZspline_free(vp_spl,ier)
-            CALL EZspline_init(vp_spl,ns_restart,bcs1,ier)
-            IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'thrift_init: vp_spl',ier)
-            vp_spl%isHermite = 0
-            FORALL (k=1:ns_restart) vp_spl%x1(k) = sqrt(DBLE(k-1)/DBLE(ns_restart-1))
-            CALL EZspline_setup(vp_spl,temp2d(:,ntimesteps_restart)/eq_phiedge,ier,EXACT_DIM=.true.)
-            IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'thrift_init: vp_spl',ier)
-
-            CALL read_var_hdf5(fid,'THRIFT_BSQAV',ns_restart,ntimesteps_restart,ier,DBLVAR=temp2d)
-            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_BSQAV',ier)
-
-            ! Bsq Spline
-            bcs1=(/ 0, 0/)
-            IF (EZspline_allocated(bsq_spl)) CALL EZspline_free(bsq_spl,ier)
-            CALL EZspline_init(bsq_spl,ns_restart,bcs1,ier)
-            IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'thrift_init: bsq_spl',ier)
-            bsq_spl%isHermite = 0
-            FORALL (k=1:ns_restart) bsq_spl%x1(k) = sqrt(DBLE(k-1)/DBLE(ns_restart-1))
-            CALL EZspline_setup(bsq_spl,temp2d(:,ntimesteps_restart),ier,EXACT_DIM=.true.)
-            IF (ier /=0) CALL handle_err(EZSPLINE_ERR,'thrift_init: bsq_spl',ier)
-
-            DEALLOCATE(temp2d,temp1d)
-            
-            !Close the HDF5 file
-            CALL close_hdf5(fid,ier)
-            IF (ier /= 0) CALL handle_err(HDF5_CLOSE_ERR,TRIM(restart_filename),ier)
-         END IF
-      END IF
+      IF (lrestart_from_file) CALL thrift_restart
 
       CALL MPI_BCAST(dt,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
       CALL MPI_BCAST(dt_first_iter,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      IF (lrestart_from_file .AND. ntimesteps == 1) dt = dt_first_iter
+      IF (lrestart_from_file) tend_restart = tstart - dt_first_iter
 
       IF(solve_plasma_equations) THEN
          ! Check dt_plasma_solver and ajust it
@@ -335,10 +241,19 @@
 
       ! Now setup the profiles (plasma profiles if not solving plasma eqs; external source profiles if solving plasma eqs.)
       IF(solve_plasma_equations) THEN
-         CALL initialize_plasma_solver((TRIM(prof_string))) 
+         CALL initialize_plasma_solver((TRIM(prof_string)))
       ELSE
          CALL read_thrift_profh5(TRIM(prof_string))
       ENDIF
+
+      ! Check that the number of ion species in the restart file matches the profiles file
+      IF (lrestart_from_file .AND. nion_prof_restart /= nion_prof) THEN
+         WRITE(6,*) '!!!!!!!!!!!!ERRROR!!!!!!!!!!!!!!'
+         WRITE(6,*) '  nion_prof mismatch: restart file has ', nion_prof_restart, &
+                    ' ion species but profiles file has ', nion_prof
+         WRITE(6,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+         STOP
+      END IF
 
       ! Allocate particle and heat fluxes (do it here because nion_prof only now available)
       CALL mpialloc(THRIFT_GNEO,   nion_prof+1, nsj, ntimesteps, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_gneo) 
@@ -347,38 +262,7 @@
       CALL mpialloc(THRIFT_DENS,   nion_prof+1, nsj, ntimesteps, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_dens)
       CALL mpialloc(THRIFT_TEMP,   nion_prof+1, nsj, ntimesteps, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_temp)
       CALL mpialloc(THRIFT_PRESS,  nion_prof+1, nsj, ntimesteps, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_press)    
-      CALL mpialloc(THRIFT_FAST_ALPHAS_DENS,    nsj, ntimesteps, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_fast_alphas_dens)    
-      ! Restart vars
-      IF(lrestart_from_file) THEN
-         CALL mpialloc(DENS_RESTART,   nion_prof+1, ns_restart, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_dens_restart)
-         CALL mpialloc(TEMP_RESTART,   nion_prof+1, ns_restart, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_temp_restart)
-         CALL mpialloc(DENS_FAST_ALPHAS_RESTART,    ns_restart, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_dens_fast_alphas_restart)
-      END IF
-
-      IF(lrestart_from_file .AND. solve_plasma_equations .AND. myid_sharmem == master) THEN
-         CALL open_hdf5(TRIM(restart_filename),fid,ier,LCREATE=.false.)
-         IF (ier /= 0) CALL handle_err(HDF5_OPEN_ERR,TRIM(restart_filename),ier)
-
-         ALLOCATE(temp3d(nion_prof+1,ns_restart,ntimesteps_restart),temp2d(ns_restart,ntimesteps_restart))
-         ! Read density of all species at last time step
-         CALL read_var_hdf5(fid,'THRIFT_DENS',nion_prof+1,ns_restart,ntimesteps_restart,ier,DBLVAR=temp3d)
-         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_DENS',ier)
-         DENS_RESTART = temp3d(:,:,ntimesteps_restart)
-         ! Read fast alphas density at last time step
-         CALL read_var_hdf5(fid,'THRIFT_FAST_ALPHAS_DENS',ns_restart,ntimesteps_restart,ier,DBLVAR=temp2d)
-         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_FAST_ALPHAS_DENS',ier)
-         DENS_FAST_ALPHAS_RESTART = temp2d(:,ntimesteps_restart)
-         ! Read temperature of all species at last time step
-         CALL read_var_hdf5(fid,'THRIFT_TEMP',nion_prof+1,ns_restart,ntimesteps_restart,ier,DBLVAR=temp3d)
-         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_TEMP',ier)
-         TEMP_RESTART = temp3d(:,:,ntimesteps_restart)
-         !
-         DEALLOCATE(temp3d,temp2d)
-
-         !Close the HDF5 file
-         CALL close_hdf5(fid,ier)
-         IF (ier /= 0) CALL handle_err(HDF5_CLOSE_ERR,TRIM(restart_filename),ier)
-      END IF
+      CALL mpialloc(THRIFT_FAST_ALPHAS_DENS,    nsj, ntimesteps, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_fast_alphas_dens)
 
       IF (myid_sharmem == master) THEN
         FORALL(i = 1:nrho) THRIFT_RHO(i) = DBLE(i-0.5)/DBLE(nrho) ! (half) rho grid

--- a/THRIFT/Sources/thrift_penta.f90
+++ b/THRIFT/Sources/thrift_penta.f90
@@ -36,7 +36,8 @@
                  mysurf, root_max_Er, jspecies, irho, it_prev
       REAL(rprec) :: s, rho, mytime
       REAL(rprec), DIMENSION(:), ALLOCATABLE :: rho_k, iota, phip, chip, btheta, bzeta, bsq, vp, &
-                        te, ne, dtedrho, dnedrho, EparB, JBS_PENTA, etapar_PENTA, Er_PENTA, rho_temp, J_temp, eta_temp, Er_temp
+                        te, ne, dtedrho, dnedrho, EparB, JBS_PENTA, etapar_PENTA, Er_PENTA, rho_temp, J_temp, eta_temp, Er_temp, &
+                        Er_k
       REAL(rprec), DIMENSION(:,:), ALLOCATABLE :: GNEO_PENTA, QNEO_PENTA, GNEO_temp, QNEO_temp
       REAL(rprec), DIMENSION(:,:), ALLOCATABLE :: Dn_PENTA, cn_PENTA, Dn_temp, cn_temp
       REAL(rprec), DIMENSION(:,:), ALLOCATABLE :: Dp_PENTA, cp_PENTA, Dp_temp, cp_temp
@@ -68,12 +69,12 @@
       ALLOCATE(rho_k(ns_dkes),iota(ns_dkes),phip(ns_dkes),chip(ns_dkes),btheta(ns_dkes),bzeta(ns_dkes),bsq(ns_dkes),vp(ns_dkes),EparB(ns_dkes))
       ALLOCATE(te(ns_dkes),ne(ns_dkes),dtedrho(ns_dkes),dnedrho(ns_dkes))
       ALLOCATE(ni(ns_dkes,nion_prof),ti(ns_dkes,nion_prof),dtidrho(ns_dkes,nion_prof),dnidrho(ns_dkes,nion_prof))
-      ALLOCATE(JBS_PENTA(ns_dkes),etapar_PENTA(ns_dkes),Er_PENTA(ns_dkes))
+      ALLOCATE(JBS_PENTA(ns_dkes),etapar_PENTA(ns_dkes),Er_PENTA(ns_dkes),Er_k(ns_dkes))
       ALLOCATE(GNEO_PENTA(nion_prof+1,ns_dkes),QNEO_PENTA(nion_prof+1,ns_dkes))
       ALLOCATE(Dn_PENTA(nion_prof+1,ns_dkes),cn_PENTA(nion_prof+1,ns_dkes))
       ALLOCATE(Dp_PENTA(nion_prof+1,ns_dkes),cp_PENTA(nion_prof+1,ns_dkes))
 
-      JBS_PENTA = 0.0; etapar_PENTA = 0.0; Er_PENTA = 0.0
+      JBS_PENTA = 0.0; etapar_PENTA = 0.0; Er_PENTA = 0.0; Er_k = 0.0
       GNEO_PENTA = 0.0; QNEO_PENTA = 0.0
       Dn_PENTA = 0.0; cn_PENTA = 0.0
       Dp_PENTA = 0.0; cp_PENTA = 0.0
@@ -129,6 +130,11 @@
                   ! EparB
                   ier = 0
                   CALL EZSpline_interp(EparB_spl, rho, EparB(k), ier)
+                  ! Er from previous plasma solver step
+                  IF (solve_plasma_equations) THEN
+                        ier = 0
+                        CALL EZspline_interp(Er_spline, rho, Er_k(k), ier)
+                  END IF
             END DO
             !
             CALL EZspline_free(EparB_spl,ier)    
@@ -151,6 +157,7 @@
       CALL MPI_BCAST(dtidrho,ns_dkes*nion_prof,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
       CALL MPI_BCAST(dnidrho,ns_dkes*nion_prof,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
       CALL MPI_BCAST(EparB,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
+      CALL MPI_BCAST(Er_k,ns_dkes,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
       ! VMEC quantities
       CALL MPI_BCAST(eq_Aminor,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
       CALL MPI_BCAST(eq_Rmajor,1,MPI_DOUBLE_PRECISION,master,MPI_COMM_MYWORLD,ierr_mpi)
@@ -196,7 +203,7 @@
             IF(solve_plasma_equations .AND. .NOT. look_for_ambipolar) THEN
                   ! Need to define num_roots and set Er_roots
                   num_roots = 1
-                  CALL EZspline_interp(Er_spline,rho_k(k),Er_roots(1),ier)
+                  Er_roots(1) = Er_k(k)
             ELSE
                   ! Now the basic steps
                   CALL PENTA_RUN_2_EFIELD
@@ -258,7 +265,7 @@
             DEALLOCATE(rho_k,iota,phip,chip,btheta,bzeta,bsq,vp,EparB)
             DEALLOCATE(te,ne,dtedrho,dnedrho)
             DEALLOCATE(ni,ti,dtidrho,dnidrho)
-            DEALLOCATE(JBS_PENTA,etapar_PENTA,Er_PENTA,GNEO_PENTA,QNEO_PENTA,Dn_PENTA,cn_PENTA,Dp_PENTA,cp_PENTA)
+            DEALLOCATE(JBS_PENTA,etapar_PENTA,Er_PENTA,Er_k,GNEO_PENTA,QNEO_PENTA,Dn_PENTA,cn_PENTA,Dp_PENTA,cp_PENTA)
             RETURN
       ENDIF
 #endif
@@ -338,7 +345,7 @@
             DEALLOCATE(rho_k,iota,phip,chip,btheta,bzeta,bsq,vp,EparB)
             DEALLOCATE(te,ne,dtedrho,dnedrho)
             DEALLOCATE(ni,ti,dtidrho,dnidrho)
-            DEALLOCATE(JBS_PENTA,etapar_PENTA,Er_PENTA,GNEO_PENTA,QNEO_PENTA)
+            DEALLOCATE(JBS_PENTA,etapar_PENTA,Er_PENTA,Er_k,GNEO_PENTA,QNEO_PENTA)
             DEALLOCATE(Dn_PENTA,cn_PENTA,Dp_PENTA,cp_PENTA)              
       END IF
 

--- a/THRIFT/Sources/thrift_penta.f90
+++ b/THRIFT/Sources/thrift_penta.f90
@@ -328,7 +328,7 @@
                         !
                         CALL interpolate_from_PENTA(nrho_penta=ns_dkes, rho_penta=rho_k, y_penta=Dp_PENTA(jspecies,:),\
                                           nrho_out=Nr_plasma_solver, rho_out=rho_plasma_grid, y_out=Dp_NEO(jspecies,mytimestep_plasma_solver,:),\
-                                          isHermite=1, useLog=.FALSE.)
+                                          isHermite=1, useLog=.FALSE., preventNeg = .TRUE.)
                         !
                         CALL interpolate_from_PENTA(nrho_penta=ns_dkes, rho_penta=rho_k, y_penta=cp_PENTA(jspecies,:),\
                                           nrho_out=Nr_plasma_solver, rho_out=rho_plasma_grid, y_out=cp_NEO(jspecies,mytimestep_plasma_solver,:),\

--- a/THRIFT/Sources/thrift_plasma_solver_mod.f90
+++ b/THRIFT/Sources/thrift_plasma_solver_mod.f90
@@ -162,10 +162,16 @@ MODULE thrift_plasma_solver_mod
             ! Update equilirbrium quantities
             CALL update_equilibrium_vars
 
-            IF( .NOT. lrestart_from_file) RETURN
             ! If lrestart_from_file=T, then proceed imediately to next plasma iteration 
             ! until THRIFT_tstart is reached (don't forget that in restart mode, tstart is
             ! not the time at which the previous simulation was left at)
+            IF( .NOT. lrestart_from_file) THEN
+                RETURN
+            ELSE
+                ! If continuing due to restart, then shut off lscreen of penta
+                lscreen_subcodes = .FALSE.
+                IF (lverb) WRITE(6,'(A)') '----- Running penta for restart -----'
+            END IF
         ENDIF
         
         dr_plasma_solver = drho_plasma_solver * eq_Aminor
@@ -983,6 +989,10 @@ MODULE thrift_plasma_solver_mod
             CALL EZspline_setup(spline_restart,DENS_FAST_ALPHAS_RESTART(:),ier,EXACT_DIM=.true.)
             IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,'setup: restart fast alphas spline',ier)
             CALL EZspline_interp(spline_restart,Nr_plasma_solver,rho_plasma_grid,N_fast_alphas(1,:),ier)
+            ! Radial electric field
+            CALL EZspline_setup(spline_restart,ER_RESTART(:),ier,EXACT_DIM=.true.)
+            IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,'setup: restart Er spline',ier)
+            CALL EZspline_interp(spline_restart,Nr_plasma_solver,rho_plasma_grid,plasma_Er(1,:),ier)
             !
             CALL EZspline_free(spline_restart,ier)
         ELSEIF(trim(init_profiles_type) == 'read_from_file' ) THEN

--- a/THRIFT/Sources/thrift_plasma_solver_mod.f90
+++ b/THRIFT/Sources/thrift_plasma_solver_mod.f90
@@ -69,8 +69,8 @@ MODULE thrift_plasma_solver_mod
     SUBROUTINE evolve_plasma_equations
 
         IMPLICIT NONE
-        INTEGER :: istat, i, idx, irho, j, ispecies, ier, plasma_iteration
-        REAL(rprec) :: rho, delta_p, delta_n, k_prev, k_now
+        INTEGER :: istat, i, idx, irho, j, ispecies, ier, plasma_iteration, n_steps_per_Er
+        REAL(rprec) :: rho, delta_p, delta_n
         REAL(rprec), DIMENSION(:), ALLOCATABLE :: pressure_total, pressure_total_old, ne_old
         REAL(rprec), DIMENSION(:), ALLOCATABLE :: RHS_density, lower_diag, upper_diag, main_diag, RHS_pressure
         real(rprec), DIMENSION(:,:), ALLOCATABLE :: LHS_pressure
@@ -178,6 +178,9 @@ MODULE thrift_plasma_solver_mod
         ! ne_old from previous time step
         ne_old = plasma_N(1,:)
 
+        ! Number of plasma sub-steps per Er-ambipolar interval
+        n_steps_per_Er = NINT(dt_Er_ambipolar / dt_plasma_solver)
+
         DO plasma_iteration = 1,N_plasma_steps_per_THRIFT_step
 
             mytimestep_plasma_solver = mytimestep_plasma_solver + 1
@@ -191,10 +194,8 @@ MODULE thrift_plasma_solver_mod
 
                 ! Run PENTA if NEO fluxes are to be added
                 IF(add_NEO) THEN
-                    ! Only look for ambipolar at every dt_Er
-                    k_prev = int( (time_plasma_grid(mytimestep_plasma_solver-1) - time_plasma_grid(1)) / dt_Er_ambipolar)
-                    k_now  = int( (time_plasma_grid(mytimestep_plasma_solver)   - time_plasma_grid(1)) / dt_Er_ambipolar)
-                    IF(k_now > k_prev) THEN
+                    ! Only look for ambipolar every dt_Er_ambipolar
+                    IF( MOD(mytimestep_plasma_solver-1, n_steps_per_Er) == 0 ) THEN
                         look_for_ambipolar = .TRUE.
                         update_thrift_vars = .FALSE.
                         update_transport_vars = .TRUE.

--- a/THRIFT/Sources/thrift_plasma_solver_mod.f90
+++ b/THRIFT/Sources/thrift_plasma_solver_mod.f90
@@ -1023,7 +1023,7 @@ MODULE thrift_plasma_solver_mod
         REAL(rprec), DIMENSION(:,:), INTENT(IN) :: LHS_matrix
         REAL(rprec), DIMENSION(:), INTENT(IN) :: RHS_vec
         REAL(rprec), DIMENSION(:), INTENT(INOUT) :: result
-        INTEGER :: ier, mat_size
+        INTEGER :: ier, mat_size, idx, is_neg, ir_neg
         INTEGER, DIMENSION(:), ALLOCATABLE :: ipiv
         ier = 0
         mat_size = Nr_plasma_solver * num_species
@@ -1036,6 +1036,16 @@ MODULE thrift_plasma_solver_mod
         IF(ANY(ISNAN(result))) CALL handle_err(THRIFT_NAN_ERR,'Pressure_Solver',mytimestep_plasma_solver)
         ! Look for negative values
         IF (ANY(result < 0.0)) THEN
+            DO idx = 1, mat_size
+                IF (result(idx) < 0.0) THEN
+                    is_neg = (idx-1)/Nr_plasma_solver + 1
+                    ir_neg = MOD(idx-1, Nr_plasma_solver) + 1
+                    WRITE(*,'(A,ES12.4,A,A,A,I4,A,F8.5,A,ES12.4)') &
+                        'Negative pressure at t=', time_plasma_grid(mytimestep_plasma_solver), &
+                        ': species=', TRIM(list_of_species(is_neg)), &
+                        ', ir=', ir_neg, ', rho=', rho_plasma_grid(ir_neg), ', value=', result(idx)
+                END IF
+            END DO
             STOP 'Negative values found on pressure. Exiting program...'
         END IF
         DEALLOCATE(ipiv)
@@ -1094,7 +1104,19 @@ MODULE thrift_plasma_solver_mod
         END DO
 
         IF(ANY(ISNAN(result)))  CALL handle_err(THRIFT_NAN_ERR,'Pressure_Solver',mytimestep_plasma_solver)
-        IF(ANY(result < 0.0_rprec)) STOP 'Negative values found on pressure. Exiting program...'
+        IF (ANY(result < 0.0_rprec)) THEN
+            DO k = 1, N
+                IF (result(k) < 0.0_rprec) THEN
+                    is_k = (k-1)/Nr_plasma_solver + 1
+                    ir_k = MOD(k-1, Nr_plasma_solver) + 1
+                    WRITE(*,'(A,ES12.4,A,A,A,I4,A,F8.5,A,ES12.4)') &
+                        'Negative pressure at t=', time_plasma_grid(mytimestep_plasma_solver), &
+                        ': species=', TRIM(list_of_species(is_k)), &
+                        ', ir=', ir_k, ', rho=', rho_plasma_grid(ir_k), ', value=', result(k)
+                END IF
+            END DO
+            STOP 'Negative values found on pressure. Exiting program...'
+        END IF
 
         DEALLOCATE(AB, RHS_pm, ipiv)
         RETURN

--- a/THRIFT/Sources/thrift_plasma_solver_mod.f90
+++ b/THRIFT/Sources/thrift_plasma_solver_mod.f90
@@ -1371,7 +1371,7 @@ MODULE thrift_plasma_solver_mod
         IMPLICIT NONE
         CHARACTER(len = 200) :: header_str
 
-        header_str = '  T       NSUB    TE_AXIS [keV]    NE_AXIS[m-3]      TI1_AXIS [keV]    NI1_AXIS [m-3]      MAX(dp/p_old)      MAX(dn/n_old)'
+        header_str = '     T[s]    NSUB    TE_AXIS [keV]    NE_AXIS[m-3]      TI1_AXIS [keV]    NI1_AXIS [m-3]      MAX(dp/p_old)      MAX(dn/n_old)'
                
         WRITE(ilogplasma,'(A)')' '
         WRITE(ilogplasma,'(A)') TRIM(header_str)
@@ -1386,7 +1386,7 @@ MODULE thrift_plasma_solver_mod
         REAL(rprec), INTENT(in) :: t,te_eV,ne,ti_eV,ni,max_dp,max_dn
         CHARACTER(len = 200) :: progress_str
 
-        WRITE(progress_str,'(1X,F7.3,3X,I2,6X,F7.3,11X,ES8.2,11X,F7.3,13X,ES8.2,12X,ES8.2,11X,ES8.2)') &
+        WRITE(progress_str,'(1X,F10.5,3X,I2,6X,F7.3,11X,ES8.2,11X,F7.3,13X,ES8.2,12X,ES8.2,11X,ES8.2)') &
                   t,nsub,te_eV/1000,ne,ti_eV/1000,ni,max_dp,max_dn
         WRITE(ilogplasma,'(A)') TRIM(progress_str)
 

--- a/THRIFT/Sources/thrift_plasma_solver_mod.f90
+++ b/THRIFT/Sources/thrift_plasma_solver_mod.f90
@@ -29,6 +29,7 @@ MODULE thrift_plasma_solver_mod
     REAL(rprec), DIMENSION(:,:), ALLOCATABLE :: r_plasma_grid, N_fast_alphas, plasma_Er
     INTEGER :: ilogplasma, num_species
     REAL(rprec), DIMENSION(:,:), ALLOCATABLE, PRIVATE :: plasma_N, plasma_T, plasma_P
+    REAL(rprec), DIMENSION(:), ALLOCATABLE   :: plasma_aminor, plasma_Baxis, plasma_Bref, plasma_iota2o3
     REAL(rprec), DIMENSION(:,:,:), ALLOCATABLE :: plasma_N_keep, plasma_T_keep, &
                                                   S_energy_ext, S_particle_ext, &
                                                   S_alpha_power
@@ -95,6 +96,10 @@ MODULE thrift_plasma_solver_mod
         IF( .NOT. ALLOCATED(S_radiated_power)) ALLOCATE(S_radiated_power(Nt_total_plasma_solver,Nr_plasma_solver))
         IF( .NOT. ALLOCATED(dVdr_keep)) ALLOCATE(dVdr_keep(Nt_total_plasma_solver,Nr_plasma_solver))
         IF( .NOT. ALLOCATED(plasma_Er)) ALLOCATE(plasma_Er(Nt_total_plasma_solver,Nr_plasma_solver))
+        IF( .NOT. ALLOCATED(plasma_Baxis)) ALLOCATE(plasma_Baxis(Nt_total_plasma_solver))
+        IF( .NOT. ALLOCATED(plasma_aminor)) ALLOCATE(plasma_aminor(Nt_total_plasma_solver))
+        IF( .NOT. ALLOCATED(plasma_iota2o3)) ALLOCATE(plasma_iota2o3(Nt_total_plasma_solver))
+        IF( .NOT. ALLOCATED(plasma_Bref)) ALLOCATE(plasma_Bref(Nt_total_plasma_solver))
         ! These arrays are filled in thrift_penta with the total NEO fluxes. They include the inter-species diffusion coeffs
         ! which are neglected when computing the Dn_NEO and cn_NEO coeffs used by the transport solver
         IF( .NOT. ALLOCATED(G_NEO_complet)) ALLOCATE(G_NEO_complet(num_species,Nt_total_plasma_solver,Nr_plasma_solver))
@@ -154,6 +159,9 @@ MODULE thrift_plasma_solver_mod
             ! Update splines and exit routine
             CALL update_splines
 
+            ! Update equilirbrium quantities
+            CALL update_equilibrium_vars
+
             IF( .NOT. lrestart_from_file) RETURN
             ! If lrestart_from_file=T, then proceed imediately to next plasma iteration 
             ! until THRIFT_tstart is reached (don't forget that in restart mode, tstart is
@@ -185,6 +193,8 @@ MODULE thrift_plasma_solver_mod
 
             mytimestep_plasma_solver = mytimestep_plasma_solver + 1
             r_plasma_grid(mytimestep_plasma_solver,:) = rho_plasma_grid * eq_Aminor
+
+            CALL update_equilibrium_vars
 
             ! SUBCYCLE
             delta_p = 10*tol_plasma_solver
@@ -559,8 +569,7 @@ MODULE thrift_plasma_solver_mod
         dt = dt_plasma_solver
 
         ! Vp = dV/dr
-        CALL EZspline_interp(vp_spl,Nr,rho_plasma_grid,Vp,ier)
-        Vp = Vp * 2.0_rprec * rho_plasma_grid * eq_phiedge / eq_Aminor
+        Vp = dVdr_keep(mytimestep_plasma_solver,:)
 
         ! r=0
         main_diag(1) = one + dt*4.0_rprec*Dn(1)/dr2 + 2.0_rprec*dt*cn(2)/dr
@@ -671,10 +680,7 @@ MODULE thrift_plasma_solver_mod
         ALLOCATE(LHS_coll_heat_exchange(Nr*num_species,Nr*num_species))
 
         ! Vp = dV/dr
-        CALL EZspline_interp(vp_spl,Nr,rho_plasma_grid,Vp,ier)
-        Vp = Vp * 2.0_rprec * rho_plasma_grid * eq_phiedge / eq_Aminor
-        ! Bookkeeping
-        dVdr_keep(mytimestep_plasma_solver,:) = Vp
+        Vp = dVdr_keep(mytimestep_plasma_solver,:)
 
         kk = 1
         DO ispecies=1,num_species
@@ -920,6 +926,24 @@ MODULE thrift_plasma_solver_mod
         plasma_T = plasma_P / (plasma_N * e_charge)
         RETURN
     END SUBROUTINE
+
+    SUBROUTINE update_equilibrium_vars
+        ! Updates dVdr_keep, plasma_aminor, plasma_Baxis, plasma_Bref and plasma_iota2o3
+        IMPLICIT NONE
+        REAL(rprec), DIMENSION(Nr_plasma_solver) :: Vp
+        INTEGER :: thrift_irho2o3,ier
+
+        CALL EZspline_interp(vp_spl,Nr_plasma_solver,rho_plasma_grid,Vp,ier)
+        dVdr_keep(mytimestep_plasma_solver,:) = Vp * 2.0_rprec * rho_plasma_grid * eq_phiedge / eq_Aminor
+
+        plasma_aminor(mytimestep_plasma_solver) = eq_Aminor
+        plasma_Baxis(mytimestep_plasma_solver) = SQRT(THRIFT_BSQAV(1,mytimestep))
+        plasma_Bref(mytimestep_plasma_solver) = eq_phiedge / (pi*eq_Aminor**2)
+
+        thrift_irho2o3 = MINLOC(ABS(SQRT(THRIFT_S) - 2./3.), DIM=1)
+        plasma_iota2o3(mytimestep_plasma_solver) = THRIFT_IOTA(thrift_irho2o3,mytimestep)
+
+    END SUBROUTINE update_equilibrium_vars
 
     SUBROUTINE set_initial_profiles
         IMPLICIT NONE
@@ -1228,7 +1252,7 @@ MODULE thrift_plasma_solver_mod
         nref = ni
         Tref = Ti
         mref = mass_ref_species
-        Bref = eq_phiedge / (pi*eq_Aminor**2)
+        Bref = plasma_Bref(mytimestep_plasma_solver)
 
         !Q gyroBohm (for the scaling)
         Q_gB = 2.0_rprec * SQRT(2.0_rprec) * nref * SQRT(mref) * (e_charge*Tref)**2.5_rprec
@@ -1276,7 +1300,7 @@ MODULE thrift_plasma_solver_mod
         nref = n
         Tref = T
         mref = mass_ref_species
-        Bref = eq_phiedge / (pi*eq_Aminor**2)
+        Bref = plasma_Bref(mytimestep_plasma_solver)
 
         !Q gyroBohm (for the scaling)
         Q_gB = 2.0_rprec * SQRT(2.0_rprec) * nref * SQRT(mref) * (e_charge*Tref)**2.5_rprec

--- a/THRIFT/Sources/thrift_restart.f90
+++ b/THRIFT/Sources/thrift_restart.f90
@@ -12,13 +12,11 @@
 !-----------------------------------------------------------------------
       USE thrift_runtime
       USE thrift_vars
-      USE thrift_equil, ONLY: eq_Aminor, eq_phiedge, vp_spl, bsq_spl, bcs1
+      USE thrift_equil, ONLY: eq_Aminor, eq_phiedge
       USE thrift_globals, ONLY: nsj, tstart, solve_plasma_equations
       USE mpi_params
       USE mpi_inc
       USE mpi_sharmem
-      USE EZspline
-      USE EZspline_obj
 #if defined(LHDF5)
       USE ez_hdf5
 #endif
@@ -26,7 +24,7 @@
 !     Local Variables
 !-----------------------------------------------------------------------
       IMPLICIT NONE
-      INTEGER     :: ier, ns_restart, ntimesteps_restart, k
+      INTEGER     :: ier, ns_restart, ntimesteps_restart
       REAL(rprec) :: tend_restart
       REAL(rprec), ALLOCATABLE :: temp1d(:), temp2d(:,:), temp3d(:,:,:)
 !----------------------------------------------------------------------
@@ -65,10 +63,11 @@
       ! Broadcast nion_prof_restart so all ranks can participate in mpialloc
       CALL MPI_BCAST(nion_prof_restart, 1, MPI_INTEGER, master, MPI_COMM_MYWORLD, ierr_mpi)
 
-      ! Allocate restart density/temperature arrays (all ranks)
+      ! Allocate restart density/temperature/Er arrays (all ranks)
       CALL mpialloc(DENS_RESTART,           nion_prof_restart+1, nsj, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_dens_restart)
       CALL mpialloc(TEMP_RESTART,           nion_prof_restart+1, nsj, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_temp_restart)
       CALL mpialloc(DENS_FAST_ALPHAS_RESTART,                nsj, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_dens_fast_alphas_restart)
+      CALL mpialloc(ER_RESTART,                              nsj, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_er_restart)
 
       ! Read all restart arrays on master (file is still open)
       IF (myid_sharmem == master) THEN
@@ -103,30 +102,6 @@
          IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_PHIEDGE',ier)
          eq_phiedge = temp1d(ntimesteps_restart)
 
-         CALL read_var_hdf5(fid,'THRIFT_VP',nsj,ntimesteps_restart,ier,DBLVAR=temp2d)
-         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_VP',ier)
-
-         bcs1 = (/ 0, 0 /)
-         IF (EZspline_allocated(vp_spl)) CALL EZspline_free(vp_spl,ier)
-         CALL EZspline_init(vp_spl,nsj,bcs1,ier)
-         IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,'thrift_restart: vp_spl',ier)
-         vp_spl%isHermite = 0
-         FORALL (k=1:nsj) vp_spl%x1(k) = sqrt(DBLE(k-1)/DBLE(nsj-1))
-         CALL EZspline_setup(vp_spl,temp2d(:,ntimesteps_restart)/eq_phiedge,ier,EXACT_DIM=.true.)
-         IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,'thrift_restart: vp_spl',ier)
-
-         CALL read_var_hdf5(fid,'THRIFT_BSQAV',nsj,ntimesteps_restart,ier,DBLVAR=temp2d)
-         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_BSQAV',ier)
-
-         bcs1 = (/ 0, 0 /)
-         IF (EZspline_allocated(bsq_spl)) CALL EZspline_free(bsq_spl,ier)
-         CALL EZspline_init(bsq_spl,nsj,bcs1,ier)
-         IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,'thrift_restart: bsq_spl',ier)
-         bsq_spl%isHermite = 0
-         FORALL (k=1:nsj) bsq_spl%x1(k) = sqrt(DBLE(k-1)/DBLE(nsj-1))
-         CALL EZspline_setup(bsq_spl,temp2d(:,ntimesteps_restart),ier,EXACT_DIM=.true.)
-         IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,'thrift_restart: bsq_spl',ier)
-
          DEALLOCATE(temp1d, temp2d)
 
          IF (solve_plasma_equations) THEN
@@ -145,6 +120,10 @@
             IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_TEMP',ier)
             TEMP_RESTART = temp3d(:,:,ntimesteps_restart)
 
+            CALL read_var_hdf5(fid,'THRIFT_ER',nsj,ntimesteps_restart,ier,DBLVAR=temp2d)
+            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_ER',ier)
+            ER_RESTART = temp2d(:,ntimesteps_restart)
+
             DEALLOCATE(temp3d, temp2d)
          END IF
 
@@ -157,3 +136,113 @@
 !     END SUBROUTINE
 !----------------------------------------------------------------------
       END SUBROUTINE thrift_restart
+
+!-----------------------------------------------------------------------
+!     Subroutine:    thrift_restart_equil
+!     Authors:       A. Coelho
+!     Date:          07/2026
+!     Description:   Reconstructs the VMEC equilibrium from restart
+!                    arrays and (if solve_plasma_equations .AND. add_NEO)
+!                    runs booz_xform+dkes so that DKES_D** are available
+!                    for thrift_penta at the first plasma iteration.
+!                    Must be called after thrift_init_mpisubgroup
+!                    (requires thrift_paraexe).
+!-----------------------------------------------------------------------
+      SUBROUTINE thrift_restart_equil
+!-----------------------------------------------------------------------
+!     Libraries
+!-----------------------------------------------------------------------
+      USE thrift_runtime
+      USE thrift_vars
+      USE thrift_equil, ONLY: eq_phiedge, ns_eq
+      USE thrift_globals, ONLY: add_NEO, solve_plasma_equations
+      USE booz_params, ONLY: lsurf_boz
+      USE vmec_input, ONLY: am_aux_s, am_aux_f, ac_aux_s, ac_aux_f, &
+                            pmass_type, pcurr_type, pres_scale, ncurr, curtor
+      USE EZspline
+      USE EZspline_obj
+      USE stel_tools
+      USE mpi_params
+      USE mpi_inc
+!-----------------------------------------------------------------------
+!     Local Variables
+!-----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER :: i, ier
+      INTEGER :: bcs0(2)
+      REAL(rprec), ALLOCATABLE :: p_restart(:), I_restart(:), s_temp(:)
+      TYPE(EZspline1_r8) :: p_spl, i_spl
+!----------------------------------------------------------------------
+!     BEGIN SUBROUTINE
+!----------------------------------------------------------------------
+
+      ! Build total pressure and enclosed current from restart arrays
+      ALLOCATE(p_restart(nsj), I_restart(nsj))
+      DO i = 1, nsj
+         p_restart(i) = SUM(DENS_RESTART(:,i) * TEMP_RESTART(:,i)) * e_charge
+      END DO
+      I_restart = eq_phiedge / mu0 * UGRID_RESTART
+
+      IF (lvmec) THEN
+         bcs0 = (/ 0, 0 /)
+         ALLOCATE(s_temp(n_eq))
+         FORALL(i = 1:n_eq) s_temp(i) = DBLE(i-1)/DBLE(n_eq-1)
+
+         ! Pressure profile -> AM_AUX_S/F
+         CALL EZspline_init(p_spl, nsj, bcs0, ier)
+         p_spl%x1        = THRIFT_S
+         p_spl%isHermite = 1
+         CALL EZspline_setup(p_spl, p_restart, ier, EXACT_DIM=.true.)
+         PMASS_TYPE = 'akima_spline'
+         PRES_SCALE = one
+         DO i = 1, n_eq
+            CALL EZspline_interp(p_spl, s_temp(i), AM_AUX_F(i), ier)
+            AM_AUX_S(i) = s_temp(i)
+         END DO
+         CALL EZspline_free(p_spl, ier)
+
+         ! Current profile dI/ds -> AC_AUX_S/F
+         CALL EZspline_init(i_spl, nsj, bcs0, ier)
+         i_spl%x1        = THRIFT_S
+         i_spl%isHermite = 1
+         CALL EZspline_setup(i_spl, I_restart, ier, EXACT_DIM=.true.)
+         PCURR_TYPE = 'akima_spline_ip'
+         NCURR = 1
+         CALL EZspline_derivative1_array_r8(i_spl, 1, n_eq, s_temp, AC_AUX_F(1:n_eq), ier)
+         CURTOR = I_restart(nsj)
+         AC_AUX_S(1:n_eq) = s_temp
+         CALL EZspline_free(i_spl, ier)
+
+         DEALLOCATE(s_temp)
+      END IF
+
+      DEALLOCATE(p_restart, I_restart)
+
+      IF (lverb) WRITE(6,'(A)') '----- Running equilibrium for restart -----'
+
+      ! Run VMEC and load equilibrium splines (sets iota, vp, bsq, bu, bv, phip, ...)
+      lscreen_subcodes = .TRUE.
+      proc_string = TRIM(TRIM(id_string) // '.000_000')
+      CALL thrift_run_equil
+      lscreen_subcodes = .FALSE.
+
+      ! Run booz_xform and dkes so DKES_D** are ready for thrift_penta
+      IF (solve_plasma_equations .AND. add_NEO) THEN
+         IF (ALLOCATED(lsurf_boz)) DEALLOCATE(lsurf_boz)
+         ALLOCATE(lsurf_boz(ns_eq))
+         lsurf_boz = .FALSE.
+         DO i = 1, DKES_NS_MAX
+            IF (DKES_K(i) < 1) CYCLE
+            lsurf_boz(DKES_K(i)) = .TRUE.
+         END DO
+         IF (lverb) WRITE(6,'(A)') '----- Running booz_xform for restart -----'
+         CALL thrift_paraexe('booz_xform', proc_string, lscreen_subcodes)
+         IF (lverb) WRITE(6,'(A)') '----- Running dkes for restart -----'
+         CALL thrift_paraexe('dkes', proc_string, lscreen_subcodes)
+      END IF
+
+      RETURN
+!----------------------------------------------------------------------
+!     END SUBROUTINE
+!----------------------------------------------------------------------
+      END SUBROUTINE thrift_restart_equil

--- a/THRIFT/Sources/thrift_restart.f90
+++ b/THRIFT/Sources/thrift_restart.f90
@@ -1,0 +1,159 @@
+!-----------------------------------------------------------------------
+!     Subroutine:    thrift_restart
+!     Authors:       A. Coelho
+!     Date:          07/2026
+!     Description:   Reads the restart file and initialises all restart
+!                    arrays.  Must be called after UGRID_RESTART and
+!                    J_RESTART have been mpialloc'd in thrift_init.
+!-----------------------------------------------------------------------
+      SUBROUTINE thrift_restart
+!-----------------------------------------------------------------------
+!     Libraries
+!-----------------------------------------------------------------------
+      USE thrift_runtime
+      USE thrift_vars
+      USE thrift_equil, ONLY: eq_Aminor, eq_phiedge, vp_spl, bsq_spl, bcs1
+      USE thrift_globals, ONLY: nsj, tstart, solve_plasma_equations
+      USE mpi_params
+      USE mpi_inc
+      USE mpi_sharmem
+      USE EZspline
+      USE EZspline_obj
+#if defined(LHDF5)
+      USE ez_hdf5
+#endif
+!-----------------------------------------------------------------------
+!     Local Variables
+!-----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER     :: ier, ns_restart, ntimesteps_restart, k
+      REAL(rprec) :: tend_restart
+      REAL(rprec), ALLOCATABLE :: temp1d(:), temp2d(:,:), temp3d(:,:,:)
+!----------------------------------------------------------------------
+!     BEGIN SUBROUTINE
+!----------------------------------------------------------------------
+
+      UGRID_RESTART = 0.0_rprec
+
+      IF (lverb) THEN
+         WRITE(6,'(A)') '----- Reading Restart File -----'
+         WRITE(6,'(A)') '   FILE: '//TRIM(restart_filename)
+      END IF
+
+      ! Read dimension scalars on master to know sizes before mpialloc
+      IF (myid_sharmem == master) THEN
+         CALL open_hdf5(TRIM(restart_filename),fid,ier,LCREATE=.false.)
+         IF (ier /= 0) CALL handle_err(HDF5_OPEN_ERR,TRIM(restart_filename),ier)
+
+         CALL read_scalar_hdf5(fid,'ntimesteps',ier,INTVAR=ntimesteps_restart)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'ntimesteps',ier)
+
+         CALL read_scalar_hdf5(fid,'nssize',ier,INTVAR=ns_restart)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'nssize',ier)
+
+         IF (ns_restart /= nsj) THEN
+            WRITE(6,*) '!!!!!!!!!!!!ERRROR!!!!!!!!!!!!!!'
+            WRITE(6,*) '  ns_restart different from nsj '
+            WRITE(6,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+            STOP
+         END IF
+
+         CALL read_scalar_hdf5(fid,'nion_prof',ier,INTVAR=nion_prof_restart)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'nion_prof',ier)
+      END IF
+
+      ! Broadcast nion_prof_restart so all ranks can participate in mpialloc
+      CALL MPI_BCAST(nion_prof_restart, 1, MPI_INTEGER, master, MPI_COMM_MYWORLD, ierr_mpi)
+
+      ! Allocate restart density/temperature arrays (all ranks)
+      CALL mpialloc(DENS_RESTART,           nion_prof_restart+1, nsj, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_dens_restart)
+      CALL mpialloc(TEMP_RESTART,           nion_prof_restart+1, nsj, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_temp_restart)
+      CALL mpialloc(DENS_FAST_ALPHAS_RESTART,                nsj, myid_sharmem, 0, MPI_COMM_SHARMEM, win_thrift_dens_fast_alphas_restart)
+
+      ! Read all restart arrays on master (file is still open)
+      IF (myid_sharmem == master) THEN
+         ALLOCATE(temp1d(ntimesteps_restart), temp2d(nsj, ntimesteps_restart))
+
+         CALL read_var_hdf5(fid,'THRIFT_T',ntimesteps_restart,ier,DBLVAR=temp1d)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_T',ier)
+         tend_restart = temp1d(ntimesteps_restart)
+         IF (lverb) WRITE(6,'(A17,F8.4)') '   TEND_RESTART: ', tend_restart
+
+         IF (tstart < tend_restart) THEN
+            WRITE(6,*) '!!!!!!!!!!!!ERRROR!!!!!!!!!!!!!!'
+            WRITE(6,*) '          tstart < tend_resart  '
+            WRITE(6,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+            STOP
+         END IF
+
+         dt_first_iter = tstart - tend_restart
+
+         CALL read_var_hdf5(fid,'THRIFT_UGRID',nsj,ntimesteps_restart,ier,DBLVAR=temp2d)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_UGRID',ier)
+         UGRID_RESTART = temp2d(:,ntimesteps_restart)
+
+         CALL read_var_hdf5(fid,'THRIFT_J',nsj,ntimesteps_restart,ier,DBLVAR=temp2d)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_J',ier)
+         J_RESTART = temp2d(:,ntimesteps_restart)
+
+         CALL read_var_hdf5(fid,'eq_Aminor',ier,DBLVAR=eq_Aminor)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'eq_Aminor',ier)
+
+         CALL read_var_hdf5(fid,'THRIFT_PHIEDGE',ntimesteps_restart,ier,DBLVAR=temp1d)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_PHIEDGE',ier)
+         eq_phiedge = temp1d(ntimesteps_restart)
+
+         CALL read_var_hdf5(fid,'THRIFT_VP',nsj,ntimesteps_restart,ier,DBLVAR=temp2d)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_VP',ier)
+
+         bcs1 = (/ 0, 0 /)
+         IF (EZspline_allocated(vp_spl)) CALL EZspline_free(vp_spl,ier)
+         CALL EZspline_init(vp_spl,nsj,bcs1,ier)
+         IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,'thrift_restart: vp_spl',ier)
+         vp_spl%isHermite = 0
+         FORALL (k=1:nsj) vp_spl%x1(k) = sqrt(DBLE(k-1)/DBLE(nsj-1))
+         CALL EZspline_setup(vp_spl,temp2d(:,ntimesteps_restart)/eq_phiedge,ier,EXACT_DIM=.true.)
+         IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,'thrift_restart: vp_spl',ier)
+
+         CALL read_var_hdf5(fid,'THRIFT_BSQAV',nsj,ntimesteps_restart,ier,DBLVAR=temp2d)
+         IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_BSQAV',ier)
+
+         bcs1 = (/ 0, 0 /)
+         IF (EZspline_allocated(bsq_spl)) CALL EZspline_free(bsq_spl,ier)
+         CALL EZspline_init(bsq_spl,nsj,bcs1,ier)
+         IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,'thrift_restart: bsq_spl',ier)
+         bsq_spl%isHermite = 0
+         FORALL (k=1:nsj) bsq_spl%x1(k) = sqrt(DBLE(k-1)/DBLE(nsj-1))
+         CALL EZspline_setup(bsq_spl,temp2d(:,ntimesteps_restart),ier,EXACT_DIM=.true.)
+         IF (ier /= 0) CALL handle_err(EZSPLINE_ERR,'thrift_restart: bsq_spl',ier)
+
+         DEALLOCATE(temp1d, temp2d)
+
+         IF (solve_plasma_equations) THEN
+            ALLOCATE(temp3d(nion_prof_restart+1,nsj,ntimesteps_restart), &
+                     temp2d(nsj,ntimesteps_restart))
+
+            CALL read_var_hdf5(fid,'THRIFT_DENS',nion_prof_restart+1,nsj,ntimesteps_restart,ier,DBLVAR=temp3d)
+            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_DENS',ier)
+            DENS_RESTART = temp3d(:,:,ntimesteps_restart)
+
+            CALL read_var_hdf5(fid,'THRIFT_FAST_ALPHAS_DENS',nsj,ntimesteps_restart,ier,DBLVAR=temp2d)
+            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_FAST_ALPHAS_DENS',ier)
+            DENS_FAST_ALPHAS_RESTART = temp2d(:,ntimesteps_restart)
+
+            CALL read_var_hdf5(fid,'THRIFT_TEMP',nion_prof_restart+1,nsj,ntimesteps_restart,ier,DBLVAR=temp3d)
+            IF (ier /= 0) CALL handle_err(HDF5_READ_ERR,'THRIFT_TEMP',ier)
+            TEMP_RESTART = temp3d(:,:,ntimesteps_restart)
+
+            DEALLOCATE(temp3d, temp2d)
+         END IF
+
+         CALL close_hdf5(fid,ier)
+         IF (ier /= 0) CALL handle_err(HDF5_CLOSE_ERR,TRIM(restart_filename),ier)
+      END IF
+
+      RETURN
+!----------------------------------------------------------------------
+!     END SUBROUTINE
+!----------------------------------------------------------------------
+      END SUBROUTINE thrift_restart

--- a/THRIFT/Sources/thrift_vars.f90
+++ b/THRIFT/Sources/thrift_vars.f90
@@ -96,13 +96,14 @@ MODULE thrift_vars
              win_thrift_gneo,    win_thrift_qneo,                                               &
              win_thrift_dens, win_thrift_temp, win_thrift_press, win_thrift_fast_alphas_dens,   &
              win_thrift_dens_restart,win_thrift_temp_restart,win_thrift_dens_fast_alphas_restart, &
-             win_thrift_dpecrhdv, win_thrift_pecrh     
+             win_thrift_er_restart, &
+             win_thrift_dpecrhdv, win_thrift_pecrh
     REAL(rprec) :: dt_first_iter
     INTEGER :: nion_prof_restart
     REAL(rprec), DIMENSION(:), POINTER :: THRIFT_RHO(:), THRIFT_RHOFULL(:), THRIFT_PHIEDGE(:), &
                                           THRIFT_S(:),   THRIFT_SNOB(:),  THRIFT_T(:),         &
                                           UGRID_RESTART(:), J_RESTART(:), THRIFT_BETATOT(:), &
-                                          DENS_FAST_ALPHAS_RESTART(:)
+                                          DENS_FAST_ALPHAS_RESTART(:), ER_RESTART(:)
     REAL(rprec), DIMENSION(:,:), POINTER :: &
                  THRIFT_J,THRIFT_I,THRIFT_UGRID, &
                  THRIFT_JPLASMA, THRIFT_IPLASMA, &

--- a/THRIFT/Sources/thrift_vars.f90
+++ b/THRIFT/Sources/thrift_vars.f90
@@ -98,6 +98,7 @@ MODULE thrift_vars
              win_thrift_dens_restart,win_thrift_temp_restart,win_thrift_dens_fast_alphas_restart, &
              win_thrift_dpecrhdv, win_thrift_pecrh     
     REAL(rprec) :: dt_first_iter
+    INTEGER :: nion_prof_restart
     REAL(rprec), DIMENSION(:), POINTER :: THRIFT_RHO(:), THRIFT_RHOFULL(:), THRIFT_PHIEDGE(:), &
                                           THRIFT_S(:),   THRIFT_SNOB(:),  THRIFT_T(:),         &
                                           UGRID_RESTART(:), J_RESTART(:), THRIFT_BETATOT(:), &

--- a/THRIFT/Sources/thrift_write.f90
+++ b/THRIFT/Sources/thrift_write.f90
@@ -47,6 +47,8 @@
          IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'ntimesteps',ier)
          CALL write_scalar_hdf5(fid,'nssize',ier,INTVAR=nsj,ATT='Number of Radial Gridpoints in s space',ATT_NAME='description')
          IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'nssize',ier)
+         CALL write_scalar_hdf5(fid,'nion_prof',ier,INTVAR=nion_prof,ATT='Number of ion species',ATT_NAME='description')
+         IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'nion_prof',ier)
          CALL write_scalar_hdf5(fid,'nrho',ier,INTVAR=nrho,ATT='Number of Radial Gridpoints',ATT_NAME='description')
          IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'nrho',ier)
          CALL write_scalar_hdf5(fid,'npicard',ier,INTVAR=npicard,ATT='Maximum number of Picard Iterations',ATT_NAME='description')

--- a/THRIFT/Sources/thrift_write.f90
+++ b/THRIFT/Sources/thrift_write.f90
@@ -312,6 +312,13 @@
          ! Electric Field
          CALL write_var_hdf5(fid,'plasma_Er',Nt_write,Nr_plasma_solver,ier,DBLVAR=plasma_Er(write_idx,:),ATT='Radial Electric Field [V/n]',ATT_NAME='description')
          IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'plasma_Er',ier)
+         ! aminor, Baxis and iota2o3 (needed for ISS04)
+         CALL write_var_hdf5(fid,'aminor',Nt_write,ier,DBLVAR=plasma_aminor(write_idx),ATT='aminor [m]',ATT_NAME='description')
+         IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'aminor',ier)
+         CALL write_var_hdf5(fid,'Baxis',Nt_write,ier,DBLVAR=plasma_Baxis(write_idx),ATT='Baxis [T]',ATT_NAME='description')
+         IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'Baxis',ier)
+         CALL write_var_hdf5(fid,'iota2o3',Nt_write,ier,DBLVAR=plasma_iota2o3(write_idx),ATT='iota2o3',ATT_NAME='description')
+         IF (ier /= 0) CALL handle_err(HDF5_WRITE_ERR,'iota2o3',ier)
          ! Close file
          CALL close_hdf5(fid,ier)
          IF (ier /= 0) CALL handle_err(HDF5_CLOSE_ERR,'plasma_solver_'//TRIM(id_string)//'.h5',ier)

--- a/pySTEL/libstell/plasma_solver.py
+++ b/pySTEL/libstell/plasma_solver.py
@@ -2167,7 +2167,7 @@ class PLASMA_SOLVER:
         saved_class.list_of_species = self.list_of_species
         # In case of a VMEC equilibrium
         if hasattr(self,'iota23'):
-            saved_class.iota23 = self.iota23
+            saved_class.iota2o3 = self.iota23
         
         # only save at minimum every dt=dt_save
         freq = max(1, round(dt_save / self.dt))

--- a/pySTEL/libstell/thrift.py
+++ b/pySTEL/libstell/thrift.py
@@ -1470,15 +1470,18 @@ class THRIFT_plasma_solver():
                 for temp in ['r_plasma_grid','plasma_N','plasma_T','N_fast_alphas','Dn_NEO','cn_NEO','Dp_NEO',\
                              'cp_NEO','G_NEO_complet','Q_NEO_complet','Dp_total','cp_total','Dn_total','cn_total',\
                              'S_radiated_power','S_alpha_power','S_energy_ext','S_particle_ext','dVdr','plasma_Er',\
-                             'iota2o3','plasma_aminor','plasma_Baxis']:
+                             'iota2o3','aminor','Baxis']:
                     data = np.array(f[temp])
                     # Check if the attribute exists; if not, initialize it
                     if not hasattr(self, temp):
                         setattr(self, temp, data)
                     else:
-                        # Concatenate the new data to the existing attribute
+                        # Concatenate the new data to the existing attribute along the last axis
                         existing_data = getattr(self, temp)
-                        setattr(self, temp, np.concatenate((existing_data, data),axis=1))                       
+                        if data.ndim == 1:
+                            setattr(self, temp, np.concatenate((existing_data, data), axis=0))       
+                        else:
+                            setattr(self, temp, np.concatenate((existing_data, data), axis=1))                    
                     
         ##################### TRANSPOSE DATA #################################
         #### 2D arrays should be [time,rho]

--- a/pySTEL/libstell/thrift.py
+++ b/pySTEL/libstell/thrift.py
@@ -1693,14 +1693,17 @@ class THRIFT_plasma_solver():
         saved_class.Er = self.plasma_Er[sl,:]
         
         for attr1,attr2 in zip(\
-            ('N','T','Dp','cp','Dn','cn','Dn_NEO','Dp_NEO','cp_NEO','cn_NEO','Q_NEO_complet','aminor','iota2o3','Baxis'),\
-            ('plasma_N','plasma_T','Dp_total','cp_total','Dn_total','cn_total','Dn_NEO','Dp_NEO','cp_NEO','cn_NEO','Q_NEO_complet','aminor','iota2o3','Baxis')):
+            ('N','T','Dp','cp','Dn','cn','Dn_NEO','Dp_NEO','cp_NEO','cn_NEO','Q_NEO_complet'),\
+            ('plasma_N','plasma_T','Dp_total','cp_total','Dn_total','cn_total','Dn_NEO','Dp_NEO','cp_NEO','cn_NEO','Q_NEO_complet')):
             setattr(saved_class, attr1, {})
             for ispecies,species in enumerate(self.list_of_species):
                 getattr(saved_class, attr1)[species] = getattr(self, attr2)[ispecies,sl,:]
         
         saved_class.N['alphas_fast'] = self.N_fast_alphas[sl,:]
-        
+        saved_class.aminor = self.aminor[sl]
+        saved_class.iota2o3 = self.iota2o3[sl]
+        saved_class.Baxis = self.Baxis[sl]
+
         saved_class.explicit_energy_sources   = defaultdict(dict)
         saved_class.explicit_particle_sources = defaultdict(dict)
         saved_class.Q_total = defaultdict(dict)

--- a/pySTEL/libstell/thrift.py
+++ b/pySTEL/libstell/thrift.py
@@ -1469,11 +1469,9 @@ class THRIFT_plasma_solver():
             with h5py.File(file,'r') as f:
                 for temp in ['r_plasma_grid','plasma_N','plasma_T','N_fast_alphas','Dn_NEO','cn_NEO','Dp_NEO',\
                              'cp_NEO','G_NEO_complet','Q_NEO_complet','Dp_total','cp_total','Dn_total','cn_total',\
-                             'S_radiated_power','S_alpha_power','S_energy_ext','S_particle_ext','dVdr','plasma_Er']:
-                    try:
-                        data = np.array(f[temp][:,:,:])
-                    except:
-                        data = np.array(f[temp][:,:])
+                             'S_radiated_power','S_alpha_power','S_energy_ext','S_particle_ext','dVdr','plasma_Er',\
+                             'iota2o3','plasma_aminor','plasma_Baxis']:
+                    data = np.array(f[temp])
                     # Check if the attribute exists; if not, initialize it
                     if not hasattr(self, temp):
                         setattr(self, temp, data)
@@ -1659,7 +1657,7 @@ class THRIFT_plasma_solver():
             for it,t in enumerate(self.t_grid_source): 
                 dset[:,it,species_id] = source(t)
                 
-    def convert_to_joblib(self,dt_save=0.1,filename='thrift_transport_simul',thrift_class=None):
+    def convert_to_joblib(self,dt_save=0.1,filename='thrift_transport_simul'):
         """ This function creates a joblib file with the transport simulation data
         We can the use the same post-processing tools we use to analyse transport simulations
         performed by pySTEL class plasma_solver
@@ -1691,7 +1689,9 @@ class THRIFT_plasma_solver():
         
         saved_class.Er = self.plasma_Er[sl,:]
         
-        for attr1,attr2 in zip(('N','T','Dp','cp','Dn','cn','Dn_NEO','Dp_NEO','cp_NEO','cn_NEO','Q_NEO_complet'),('plasma_N','plasma_T','Dp_total','cp_total','Dn_total','cn_total','Dn_NEO','Dp_NEO','cp_NEO','cn_NEO','Q_NEO_complet')):
+        for attr1,attr2 in zip(\
+            ('N','T','Dp','cp','Dn','cn','Dn_NEO','Dp_NEO','cp_NEO','cn_NEO','Q_NEO_complet','aminor','iota2o3','Baxis'),\
+            ('plasma_N','plasma_T','Dp_total','cp_total','Dn_total','cn_total','Dn_NEO','Dp_NEO','cp_NEO','cn_NEO','Q_NEO_complet','aminor','iota2o3','Baxis')):
             setattr(saved_class, attr1, {})
             for ispecies,species in enumerate(self.list_of_species):
                 getattr(saved_class, attr1)[species] = getattr(self, attr2)[ispecies,sl,:]
@@ -1731,12 +1731,6 @@ class THRIFT_plasma_solver():
             #
             saved_class.Q_turb[species] = saved_class.Q_total[species] - saved_class.Q_NEO[species]
             saved_class.Gamma_turb[species] = saved_class.Gamma_total[species] - saved_class.Gamma_NEO[species]
-            
-        if(thrift_class is not None):
-            saved_class.aminor = thrift_class.get_vars('THRIFT_AMINOR',time=saved_class.time)[:,-1]
-            saved_class.Rmajor = thrift_class.get_vars('THRIFT_RMAJOR',time=saved_class.time)[:,-1]
-            saved_class.B      = thrift_class.get_vars('THRIFT_BAV',  time=saved_class.time)[:,:]
-            saved_class.iota   = thrift_class.get_vars('THRIFT_IOTA',  time=saved_class.time)[:,:]
 
         joblib.dump(saved_class, output_filename)
         


### PR DESCRIPTION
This merge fixes a long-standing issue in THRIFT: thus far, the code was not able to make a restart when `add_NEO` was  TRUE (when solving the plasma equations). This had to do with the way a restart is handled in THRIFT: instead of having the first THRIFT time-step being equal to the last one of the previous run, the first THRIFT step corresponds to the _next_ time step. So if the code ended at `t=5` in the previous run and `dt_THRIFT=0.5`, then `THRIFT_T(1)` of the restarted run is 5.5 and not 5. 

The current merge does not change this paradigm. Instead, it makes the code run VMEC, booz_xform and DKES inside the newly created file `thrift_restart.f90`, such that the DKES coefficients become available to be used by PENTA, before THRIFT enters the subiteration loop of `thrift_evolve`.

After the current merge, the code restarts perfectly as can be seen by the following traces of current, density and temperature, where a restart was made at t=30s and t=60s:

<img width="1018" height="737" alt="image" src="https://github.com/user-attachments/assets/1d6e94c4-5a90-4f20-a484-aae83043921e" />
<img width="1125" height="733" alt="image" src="https://github.com/user-attachments/assets/1191c49a-2169-4d08-a3bc-a8f6d3195ff1" />
<img width="956" height="751" alt="image" src="https://github.com/user-attachments/assets/4621e231-b9e8-42e1-bc03-1cd8c15980b8" />
<img width="1004" height="754" alt="image" src="https://github.com/user-attachments/assets/e114687c-a84f-4524-94eb-3752cb165866" />
<img width="1004" height="754" alt="image" src="https://github.com/user-attachments/assets/92e76ddd-e226-459a-a93e-78fc0d22cd8e" />


My goal in a near-future is to change the restart mode to something more intuitive from a coding point of view: THRIFT_T(1) of a restarted run should be the same as THRIFT_T(-1) of the previous run. This way we can simply read all arrays of the last run and go straight to the loop in `thrift_evolve` without having to worry about anything else.