### PR TITLE
Make BEAMS3D VMEC grid construction deterministic

### DIFF
--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -42,11 +42,15 @@
       INTEGER :: MPI_COMM_LOCAL
       LOGICAL :: lnyquist, luse_vc, lcreate_wall, lverb_wall
       INTEGER :: ier, s, i, j, k, nu, nv, mystart, myend, mnmax_temp, u, v
+      INTEGER :: nfailed, ifailed
       INTEGER :: bcs1_s(2)
-      INTEGER, ALLOCATABLE :: xn_temp(:), xm_temp(:)
+      INTEGER, ALLOCATABLE :: xn_temp(:), xm_temp(:), failed_index(:)
+      LOGICAL, ALLOCATABLE :: retry_success(:)
       REAL :: br_vc, bphi_vc, bz_vc, xaxis_vc, yaxis_vc, zaxis_vc,&
               bx_vc, by_vc
       REAL(rprec) :: br, bphi, bz, sflx, uflx, xaxis, yaxis
+      REAL(rprec), ALLOCATABLE :: retry_s(:), retry_u(:), retry_br(:),&
+                                 retry_bphi(:), retry_bz(:)
       DOUBLE PRECISION, ALLOCATABLE :: mfact(:,:)
       DOUBLE PRECISION, ALLOCATABLE :: rmnc_temp(:,:),zmns_temp(:,:),&
                            bumnc_temp(:,:),bvmnc_temp(:,:),&
@@ -326,7 +330,8 @@
          j = MOD(s-1,nr*nphi)
          j = FLOOR(REAL(j) / REAL(nr))+1
          k = CEILING(REAL(s) / REAL(nr*nphi))
-         sflx = MAX(0.001,MIN(0.999,sflx))
+         sflx = 0.001
+         uflx = 0.0
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                       br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
          !PRINT *,i,j,k,raxis_g(i),phiaxis(j),zaxis_g(k), br, bphi, bz, sflx,uflx,ier
@@ -367,71 +372,80 @@
 #endif
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      !! Perform the 2nd Pass only inside domain
+      !! Retry reduced-tolerance lookups from an interior neighbor
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      IF (lverb) THEN
-         WRITE(6,*)
-         WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Plasma Field 2nd Pass [',0,']%'
-      END IF
-      CALL FLUSH(6)
+      nfailed = 0
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
          j = MOD(s-1,nr*nphi)
          j = FLOOR(REAL(j) / REAL(nr))+1
          k = CEILING(REAL(s) / REAL(nr*nphi))
-         ! First update progress
-         IF (MOD(s,nr) == 0) THEN
-            IF (lverb) THEN
-               CALL backspace_out(6,6)
-               WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
-            END IF
-         END IF
-         CALL FLUSH(6)
-         ! Don't do edge points
          IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
-         ! Now do the problematic parts
-         IF (S_ARR(i,j,k) < 0.0) THEN
-            sflx = 0; uflx = 0; br = 0; bphi = 0; bz = 0; u = 0
-            IF (S_ARR(i+1,j  ,k  )>=0.0) THEN
-               sflx = sflx + S_ARR(i+1,j  ,k  )
-               uflx = uflx + U_ARR(i+1,j  ,k  )
-               br   = br   +   B_R(i+1,j  ,k  )
-               bphi = bphi + B_PHI(i+1,j  ,k  )
-               bz   = bz   +   B_Z(i+1,j  ,k  )
-               u = u + 1
-            ENDIF
-            IF (S_ARR(i-1,j  ,k  )>=0.0) THEN
-               sflx = sflx + S_ARR(i-1,j  ,k  )
-               uflx = uflx + U_ARR(i-1,j  ,k  )
-               br   = br   +   B_R(i-1,j  ,k  )
-               bphi = bphi + B_PHI(i-1,j  ,k  )
-               bz   = bz   +   B_Z(i-1,j  ,k  )
-               u = u + 1
-            ENDIF
-            IF (S_ARR(i  ,j  ,k+1)>=0.0) THEN
-               sflx = sflx + S_ARR(i  ,j  ,k+1)
-               uflx = uflx + U_ARR(i  ,j  ,k+1)
-               br   = br   +   B_R(i  ,j  ,k+1)
-               bphi = bphi + B_PHI(i  ,j  ,k+1)
-               bz   = bz   +   B_Z(i  ,j  ,k+1)
-               u = u + 1
-            ENDIF
-            IF (S_ARR(i  ,j  ,k-1)>=0.0) THEN
-               sflx = sflx + S_ARR(i  ,j  ,k-1)
-               uflx = uflx + U_ARR(i  ,j  ,k-1)
-               br   = br   +   B_R(i  ,j  ,k-1)
-               bphi = bphi + B_PHI(i  ,j  ,k-1)
-               bz   = bz   +   B_Z(i  ,j  ,k-1)
-               u = u + 1
-            ENDIF
-            S_ARR(i,j,k) = sflx/DBLE(u)
-            U_ARR(i,j,k) = uflx/DBLE(u)
-            B_R(i,j,k)   =   br/DBLE(u)
-            B_PHI(i,j,k) = bphi/DBLE(u)
-            B_Z(i,j,k)   =   bz/DBLE(u)
-         ENDIF
-         CALL FLUSH(6)
+         IF (S_ARR(i,j,k) < 0.0) nfailed = nfailed + 1
       END DO
+
+      IF (nfailed > 0) THEN
+         ALLOCATE(failed_index(nfailed),retry_success(nfailed))
+         ALLOCATE(retry_s(nfailed),retry_u(nfailed),retry_br(nfailed),&
+                  retry_bphi(nfailed),retry_bz(nfailed))
+         retry_success = .false.
+         ifailed = 0
+         DO s = mystart, myend
+            i = MOD(s-1,nr)+1
+            j = MOD(s-1,nr*nphi)
+            j = FLOOR(REAL(j) / REAL(nr))+1
+            k = CEILING(REAL(s) / REAL(nr*nphi))
+            IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
+            IF (S_ARR(i,j,k) >= 0.0) CYCLE
+            ifailed = ifailed + 1
+            failed_index(ifailed) = s
+            sflx = -1.0
+            IF (S_ARR(i-1,j,k) >= 0.0 .and. S_ARR(i-1,j,k) <= 1.0) THEN
+               sflx = S_ARR(i-1,j,k)
+               uflx = U_ARR(i-1,j,k)
+            ELSE IF (S_ARR(i+1,j,k) >= 0.0 .and. S_ARR(i+1,j,k) <= 1.0) THEN
+               sflx = S_ARR(i+1,j,k)
+               uflx = U_ARR(i+1,j,k)
+            ELSE IF (S_ARR(i,j,k-1) >= 0.0 .and. S_ARR(i,j,k-1) <= 1.0) THEN
+               sflx = S_ARR(i,j,k-1)
+               uflx = U_ARR(i,j,k-1)
+            ELSE IF (S_ARR(i,j,k+1) >= 0.0 .and. S_ARR(i,j,k+1) <= 1.0) THEN
+               sflx = S_ARR(i,j,k+1)
+               uflx = U_ARR(i,j,k+1)
+            END IF
+            IF (sflx < 0.0) CYCLE
+            CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
+                         br,bphi,bz,SFLX=sflx,UFLX=uflx,info=ier)
+            IF (ier /= 0) CYCLE
+            retry_success(ifailed) = .true.
+            retry_s(ifailed) = MAX(sflx,0.0_rprec)
+            retry_u(ifailed) = MODULO(uflx,pi2)
+            retry_br(ifailed) = br
+            retry_bphi(ifailed) = bphi
+            retry_bz(ifailed) = bz
+         END DO
+      END IF
+
+#if defined(MPI_OPT)
+      CALL MPI_BARRIER(MPI_COMM_LOCAL,ierr_mpi)
+#endif
+      IF (nfailed > 0) THEN
+         DO ifailed = 1, nfailed
+            IF (.not. retry_success(ifailed)) CYCLE
+            s = failed_index(ifailed)
+            i = MOD(s-1,nr)+1
+            j = MOD(s-1,nr*nphi)
+            j = FLOOR(REAL(j) / REAL(nr))+1
+            k = CEILING(REAL(s) / REAL(nr*nphi))
+            S_ARR(i,j,k) = retry_s(ifailed)
+            U_ARR(i,j,k) = retry_u(ifailed)
+            B_R(i,j,k) = retry_br(ifailed)
+            B_PHI(i,j,k) = retry_bphi(ifailed)
+            B_Z(i,j,k) = retry_bz(ifailed)
+         END DO
+         DEALLOCATE(failed_index,retry_success,retry_s,retry_u,retry_br,&
+                    retry_bphi,retry_bz)
+      END IF
       
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       !! Set S==-1 values to default

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -372,7 +372,7 @@
 #endif
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      !! Retry reduced-tolerance lookups from an interior neighbor
+      !! Retry failed lookups from an interior-neighbor initial guess
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       nfailed = 0
       DO s = mystart, myend

--- a/BENCHMARKS/compare_beams3d_mpi_grid.py
+++ b/BENCHMARKS/compare_beams3d_mpi_grid.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+
+import h5py
+import numpy as np
+
+
+DATASETS = ("S_ARR", "U_ARR", "B_R", "B_PHI", "B_Z", "S_lines", "B_lines")
+
+
+def compare(reference_path, candidate_path):
+    failed = False
+    with h5py.File(reference_path) as reference, h5py.File(candidate_path) as candidate:
+        reference_mask = reference["S_ARR"][:] == 4.0
+        candidate_mask = candidate["S_ARR"][:] == 4.0
+        mask_changes = np.count_nonzero(reference_mask != candidate_mask)
+        print(f"default-mask changes: {mask_changes}")
+        failed = mask_changes != 0
+        for name in DATASETS:
+            reference_values = reference[name][:]
+            candidate_values = candidate[name][:]
+            changes = np.count_nonzero(reference_values != candidate_values)
+            max_difference = np.max(np.abs(reference_values - candidate_values))
+            print(f"{name}: changed={changes} max_abs={max_difference:.17e}")
+            failed = failed or changes != 0
+    return failed
+
+
+parser = ArgumentParser()
+parser.add_argument("reference")
+parser.add_argument("candidates", nargs="+")
+args = parser.parse_args()
+failed = False
+for candidate in args.candidates:
+    failed = compare(args.reference, candidate) or failed
+raise SystemExit(failed)


### PR DESCRIPTION
## Summary

Make the BEAMS3D VMEC Cartesian field grid independent of traversal order and MPI decomposition.

`beams3d_init_vmec` previously passed uninitialized `sflx` and `uflx` values into the first inverse lookup on each rank, then carried each result into the next grid point. Its second pass concurrently averaged failed cells in shared arrays, so a rank could read a neighbor before or after another rank changed it. The averaging also treated the periodic poloidal angle as a scalar.

The new first pass uses the same axis seed for every Cartesian point. Reduced-tolerance cells are retried from one valid interior neighbor selected in a fixed order. Retry results remain private until every rank finishes, then are committed after a shared-memory barrier. Failed cells retain the existing outside/default treatment. No field or angle is averaged.

The preserved invariant is the VMEC map `(R [m], phi [rad], Z [m]) -> (s, u [rad], B [T])`: the result at one Cartesian node does not depend on the preceding node or MPI partition. The equilibrium, `NFP` periodicity, LCFS boundary, coordinate conventions, and interior field equations are unchanged.

This is complementary to #459. That pull request improves inverse-solver convergence; this change removes BEAMS3D caller state and shared-array races without changing the inverse solver.

## Verification

### Test fails on main

The same W7-X `32 x 16 x 32` grid was constructed with 1 and 48 MPI ranks at `c47d790`:

```text
$ python BENCHMARKS/compare_beams3d_mpi_grid.py main-np1.h5 main-np48.h5
default-mask changes: 0
S_ARR: changed=1301 max_abs=2.23629497364541407e-07
U_ARR: changed=1247 max_abs=2.86359966850113778e-08
B_R: changed=1270 max_abs=1.12312335431852262e-07
B_PHI: changed=1059 max_abs=5.64656410517727636e-09
B_Z: changed=1272 max_abs=9.38857496191047858e-08
S_lines: changed=2 max_abs=9.86988268891764164e-14
B_lines: changed=1 max_abs=4.44089209850062616e-15
```

Exit status: 1.

### Test passes after fix

```text
$ python BENCHMARKS/compare_beams3d_mpi_grid.py fixed-np1.h5 fixed-np2.h5 fixed-np48.h5
default-mask changes: 0
S_ARR: changed=0 max_abs=0.00000000000000000e+00
U_ARR: changed=0 max_abs=0.00000000000000000e+00
B_R: changed=0 max_abs=0.00000000000000000e+00
B_PHI: changed=0 max_abs=0.00000000000000000e+00
B_Z: changed=0 max_abs=0.00000000000000000e+00
S_lines: changed=0 max_abs=0.00000000000000000e+00
B_lines: changed=0 max_abs=0.00000000000000000e+00
```

Exit status: 0. The default mask contains 11,314 cells in every run. Total elapsed times for 1, 2, and 48 ranks were 25 s, 15 s, and 19 s; the corresponding main runs took 22 s, 14 s, and 15 s.

The changed source also passed an incremental repository build:

```text
$ MACHINE=ubuntu ./build_all -o release -j 24 BEAMS3D
Begin building BEAMS3D
...
```

The executable completed all three MPI cases with exit status 0. Relative to the 48-rank main result, the fixed grid has the same default mask. The maximum changes among successful nodes are `3.99e-7` in `s`, `8.50e-7 rad` in `u`, and `2.41e-7 T` in a field component, within the inverse lookup tolerance.
