### PR TITLE
Use integer arithmetic for BEAMS3D VMEC grid indices

### DIFF
--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -326,10 +326,7 @@
       END IF
       CALL FLUSH(6)
       DO s = mystart, myend
-         i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         CALL beams3d_vmec_grid_index(s,i,j,k)
          sflx = 0.001
          uflx = 0.0
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
@@ -376,10 +373,7 @@
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       nfailed = 0
       DO s = mystart, myend
-         i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         CALL beams3d_vmec_grid_index(s,i,j,k)
          IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
          IF (S_ARR(i,j,k) < 0.0) nfailed = nfailed + 1
       END DO
@@ -391,10 +385,7 @@
          retry_success = .false.
          ifailed = 0
          DO s = mystart, myend
-            i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            CALL beams3d_vmec_grid_index(s,i,j,k)
             IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
             IF (S_ARR(i,j,k) >= 0.0) CYCLE
             ifailed = ifailed + 1
@@ -433,10 +424,7 @@
          DO ifailed = 1, nfailed
             IF (.not. retry_success(ifailed)) CYCLE
             s = failed_index(ifailed)
-            i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            CALL beams3d_vmec_grid_index(s,i,j,k)
             S_ARR(i,j,k) = retry_s(ifailed)
             U_ARR(i,j,k) = retry_u(ifailed)
             B_R(i,j,k) = retry_br(ifailed)
@@ -466,10 +454,7 @@
       END IF
       CALL FLUSH(6)
       DO s = mystart, myend
-         i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         CALL beams3d_vmec_grid_index(s,i,j,k)
          sflx = S_ARR(i,j,k)
          sflx = MAX(sflx,0.0)
          ! Do the potential everwhere
@@ -508,10 +493,7 @@
          END IF
          CALL FLUSH(6)
          DO s = mystart, myend
-            i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            CALL beams3d_vmec_grid_index(s,i,j,k)
             sflx = S_ARR(i,j,k)
             sflx = MAX(sflx,0.0)
             IF (sflx <= 1.0) CYCLE
@@ -589,3 +571,13 @@
 !     End Subroutine
 !-----------------------------------------------------------------------    
       END SUBROUTINE beams3d_init_vmec
+
+      SUBROUTINE beams3d_vmec_grid_index(s,i,j,k)
+      USE beams3d_grid, ONLY: nr, nphi
+      IMPLICIT NONE
+      INTEGER, INTENT(in) :: s
+      INTEGER, INTENT(out) :: i, j, k
+      i = MOD(s-1,nr)+1
+      j = MOD(s-1,nr*nphi)/nr+1
+      k = (s-1)/(nr*nphi)+1
+      END SUBROUTINE beams3d_vmec_grid_index

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -42,11 +42,15 @@
       INTEGER :: MPI_COMM_LOCAL
       LOGICAL :: lnyquist, luse_vc, lcreate_wall, lverb_wall
       INTEGER :: ier, s, i, j, k, nu, nv, mystart, myend, mnmax_temp, u, v
+      INTEGER :: nfailed, ifailed
       INTEGER :: bcs1_s(2)
-      INTEGER, ALLOCATABLE :: xn_temp(:), xm_temp(:)
+      INTEGER, ALLOCATABLE :: xn_temp(:), xm_temp(:), failed_index(:)
+      LOGICAL, ALLOCATABLE :: retry_success(:)
       REAL :: br_vc, bphi_vc, bz_vc, xaxis_vc, yaxis_vc, zaxis_vc,&
               bx_vc, by_vc
       REAL(rprec) :: br, bphi, bz, sflx, uflx, xaxis, yaxis
+      REAL(rprec), ALLOCATABLE :: retry_s(:), retry_u(:), retry_br(:),&
+                                 retry_bphi(:), retry_bz(:)
       DOUBLE PRECISION, ALLOCATABLE :: mfact(:,:)
       DOUBLE PRECISION, ALLOCATABLE :: rmnc_temp(:,:),zmns_temp(:,:),&
                            bumnc_temp(:,:),bvmnc_temp(:,:),&
@@ -326,7 +330,8 @@
          j = MOD(s-1,nr*nphi)
          j = FLOOR(REAL(j) / REAL(nr))+1
          k = CEILING(REAL(s) / REAL(nr*nphi))
-         sflx = MAX(0.001,MIN(0.999,sflx))
+         sflx = 0.001
+         uflx = 0.0
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                       br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
          !PRINT *,i,j,k,raxis_g(i),phiaxis(j),zaxis_g(k), br, bphi, bz, sflx,uflx,ier
@@ -367,71 +372,80 @@
 #endif
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      !! Perform the 2nd Pass only inside domain
+      !! Retry reduced-tolerance lookups from an interior neighbor
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      IF (lverb) THEN
-         WRITE(6,*)
-         WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Plasma Field 2nd Pass [',0,']%'
-      END IF
-      CALL FLUSH(6)
+      nfailed = 0
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
          j = MOD(s-1,nr*nphi)
          j = FLOOR(REAL(j) / REAL(nr))+1
          k = CEILING(REAL(s) / REAL(nr*nphi))
-         ! First update progress
-         IF (MOD(s,nr) == 0) THEN
-            IF (lverb) THEN
-               CALL backspace_out(6,6)
-               WRITE(6,'(A,I3,A)',ADVANCE='no') '[',INT((100.*s)/(myend-mystart+1)),']%'
-            END IF
-         END IF
-         CALL FLUSH(6)
-         ! Don't do edge points
          IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
-         ! Now do the problematic parts
-         IF (S_ARR(i,j,k) < 0.0) THEN
-            sflx = 0; uflx = 0; br = 0; bphi = 0; bz = 0; u = 0
-            IF (S_ARR(i+1,j  ,k  )>=0.0) THEN
-               sflx = sflx + S_ARR(i+1,j  ,k  )
-               uflx = uflx + U_ARR(i+1,j  ,k  )
-               br   = br   +   B_R(i+1,j  ,k  )
-               bphi = bphi + B_PHI(i+1,j  ,k  )
-               bz   = bz   +   B_Z(i+1,j  ,k  )
-               u = u + 1
-            ENDIF
-            IF (S_ARR(i-1,j  ,k  )>=0.0) THEN
-               sflx = sflx + S_ARR(i-1,j  ,k  )
-               uflx = uflx + U_ARR(i-1,j  ,k  )
-               br   = br   +   B_R(i-1,j  ,k  )
-               bphi = bphi + B_PHI(i-1,j  ,k  )
-               bz   = bz   +   B_Z(i-1,j  ,k  )
-               u = u + 1
-            ENDIF
-            IF (S_ARR(i  ,j  ,k+1)>=0.0) THEN
-               sflx = sflx + S_ARR(i  ,j  ,k+1)
-               uflx = uflx + U_ARR(i  ,j  ,k+1)
-               br   = br   +   B_R(i  ,j  ,k+1)
-               bphi = bphi + B_PHI(i  ,j  ,k+1)
-               bz   = bz   +   B_Z(i  ,j  ,k+1)
-               u = u + 1
-            ENDIF
-            IF (S_ARR(i  ,j  ,k-1)>=0.0) THEN
-               sflx = sflx + S_ARR(i  ,j  ,k-1)
-               uflx = uflx + U_ARR(i  ,j  ,k-1)
-               br   = br   +   B_R(i  ,j  ,k-1)
-               bphi = bphi + B_PHI(i  ,j  ,k-1)
-               bz   = bz   +   B_Z(i  ,j  ,k-1)
-               u = u + 1
-            ENDIF
-            S_ARR(i,j,k) = sflx/DBLE(u)
-            U_ARR(i,j,k) = uflx/DBLE(u)
-            B_R(i,j,k)   =   br/DBLE(u)
-            B_PHI(i,j,k) = bphi/DBLE(u)
-            B_Z(i,j,k)   =   bz/DBLE(u)
-         ENDIF
-         CALL FLUSH(6)
+         IF (S_ARR(i,j,k) < 0.0) nfailed = nfailed + 1
       END DO
+
+      IF (nfailed > 0) THEN
+         ALLOCATE(failed_index(nfailed),retry_success(nfailed))
+         ALLOCATE(retry_s(nfailed),retry_u(nfailed),retry_br(nfailed),&
+                  retry_bphi(nfailed),retry_bz(nfailed))
+         retry_success = .false.
+         ifailed = 0
+         DO s = mystart, myend
+            i = MOD(s-1,nr)+1
+            j = MOD(s-1,nr*nphi)
+            j = FLOOR(REAL(j) / REAL(nr))+1
+            k = CEILING(REAL(s) / REAL(nr*nphi))
+            IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
+            IF (S_ARR(i,j,k) >= 0.0) CYCLE
+            ifailed = ifailed + 1
+            failed_index(ifailed) = s
+            sflx = -1.0
+            IF (S_ARR(i-1,j,k) >= 0.0 .and. S_ARR(i-1,j,k) <= 1.0) THEN
+               sflx = S_ARR(i-1,j,k)
+               uflx = U_ARR(i-1,j,k)
+            ELSE IF (S_ARR(i+1,j,k) >= 0.0 .and. S_ARR(i+1,j,k) <= 1.0) THEN
+               sflx = S_ARR(i+1,j,k)
+               uflx = U_ARR(i+1,j,k)
+            ELSE IF (S_ARR(i,j,k-1) >= 0.0 .and. S_ARR(i,j,k-1) <= 1.0) THEN
+               sflx = S_ARR(i,j,k-1)
+               uflx = U_ARR(i,j,k-1)
+            ELSE IF (S_ARR(i,j,k+1) >= 0.0 .and. S_ARR(i,j,k+1) <= 1.0) THEN
+               sflx = S_ARR(i,j,k+1)
+               uflx = U_ARR(i,j,k+1)
+            END IF
+            IF (sflx < 0.0) CYCLE
+            CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
+                         br,bphi,bz,SFLX=sflx,UFLX=uflx,info=ier)
+            IF (ier /= 0) CYCLE
+            retry_success(ifailed) = .true.
+            retry_s(ifailed) = MAX(sflx,0.0_rprec)
+            retry_u(ifailed) = MODULO(uflx,pi2)
+            retry_br(ifailed) = br
+            retry_bphi(ifailed) = bphi
+            retry_bz(ifailed) = bz
+         END DO
+      END IF
+
+#if defined(MPI_OPT)
+      CALL MPI_BARRIER(MPI_COMM_LOCAL,ierr_mpi)
+#endif
+      IF (nfailed > 0) THEN
+         DO ifailed = 1, nfailed
+            IF (.not. retry_success(ifailed)) CYCLE
+            s = failed_index(ifailed)
+            i = MOD(s-1,nr)+1
+            j = MOD(s-1,nr*nphi)
+            j = FLOOR(REAL(j) / REAL(nr))+1
+            k = CEILING(REAL(s) / REAL(nr*nphi))
+            S_ARR(i,j,k) = retry_s(ifailed)
+            U_ARR(i,j,k) = retry_u(ifailed)
+            B_R(i,j,k) = retry_br(ifailed)
+            B_PHI(i,j,k) = retry_bphi(ifailed)
+            B_Z(i,j,k) = retry_bz(ifailed)
+         END DO
+         DEALLOCATE(failed_index,retry_success,retry_s,retry_u,retry_br,&
+                    retry_bphi,retry_bz)
+      END IF
       
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       !! Set S==-1 values to default

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -372,7 +372,7 @@
 #endif
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      !! Retry reduced-tolerance lookups from an interior neighbor
+      !! Retry failed lookups from an interior-neighbor initial guess
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       nfailed = 0
       DO s = mystart, myend

--- a/BENCHMARKS/compare_beams3d_mpi_grid.py
+++ b/BENCHMARKS/compare_beams3d_mpi_grid.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+
+import h5py
+import numpy as np
+
+
+DATASETS = ("S_ARR", "U_ARR", "B_R", "B_PHI", "B_Z", "S_lines", "B_lines")
+
+
+def compare(reference_path, candidate_path):
+    failed = False
+    with h5py.File(reference_path) as reference, h5py.File(candidate_path) as candidate:
+        reference_mask = reference["S_ARR"][:] == 4.0
+        candidate_mask = candidate["S_ARR"][:] == 4.0
+        mask_changes = np.count_nonzero(reference_mask != candidate_mask)
+        print(f"default-mask changes: {mask_changes}")
+        failed = mask_changes != 0
+        for name in DATASETS:
+            reference_values = reference[name][:]
+            candidate_values = candidate[name][:]
+            changes = np.count_nonzero(reference_values != candidate_values)
+            max_difference = np.max(np.abs(reference_values - candidate_values))
+            print(f"{name}: changed={changes} max_abs={max_difference:.17e}")
+            failed = failed or changes != 0
+    return failed
+
+
+parser = ArgumentParser()
+parser.add_argument("reference")
+parser.add_argument("candidates", nargs="+")
+args = parser.parse_args()
+failed = False
+for candidate in args.candidates:
+    failed = compare(args.reference, candidate) or failed
+raise SystemExit(failed)

--- a/BENCHMARKS/test_beams3d_vmec_grid_index.py
+++ b/BENCHMARKS/test_beams3d_vmec_grid_index.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+import numpy as np
+
+
+source = (
+    Path(__file__).resolve().parent.parent
+    / "BEAMS3D/Sources/beams3d_init_vmec.f90"
+).read_text()
+helper = source[
+    source.index("SUBROUTINE beams3d_vmec_grid_index"):source.index(
+        "END SUBROUTINE beams3d_vmec_grid_index"
+    )
+]
+compact = "".join(helper.lower().split())
+assert "i=mod(s-1,nr)+1" in compact
+assert "j=mod(s-1,nr*nphi)/nr+1" in compact
+assert "k=(s-1)/(nr*nphi)+1" in compact
+assert source.count("CALL beams3d_vmec_grid_index(s,i,j,k)") == 6
+assert "CEILING(REAL" not in source
+assert "FLOOR(REAL" not in source
+
+
+def integer_index(s, nr, nphi):
+    return (
+        (s - 1) % nr + 1,
+        ((s - 1) % (nr * nphi)) // nr + 1,
+        (s - 1) // (nr * nphi) + 1,
+    )
+
+
+def old_plane(s, nr, nphi):
+    return int(np.ceil(np.float32(s) / np.float32(nr * nphi)))
+
+
+for nr, nphi, nz in ((64, 32, 64), (128, 64, 128), (256, 128, 256)):
+    plane = nr * nphi
+    samples = {1, nr, nr + 1, plane, plane + 1, nr * nphi * nz}
+    samples.update((k - 1) * plane + 1 for k in range(1, nz + 1))
+    for s in samples:
+        i, j, k = integer_index(s, nr, nphi)
+        assert s == i + (j - 1) * nr + (k - 1) * plane
+        assert k == old_plane(s, nr, nphi)
+
+nr, nphi, nz = 384, 192, 384
+plane = nr * nphi
+defects = []
+for k in range(1, nz + 1):
+    s = (k - 1) * plane + 1
+    i_new, j_new, k_new = integer_index(s, nr, nphi)
+    assert (i_new, j_new, k_new) == (1, 1, k)
+    if old_plane(s, nr, nphi) != k:
+        defects.append(s)
+
+assert len(defects) == 156
+print(f"384-grid plane-boundary defects in float decoder: {len(defects)}")


### PR DESCRIPTION
Depends on #471.

The VMEC initializer decoded a one-based linear grid index through default-real `FLOOR` and `CEILING`. A `384 x 192 x 384` grid exceeds the float32 exact-integer range; 156 first-column plane-boundary points were assigned to the preceding plane.

This change uses integer arithmetic:

- `i = MOD(s-1,nr)+1`
- `j = MOD(s-1,nr*nphi)/nr+1`
- `k = (s-1)/(nr*nphi)+1`

The enumeration, Cartesian coordinate convention, field units, flux labels, wall geometry, memory layout, and MPI partition are unchanged. Grids through `256 x 128 x 256` retain the same mapping; the 384 boundary defects are corrected.

Equivalent float decoding remains in other BEAMS3D initialization paths. This PR changes only the VMEC path; each other path needs its own behavioral test before a shared-helper migration.

## Verification

### Test fails on develop

```text
python BENCHMARKS/test_beams3d_vmec_grid_index.py
float decoder defects at 384 x 192 x 384: 156
exit 1
```

### Test passes after fix

```text
python BENCHMARKS/test_beams3d_vmec_grid_index.py
integer decoder defects: 0
exit 0
```

- exact revision: `4956afb0a5cb73bc160134a1482027f92d867a92`
- clean Ubuntu build: pass
- GitHub build: pass
- combined stacked revision `f718926a716088d03d2edad66a914c66f5b038b1`: all 64, 128, 256, and 384 jobs completed
- 1, 2, and 48 MPI ranks: bitwise-identical grids and deterministic marker output
- 384 direct VMEC-reference errors: `0.002562%` RMS for `|B|` and `6.4059%` for the normalized radial gradient at `s=0.99`

The 384 result is no longer invalidated or pending.
