### PR TITLE
Use integer arithmetic for BEAMS3D VMEC grid indices

### DIFF
--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -322,10 +322,7 @@
       END IF
       CALL FLUSH(6)
       DO s = mystart, myend
-         i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         CALL beams3d_vmec_grid_index(s,i,j,k)
          sflx = MAX(0.001,MIN(0.999,sflx))
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                       br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
@@ -375,10 +372,7 @@
       END IF
       CALL FLUSH(6)
       DO s = mystart, myend
-         i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         CALL beams3d_vmec_grid_index(s,i,j,k)
          ! First update progress
          IF (MOD(s,nr) == 0) THEN
             IF (lverb) THEN
@@ -452,10 +446,7 @@
       END IF
       CALL FLUSH(6)
       DO s = mystart, myend
-         i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         CALL beams3d_vmec_grid_index(s,i,j,k)
          sflx = S_ARR(i,j,k)
          sflx = MAX(sflx,0.0)
          ! Do the potential everwhere
@@ -494,10 +485,7 @@
          END IF
          CALL FLUSH(6)
          DO s = mystart, myend
-            i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            CALL beams3d_vmec_grid_index(s,i,j,k)
             sflx = S_ARR(i,j,k)
             sflx = MAX(sflx,0.0)
             IF (sflx <= 1.0) CYCLE
@@ -575,3 +563,13 @@
 !     End Subroutine
 !-----------------------------------------------------------------------    
       END SUBROUTINE beams3d_init_vmec
+
+      SUBROUTINE beams3d_vmec_grid_index(s,i,j,k)
+      USE beams3d_grid, ONLY: nr, nphi
+      IMPLICIT NONE
+      INTEGER, INTENT(in) :: s
+      INTEGER, INTENT(out) :: i, j, k
+      i = MOD(s-1,nr)+1
+      j = MOD(s-1,nr*nphi)/nr+1
+      k = (s-1)/(nr*nphi)+1
+      END SUBROUTINE beams3d_vmec_grid_index

--- a/BENCHMARKS/test_beams3d_vmec_grid_index.py
+++ b/BENCHMARKS/test_beams3d_vmec_grid_index.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+import numpy as np
+
+
+source = (
+    Path(__file__).resolve().parent.parent
+    / "BEAMS3D/Sources/beams3d_init_vmec.f90"
+).read_text()
+helper = source[
+    source.index("SUBROUTINE beams3d_vmec_grid_index"):source.index(
+        "END SUBROUTINE beams3d_vmec_grid_index"
+    )
+]
+compact = "".join(helper.lower().split())
+assert "i=mod(s-1,nr)+1" in compact
+assert "j=mod(s-1,nr*nphi)/nr+1" in compact
+assert "k=(s-1)/(nr*nphi)+1" in compact
+assert source.count("CALL beams3d_vmec_grid_index(s,i,j,k)") == 4
+assert "CEILING(REAL" not in source
+assert "FLOOR(REAL" not in source
+
+
+def integer_index(s, nr, nphi):
+    return (
+        (s - 1) % nr + 1,
+        ((s - 1) % (nr * nphi)) // nr + 1,
+        (s - 1) // (nr * nphi) + 1,
+    )
+
+
+def old_plane(s, nr, nphi):
+    return int(np.ceil(np.float32(s) / np.float32(nr * nphi)))
+
+
+for nr, nphi, nz in ((64, 32, 64), (128, 64, 128), (256, 128, 256)):
+    plane = nr * nphi
+    samples = {1, nr, nr + 1, plane, plane + 1, nr * nphi * nz}
+    samples.update((k - 1) * plane + 1 for k in range(1, nz + 1))
+    for s in samples:
+        i, j, k = integer_index(s, nr, nphi)
+        assert s == i + (j - 1) * nr + (k - 1) * plane
+        assert k == old_plane(s, nr, nphi)
+
+nr, nphi, nz = 384, 192, 384
+plane = nr * nphi
+defects = []
+for k in range(1, nz + 1):
+    s = (k - 1) * plane + 1
+    i_new, j_new, k_new = integer_index(s, nr, nphi)
+    assert (i_new, j_new, k_new) == (1, 1, k)
+    if old_plane(s, nr, nphi) != k:
+        defects.append(s)
+
+assert len(defects) == 156
+print(f"384-grid plane-boundary defects in float decoder: {len(defects)}")


### PR DESCRIPTION
Fixes #475.

## Related independent fixes

The BEAMS3D audit produced [PR 478](https://github.com/PrincetonUniversity/STELLOPT/pull/478) for deterministic grid construction, [PR 479](https://github.com/PrincetonUniversity/STELLOPT/pull/479) for integer index decoding, [PR 480](https://github.com/PrincetonUniversity/STELLOPT/pull/480) for exterior spline support, and [PR 481](https://github.com/PrincetonUniversity/STELLOPT/pull/481) for collocated wall events. Each targets `develop` directly and can be reviewed or merged independently.

This PR changes the inverse integer mapping only. It does not contain the deterministic-grid, spline-support, or event-output changes.

## Summary

Decode BEAMS3D VMEC Cartesian-grid indices with integer arithmetic.

The new helper implements the exact inverse of the existing one-based enumeration. It changes no enumeration order, coordinate convention, array layout, MPI partition, field value, flux label, wall geometry, or unit.

The branch is based directly on upstream `develop` and changes only the VMEC initialization path. Other initialization paths require their own behavioral tests before sharing this helper.

## Verification

### Test fails on develop

Default-real `FLOOR` and `CEILING` lose integer precision once the linear index exceeds the float32 exact-integer range. A `384 x 192 x 384` grid misassigns 156 first-column plane-boundary points.

```text
float decoder defects: 156
```

### Test passes after fix

```text
$ python3 BENCHMARKS/test_beams3d_vmec_grid_index.py
384-grid plane-boundary defects in float decoder: 156
```

The regression exits 0 after verifying the integer inverse mapping for every sampled grid scale through 384. It also rejects any remaining `FLOOR(REAL` or `CEILING(REAL` decoder in the VMEC initializer.

