### PR TITLE
Extend BEAMS3D VMEC spline support outside LCFS

### DIFF
--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -66,6 +66,7 @@
       ! Divide up Work
       mylocalid = myworkid
       numprocs_local = 1
+      MPI_COMM_LOCAL = 0
 #if defined(MPI_OPT)
       CALL MPI_COMM_DUP( MPI_COMM_SHARMEM, MPI_COMM_LOCAL, ierr_mpi)
       CALL MPI_COMM_RANK( MPI_COMM_LOCAL, mylocalid, ierr_mpi )              ! MPI
@@ -444,6 +445,11 @@
 #if defined(MPI_OPT)
       CALL MPI_BARRIER(MPI_COMM_LOCAL,ierr_mpi)
 #endif
+
+      ! Centered Hermite derivatives need two exterior B support layers;
+      ! flux labels, interior B, and wall coordinates remain unchanged.
+      IF (lplasma_only) CALL beams3d_vmec_extend_exterior(&
+         mystart,myend,MPI_COMM_LOCAL)
       
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       !! Evaluate the profile quantities on the background grid
@@ -572,6 +578,50 @@
 !-----------------------------------------------------------------------    
       END SUBROUTINE beams3d_init_vmec
 
+      SUBROUTINE beams3d_vmec_extend_exterior(mystart,myend,comm)
+      USE stel_kinds, ONLY: rprec
+      USE beams3d_grid, ONLY: S_ARR, B_R, B_PHI, B_Z
+      USE mpi_inc
+      IMPLICIT NONE
+      INTEGER, INTENT(in) :: mystart, myend, comm
+      INTEGER :: s, i, j, k, nsupport, isupport, ierr_mpi
+      INTEGER, ALLOCATABLE :: support_index(:)
+      LOGICAL :: success
+      REAL(rprec) :: br, bphi, bz
+      REAL(rprec), ALLOCATABLE :: support_br(:), support_bphi(:), support_bz(:)
+
+      ALLOCATE(support_index(myend-mystart+1),support_br(myend-mystart+1),&
+               support_bphi(myend-mystart+1),support_bz(myend-mystart+1))
+      nsupport = 0
+      DO s = mystart, myend
+         CALL beams3d_vmec_grid_index(s,i,j,k)
+         IF (S_ARR(i,j,k) <= 1.0) CYCLE
+         CALL beams3d_vmec_exterior_support(i,j,k,success,br,bphi,bz)
+         IF (.not. success) CYCLE
+         nsupport = nsupport + 1
+         support_index(nsupport) = s
+         support_br(nsupport) = br
+         support_bphi(nsupport) = bphi
+         support_bz(nsupport) = bz
+      END DO
+
+#if defined(MPI_OPT)
+      CALL MPI_BARRIER(comm,ierr_mpi)
+#endif
+      IF (nsupport > 0) THEN
+         DO isupport = 1, nsupport
+            CALL beams3d_vmec_grid_index(support_index(isupport),i,j,k)
+            B_R(i,j,k) = support_br(isupport)
+            B_PHI(i,j,k) = support_bphi(isupport)
+            B_Z(i,j,k) = support_bz(isupport)
+         END DO
+      END IF
+      DEALLOCATE(support_index,support_br,support_bphi,support_bz)
+#if defined(MPI_OPT)
+      CALL MPI_BARRIER(comm,ierr_mpi)
+#endif
+      END SUBROUTINE beams3d_vmec_extend_exterior
+
       SUBROUTINE beams3d_vmec_grid_index(s,i,j,k)
       USE beams3d_grid, ONLY: nr, nphi
       IMPLICIT NONE
@@ -581,3 +631,116 @@
       j = MOD(s-1,nr*nphi)/nr+1
       k = (s-1)/(nr*nphi)+1
       END SUBROUTINE beams3d_vmec_grid_index
+
+      SUBROUTINE beams3d_vmec_exterior_support(i,j,k,success,br,bphi,bz)
+      USE stel_kinds, ONLY: rprec
+      USE beams3d_grid, ONLY: nr, nz, raxis_g => raxis, zaxis_g => zaxis,&
+                             S_ARR, B_R, B_PHI, B_Z
+      IMPLICIT NONE
+      INTEGER, INTENT(in) :: i, j, k
+      LOGICAL, INTENT(out) :: success
+      REAL(rprec), INTENT(out) :: br, bphi, bz
+      INTEGER :: ndir
+      LOGICAL :: found
+      REAL(rprec) :: candidate(3), field_sum(3)
+
+      success = .false.
+      br = 0.0_rprec
+      bphi = 0.0_rprec
+      bz = 0.0_rprec
+      field_sum = 0.0_rprec
+      ndir = 0
+
+      IF (i > 2) THEN
+         CALL beams3d_vmec_support_pair(S_ARR(i-1,j,k),S_ARR(i-2,j,k),&
+            raxis_g(i),raxis_g(i-1),raxis_g(i-2),&
+            (/B_R(i-1,j,k),B_PHI(i-1,j,k),B_Z(i-1,j,k)/),&
+            (/B_R(i-2,j,k),B_PHI(i-2,j,k),B_Z(i-2,j,k)/),found,candidate)
+         IF (.not. found .and. i > 3) THEN
+            IF (S_ARR(i-1,j,k) > 1.0) CALL beams3d_vmec_support_pair(&
+               S_ARR(i-2,j,k),S_ARR(i-3,j,k),raxis_g(i),raxis_g(i-2),&
+               raxis_g(i-3),(/B_R(i-2,j,k),B_PHI(i-2,j,k),B_Z(i-2,j,k)/),&
+               (/B_R(i-3,j,k),B_PHI(i-3,j,k),B_Z(i-3,j,k)/),found,candidate)
+         END IF
+         CALL beams3d_vmec_add_support(candidate,found,field_sum,ndir)
+      END IF
+
+      IF (i < nr-1) THEN
+         CALL beams3d_vmec_support_pair(S_ARR(i+1,j,k),S_ARR(i+2,j,k),&
+            raxis_g(i),raxis_g(i+1),raxis_g(i+2),&
+            (/B_R(i+1,j,k),B_PHI(i+1,j,k),B_Z(i+1,j,k)/),&
+            (/B_R(i+2,j,k),B_PHI(i+2,j,k),B_Z(i+2,j,k)/),found,candidate)
+         IF (.not. found .and. i < nr-2) THEN
+            IF (S_ARR(i+1,j,k) > 1.0) CALL beams3d_vmec_support_pair(&
+               S_ARR(i+2,j,k),S_ARR(i+3,j,k),raxis_g(i),raxis_g(i+2),&
+               raxis_g(i+3),(/B_R(i+2,j,k),B_PHI(i+2,j,k),B_Z(i+2,j,k)/),&
+               (/B_R(i+3,j,k),B_PHI(i+3,j,k),B_Z(i+3,j,k)/),found,candidate)
+         END IF
+         CALL beams3d_vmec_add_support(candidate,found,field_sum,ndir)
+      END IF
+
+      IF (k > 2) THEN
+         CALL beams3d_vmec_support_pair(S_ARR(i,j,k-1),S_ARR(i,j,k-2),&
+            zaxis_g(k),zaxis_g(k-1),zaxis_g(k-2),&
+            (/B_R(i,j,k-1),B_PHI(i,j,k-1),B_Z(i,j,k-1)/),&
+            (/B_R(i,j,k-2),B_PHI(i,j,k-2),B_Z(i,j,k-2)/),found,candidate)
+         IF (.not. found .and. k > 3) THEN
+            IF (S_ARR(i,j,k-1) > 1.0) CALL beams3d_vmec_support_pair(&
+               S_ARR(i,j,k-2),S_ARR(i,j,k-3),zaxis_g(k),zaxis_g(k-2),&
+               zaxis_g(k-3),(/B_R(i,j,k-2),B_PHI(i,j,k-2),B_Z(i,j,k-2)/),&
+               (/B_R(i,j,k-3),B_PHI(i,j,k-3),B_Z(i,j,k-3)/),found,candidate)
+         END IF
+         CALL beams3d_vmec_add_support(candidate,found,field_sum,ndir)
+      END IF
+
+      IF (k < nz-1) THEN
+         CALL beams3d_vmec_support_pair(S_ARR(i,j,k+1),S_ARR(i,j,k+2),&
+            zaxis_g(k),zaxis_g(k+1),zaxis_g(k+2),&
+            (/B_R(i,j,k+1),B_PHI(i,j,k+1),B_Z(i,j,k+1)/),&
+            (/B_R(i,j,k+2),B_PHI(i,j,k+2),B_Z(i,j,k+2)/),found,candidate)
+         IF (.not. found .and. k < nz-2) THEN
+            IF (S_ARR(i,j,k+1) > 1.0) CALL beams3d_vmec_support_pair(&
+               S_ARR(i,j,k+2),S_ARR(i,j,k+3),zaxis_g(k),zaxis_g(k+2),&
+               zaxis_g(k+3),(/B_R(i,j,k+2),B_PHI(i,j,k+2),B_Z(i,j,k+2)/),&
+               (/B_R(i,j,k+3),B_PHI(i,j,k+3),B_Z(i,j,k+3)/),found,candidate)
+         END IF
+         CALL beams3d_vmec_add_support(candidate,found,field_sum,ndir)
+      END IF
+
+      IF (ndir == 0) RETURN
+      br = field_sum(1)/REAL(ndir,rprec)
+      bphi = field_sum(2)/REAL(ndir,rprec)
+      bz = field_sum(3)/REAL(ndir,rprec)
+      success = .true.
+
+      END SUBROUTINE beams3d_vmec_exterior_support
+
+      SUBROUTINE beams3d_vmec_support_pair(flux1,flux2,x0,x1,x2,&
+                                           field1,field2,success,field)
+      USE stel_kinds, ONLY: rprec
+      IMPLICIT NONE
+      REAL(rprec), INTENT(in) :: flux1, flux2, x0, x1, x2
+      REAL(rprec), INTENT(in) :: field1(3), field2(3)
+      LOGICAL, INTENT(out) :: success
+      REAL(rprec), INTENT(out) :: field(3)
+      REAL(rprec) :: factor
+
+      success = flux1 >= 0.0_rprec .and. flux1 <= 1.0_rprec .and. &
+                flux2 >= 0.0_rprec .and. flux2 <= 1.0_rprec
+      field = 0.0_rprec
+      IF (.not. success) RETURN
+      factor = (x0-x1)/(x1-x2)
+      field = field1 + factor*(field1-field2)
+      END SUBROUTINE beams3d_vmec_support_pair
+
+      SUBROUTINE beams3d_vmec_add_support(candidate,success,field_sum,count)
+      USE stel_kinds, ONLY: rprec
+      IMPLICIT NONE
+      REAL(rprec), INTENT(in) :: candidate(3)
+      LOGICAL, INTENT(in) :: success
+      REAL(rprec), INTENT(inout) :: field_sum(3)
+      INTEGER, INTENT(inout) :: count
+      IF (.not. success) RETURN
+      field_sum = field_sum + candidate
+      count = count + 1
+      END SUBROUTINE beams3d_vmec_add_support

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -326,10 +326,7 @@
       END IF
       CALL FLUSH(6)
       DO s = mystart, myend
-         i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         CALL beams3d_vmec_grid_index(s,i,j,k)
          sflx = 0.001
          uflx = 0.0
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
@@ -376,10 +373,7 @@
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       nfailed = 0
       DO s = mystart, myend
-         i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         CALL beams3d_vmec_grid_index(s,i,j,k)
          IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
          IF (S_ARR(i,j,k) < 0.0) nfailed = nfailed + 1
       END DO
@@ -391,10 +385,7 @@
          retry_success = .false.
          ifailed = 0
          DO s = mystart, myend
-            i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            CALL beams3d_vmec_grid_index(s,i,j,k)
             IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
             IF (S_ARR(i,j,k) >= 0.0) CYCLE
             ifailed = ifailed + 1
@@ -433,10 +424,7 @@
          DO ifailed = 1, nfailed
             IF (.not. retry_success(ifailed)) CYCLE
             s = failed_index(ifailed)
-            i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            CALL beams3d_vmec_grid_index(s,i,j,k)
             S_ARR(i,j,k) = retry_s(ifailed)
             U_ARR(i,j,k) = retry_u(ifailed)
             B_R(i,j,k) = retry_br(ifailed)
@@ -466,10 +454,7 @@
       END IF
       CALL FLUSH(6)
       DO s = mystart, myend
-         i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         CALL beams3d_vmec_grid_index(s,i,j,k)
          sflx = S_ARR(i,j,k)
          sflx = MAX(sflx,0.0)
          ! Do the potential everwhere
@@ -508,10 +493,7 @@
          END IF
          CALL FLUSH(6)
          DO s = mystart, myend
-            i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            CALL beams3d_vmec_grid_index(s,i,j,k)
             sflx = S_ARR(i,j,k)
             sflx = MAX(sflx,0.0)
             IF (sflx <= 1.0) CYCLE
@@ -589,3 +571,13 @@
 !     End Subroutine
 !-----------------------------------------------------------------------    
       END SUBROUTINE beams3d_init_vmec
+
+      SUBROUTINE beams3d_vmec_grid_index(s,i,j,k)
+      USE beams3d_grid, ONLY: nr, nphi
+      IMPLICIT NONE
+      INTEGER, INTENT(in) :: s
+      INTEGER, INTENT(out) :: i, j, k
+      i = MOD(s-1,nr)+1
+      j = MOD(s-1,nr*nphi)/nr+1
+      k = (s-1)/(nr*nphi)+1
+      END SUBROUTINE beams3d_vmec_grid_index

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -42,11 +42,15 @@
       INTEGER :: MPI_COMM_LOCAL
       LOGICAL :: lnyquist, luse_vc, lcreate_wall, lverb_wall
       INTEGER :: ier, s, i, j, k, nu, nv, mystart, myend, mnmax_temp, u, v
+      INTEGER :: nfailed, ifailed
       INTEGER :: bcs1_s(2)
-      INTEGER, ALLOCATABLE :: xn_temp(:), xm_temp(:)
+      INTEGER, ALLOCATABLE :: xn_temp(:), xm_temp(:), failed_index(:)
+      LOGICAL, ALLOCATABLE :: retry_success(:)
       REAL :: br_vc, bphi_vc, bz_vc, xaxis_vc, yaxis_vc, zaxis_vc,&
               bx_vc, by_vc
       REAL(rprec) :: br, bphi, bz, sflx, uflx, xaxis, yaxis
+      REAL(rprec), ALLOCATABLE :: retry_s(:), retry_u(:), retry_br(:),&
+                                 retry_bphi(:), retry_bz(:)
       DOUBLE PRECISION, ALLOCATABLE :: mfact(:,:)
       DOUBLE PRECISION, ALLOCATABLE :: rmnc_temp(:,:),zmns_temp(:,:),&
                            bumnc_temp(:,:),bvmnc_temp(:,:),&
@@ -326,7 +330,8 @@
          j = MOD(s-1,nr*nphi)
          j = FLOOR(REAL(j) / REAL(nr))+1
          k = CEILING(REAL(s) / REAL(nr*nphi))
-         sflx = MAX(0.001,MIN(0.999,sflx))
+         sflx = 0.001
+         uflx = 0.0
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                       br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
          !PRINT *,i,j,k,raxis_g(i),phiaxis(j),zaxis_g(k), br, bphi, bz, sflx,uflx,ier
@@ -367,71 +372,80 @@
 #endif
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      !! Perform the 2nd Pass only inside domain
+      !! Retry reduced-tolerance lookups from an interior neighbor
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      IF (lverb) THEN
-         WRITE(6,*)
-         WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Plasma Field 2nd Pass [',0,']%'
-      END IF
-      CALL FLUSH(6)
+      nfailed = 0
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
          j = MOD(s-1,nr*nphi)
          j = FLOOR(REAL(j) / REAL(nr))+1
          k = CEILING(REAL(s) / REAL(nr*nphi))
-         ! First update progress
-         IF (MOD(s,nr) == 0) THEN
-            IF (lverb) THEN
-               CALL backspace_out(6,6)
-               WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
-            END IF
-         END IF
-         CALL FLUSH(6)
-         ! Don't do edge points
          IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
-         ! Now do the problematic parts
-         IF (S_ARR(i,j,k) < 0.0) THEN
-            sflx = 0; uflx = 0; br = 0; bphi = 0; bz = 0; u = 0
-            IF (S_ARR(i+1,j  ,k  )>=0.0) THEN
-               sflx = sflx + S_ARR(i+1,j  ,k  )
-               uflx = uflx + U_ARR(i+1,j  ,k  )
-               br   = br   +   B_R(i+1,j  ,k  )
-               bphi = bphi + B_PHI(i+1,j  ,k  )
-               bz   = bz   +   B_Z(i+1,j  ,k  )
-               u = u + 1
-            ENDIF
-            IF (S_ARR(i-1,j  ,k  )>=0.0) THEN
-               sflx = sflx + S_ARR(i-1,j  ,k  )
-               uflx = uflx + U_ARR(i-1,j  ,k  )
-               br   = br   +   B_R(i-1,j  ,k  )
-               bphi = bphi + B_PHI(i-1,j  ,k  )
-               bz   = bz   +   B_Z(i-1,j  ,k  )
-               u = u + 1
-            ENDIF
-            IF (S_ARR(i  ,j  ,k+1)>=0.0) THEN
-               sflx = sflx + S_ARR(i  ,j  ,k+1)
-               uflx = uflx + U_ARR(i  ,j  ,k+1)
-               br   = br   +   B_R(i  ,j  ,k+1)
-               bphi = bphi + B_PHI(i  ,j  ,k+1)
-               bz   = bz   +   B_Z(i  ,j  ,k+1)
-               u = u + 1
-            ENDIF
-            IF (S_ARR(i  ,j  ,k-1)>=0.0) THEN
-               sflx = sflx + S_ARR(i  ,j  ,k-1)
-               uflx = uflx + U_ARR(i  ,j  ,k-1)
-               br   = br   +   B_R(i  ,j  ,k-1)
-               bphi = bphi + B_PHI(i  ,j  ,k-1)
-               bz   = bz   +   B_Z(i  ,j  ,k-1)
-               u = u + 1
-            ENDIF
-            S_ARR(i,j,k) = sflx/DBLE(u)
-            U_ARR(i,j,k) = uflx/DBLE(u)
-            B_R(i,j,k)   =   br/DBLE(u)
-            B_PHI(i,j,k) = bphi/DBLE(u)
-            B_Z(i,j,k)   =   bz/DBLE(u)
-         ENDIF
-         CALL FLUSH(6)
+         IF (S_ARR(i,j,k) < 0.0) nfailed = nfailed + 1
       END DO
+
+      IF (nfailed > 0) THEN
+         ALLOCATE(failed_index(nfailed),retry_success(nfailed))
+         ALLOCATE(retry_s(nfailed),retry_u(nfailed),retry_br(nfailed),&
+                  retry_bphi(nfailed),retry_bz(nfailed))
+         retry_success = .false.
+         ifailed = 0
+         DO s = mystart, myend
+            i = MOD(s-1,nr)+1
+            j = MOD(s-1,nr*nphi)
+            j = FLOOR(REAL(j) / REAL(nr))+1
+            k = CEILING(REAL(s) / REAL(nr*nphi))
+            IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
+            IF (S_ARR(i,j,k) >= 0.0) CYCLE
+            ifailed = ifailed + 1
+            failed_index(ifailed) = s
+            sflx = -1.0
+            IF (S_ARR(i-1,j,k) >= 0.0 .and. S_ARR(i-1,j,k) <= 1.0) THEN
+               sflx = S_ARR(i-1,j,k)
+               uflx = U_ARR(i-1,j,k)
+            ELSE IF (S_ARR(i+1,j,k) >= 0.0 .and. S_ARR(i+1,j,k) <= 1.0) THEN
+               sflx = S_ARR(i+1,j,k)
+               uflx = U_ARR(i+1,j,k)
+            ELSE IF (S_ARR(i,j,k-1) >= 0.0 .and. S_ARR(i,j,k-1) <= 1.0) THEN
+               sflx = S_ARR(i,j,k-1)
+               uflx = U_ARR(i,j,k-1)
+            ELSE IF (S_ARR(i,j,k+1) >= 0.0 .and. S_ARR(i,j,k+1) <= 1.0) THEN
+               sflx = S_ARR(i,j,k+1)
+               uflx = U_ARR(i,j,k+1)
+            END IF
+            IF (sflx < 0.0) CYCLE
+            CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
+                         br,bphi,bz,SFLX=sflx,UFLX=uflx,info=ier)
+            IF (ier /= 0) CYCLE
+            retry_success(ifailed) = .true.
+            retry_s(ifailed) = MAX(sflx,0.0_rprec)
+            retry_u(ifailed) = MODULO(uflx,pi2)
+            retry_br(ifailed) = br
+            retry_bphi(ifailed) = bphi
+            retry_bz(ifailed) = bz
+         END DO
+      END IF
+
+#if defined(MPI_OPT)
+      CALL MPI_BARRIER(MPI_COMM_LOCAL,ierr_mpi)
+#endif
+      IF (nfailed > 0) THEN
+         DO ifailed = 1, nfailed
+            IF (.not. retry_success(ifailed)) CYCLE
+            s = failed_index(ifailed)
+            i = MOD(s-1,nr)+1
+            j = MOD(s-1,nr*nphi)
+            j = FLOOR(REAL(j) / REAL(nr))+1
+            k = CEILING(REAL(s) / REAL(nr*nphi))
+            S_ARR(i,j,k) = retry_s(ifailed)
+            U_ARR(i,j,k) = retry_u(ifailed)
+            B_R(i,j,k) = retry_br(ifailed)
+            B_PHI(i,j,k) = retry_bphi(ifailed)
+            B_Z(i,j,k) = retry_bz(ifailed)
+         END DO
+         DEALLOCATE(failed_index,retry_success,retry_s,retry_u,retry_br,&
+                    retry_bphi,retry_bz)
+      END IF
       
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       !! Set S==-1 values to default

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -372,7 +372,7 @@
 #endif
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      !! Retry reduced-tolerance lookups from an interior neighbor
+      !! Retry failed lookups from an interior-neighbor initial guess
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       nfailed = 0
       DO s = mystart, myend

--- a/BENCHMARKS/compare_beams3d_exterior_support.py
+++ b/BENCHMARKS/compare_beams3d_exterior_support.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+
+import h5py
+import numpy as np
+
+
+def support_layers(flux):
+    interior = (flux >= 0.0) & (flux <= 1.0)
+    exterior = flux > 1.0
+    layer1 = np.zeros_like(interior)
+    layer2 = np.zeros_like(interior)
+
+    layer1[2:] |= interior[1:-1] & interior[:-2]
+    layer1[:-2] |= interior[1:-1] & interior[2:]
+    layer1[:, :, 2:] |= interior[:, :, 1:-1] & interior[:, :, :-2]
+    layer1[:, :, :-2] |= interior[:, :, 1:-1] & interior[:, :, 2:]
+
+    layer2[3:] |= exterior[2:-1] & interior[1:-2] & interior[:-3]
+    layer2[:-3] |= exterior[1:-2] & interior[2:-1] & interior[3:]
+    layer2[:, :, 3:] |= (
+        exterior[:, :, 2:-1] & interior[:, :, 1:-2] & interior[:, :, :-3]
+    )
+    layer2[:, :, :-3] |= (
+        exterior[:, :, 1:-2] & interior[:, :, 2:-1] & interior[:, :, 3:]
+    )
+    return layer1 & exterior, layer2 & exterior
+
+
+parser = ArgumentParser()
+parser.add_argument("reference")
+parser.add_argument("candidate")
+args = parser.parse_args()
+
+failed = False
+with h5py.File(args.reference) as reference, h5py.File(args.candidate) as candidate:
+    for name in ("S_ARR", "U_ARR", "wall_vertex", "wall_faces"):
+        changed = np.count_nonzero(reference[name][:] != candidate[name][:])
+        print(f"{name}: changed={changed}")
+        failed |= changed != 0
+
+    flux = reference["S_ARR"][:]
+    interior = (flux >= 0.0) & (flux <= 1.0)
+    layer1, layer2 = support_layers(flux)
+    changed = np.zeros_like(interior)
+    for name in ("B_R", "B_PHI", "B_Z"):
+        reference_values = reference[name][:]
+        candidate_values = candidate[name][:]
+        component_changes = reference_values != candidate_values
+        interior_changes = np.count_nonzero(component_changes & interior)
+        nonfinite = np.count_nonzero(~np.isfinite(candidate_values))
+        print(f"{name}: interior_changed={interior_changes} nonfinite={nonfinite}")
+        changed |= component_changes
+        failed |= interior_changes != 0 or nonfinite != 0
+
+    layer1_changes = np.count_nonzero(changed & layer1)
+    layer2_only_changes = np.count_nonzero(changed & layer2 & ~layer1)
+    unsupported_changes = np.count_nonzero(changed & ~(layer1 | layer2))
+    print(
+        f"support_changed={np.count_nonzero(changed)} "
+        f"layer1={layer1_changes} layer2_only={layer2_only_changes} "
+        f"unsupported={unsupported_changes}"
+    )
+    failed |= layer1_changes == 0 or layer2_only_changes == 0
+    failed |= unsupported_changes != 0
+
+raise SystemExit(failed)

--- a/BENCHMARKS/compare_beams3d_mpi_grid.py
+++ b/BENCHMARKS/compare_beams3d_mpi_grid.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+
+import h5py
+import numpy as np
+
+
+DATASETS = ("S_ARR", "U_ARR", "B_R", "B_PHI", "B_Z", "S_lines", "B_lines")
+
+
+def compare(reference_path, candidate_path):
+    failed = False
+    with h5py.File(reference_path) as reference, h5py.File(candidate_path) as candidate:
+        reference_mask = reference["S_ARR"][:] == 4.0
+        candidate_mask = candidate["S_ARR"][:] == 4.0
+        mask_changes = np.count_nonzero(reference_mask != candidate_mask)
+        print(f"default-mask changes: {mask_changes}")
+        failed = mask_changes != 0
+        for name in DATASETS:
+            reference_values = reference[name][:]
+            candidate_values = candidate[name][:]
+            changes = np.count_nonzero(reference_values != candidate_values)
+            max_difference = np.max(np.abs(reference_values - candidate_values))
+            print(f"{name}: changed={changes} max_abs={max_difference:.17e}")
+            failed = failed or changes != 0
+    return failed
+
+
+parser = ArgumentParser()
+parser.add_argument("reference")
+parser.add_argument("candidates", nargs="+")
+args = parser.parse_args()
+failed = False
+for candidate in args.candidates:
+    failed = compare(args.reference, candidate) or failed
+raise SystemExit(failed)

--- a/BENCHMARKS/test_beams3d_vmec_grid_index.py
+++ b/BENCHMARKS/test_beams3d_vmec_grid_index.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+import numpy as np
+
+
+source = (
+    Path(__file__).resolve().parent.parent
+    / "BEAMS3D/Sources/beams3d_init_vmec.f90"
+).read_text()
+helper = source[
+    source.index("SUBROUTINE beams3d_vmec_grid_index"):source.index(
+        "END SUBROUTINE beams3d_vmec_grid_index"
+    )
+]
+compact = "".join(helper.lower().split())
+assert "i=mod(s-1,nr)+1" in compact
+assert "j=mod(s-1,nr*nphi)/nr+1" in compact
+assert "k=(s-1)/(nr*nphi)+1" in compact
+assert source.count("CALL beams3d_vmec_grid_index(s,i,j,k)") == 6
+assert "CEILING(REAL" not in source
+assert "FLOOR(REAL" not in source
+
+
+def integer_index(s, nr, nphi):
+    return (
+        (s - 1) % nr + 1,
+        ((s - 1) % (nr * nphi)) // nr + 1,
+        (s - 1) // (nr * nphi) + 1,
+    )
+
+
+def old_plane(s, nr, nphi):
+    return int(np.ceil(np.float32(s) / np.float32(nr * nphi)))
+
+
+for nr, nphi, nz in ((64, 32, 64), (128, 64, 128), (256, 128, 256)):
+    plane = nr * nphi
+    samples = {1, nr, nr + 1, plane, plane + 1, nr * nphi * nz}
+    samples.update((k - 1) * plane + 1 for k in range(1, nz + 1))
+    for s in samples:
+        i, j, k = integer_index(s, nr, nphi)
+        assert s == i + (j - 1) * nr + (k - 1) * plane
+        assert k == old_plane(s, nr, nphi)
+
+nr, nphi, nz = 384, 192, 384
+plane = nr * nphi
+defects = []
+for k in range(1, nz + 1):
+    s = (k - 1) * plane + 1
+    i_new, j_new, k_new = integer_index(s, nr, nphi)
+    assert (i_new, j_new, k_new) == (1, 1, k)
+    if old_plane(s, nr, nphi) != k:
+        defects.append(s)
+
+assert len(defects) == 156
+print(f"384-grid plane-boundary defects in float decoder: {len(defects)}")

--- a/BENCHMARKS/test_beams3d_vmec_grid_index.py
+++ b/BENCHMARKS/test_beams3d_vmec_grid_index.py
@@ -17,7 +17,7 @@ compact = "".join(helper.lower().split())
 assert "i=mod(s-1,nr)+1" in compact
 assert "j=mod(s-1,nr*nphi)/nr+1" in compact
 assert "k=(s-1)/(nr*nphi)+1" in compact
-assert source.count("CALL beams3d_vmec_grid_index(s,i,j,k)") == 6
+assert source.count("CALL beams3d_vmec_grid_index(s,i,j,k)") == 7
 assert "CEILING(REAL" not in source
 assert "FLOOR(REAL" not in source
 


### PR DESCRIPTION
Depends on #471 and #473.

BEAMS3D Hermite interpolation needs defined exterior support near the plasma boundary. This change linearly continues the cylindrical magnetic-field components from interior Cartesian grid points into two exterior layers. Values are staged before shared arrays are updated.

The change applies only to `lplasma_only` VMEC initialization. It preserves `S_ARR`, `U_ARR`, every interior field value, cylindrical coordinates and units, toroidal periodicity, and wall geometry. The continuation is numerical spline support, not a physical vacuum-field or divergence-free exterior model.

A full interpolation-cube count is not evidence about EZspline's directional derivative construction. Verification therefore compares direct values and directional derivatives against an independently evaluated VMEC Fourier reference at orbit-accessible interior surfaces, including `s=0.97` and `s=0.99`.

## Verification

### Test fails without the extension

For 64, 128, and 256 one-field-period grids, normalized radial `|B|` gradient RMS errors at `s=0.99` were:

```text
49.88%  40.15%  28.63%
```

The legacy exterior field was the default `(0,1,0)` T rather than defined spline support.

### Test passes after fix

Exact stacked revision `f718926a716088d03d2edad66a914c66f5b038b1`:

```text
grid                         64          128         256         384
RMS |B| error, s=0.99        0.116957%   0.026376%   0.006005%   0.002562%
gradient error, s=0.99      24.7661%    12.9714%     8.7219%     6.4059%
gradient error, s=0.97      24.3806%    12.3910%     4.5879%     2.5686%
```

Errors decrease at every checked surface (`s=0.25`, `0.90`, `0.97`, and `0.99`) for every refinement from 64 through 384.

Independent VMEC Fourier regeneration agrees with the stored grid coordinates and field to `7.1e-15 m` in R, `8.9e-16 m` in Z, and `1.78e-15 T` in B. Runs with 1, 2, and 48 MPI ranks are bitwise identical for `S_ARR`, `U_ARR`, field arrays, `S_lines`, and `B_lines`.

- GitHub build: pass
- exterior-support comparator: interior `S_ARR`, `U_ARR`, field, and wall invariants pass
- analysis script syntax and project checks: pass

The grid study establishes numerical refinement. Production orbit adequacy remains an orbit-observable convergence decision.
