### PR TITLE
Bugfix/linearto3 dindexing

### DIFF
--- a/.github/workflows/build_use_docker.yml
+++ b/.github/workflows/build_use_docker.yml
@@ -20,5 +20,5 @@ jobs:
           ./build_all -o clean_debug -j 2
       - name: test
         run: |
-          make -C BENCHMARKS test_indexing
+          python3 -m unittest discover -s BENCHMARKS/tests -v
           mpiexec ./bin/xstelloptv2 test -h

--- a/.github/workflows/build_use_docker.yml
+++ b/.github/workflows/build_use_docker.yml
@@ -17,7 +17,7 @@ jobs:
       - name: compile
         run: |
           cd ${STELLOPT_PATH}
-          ./build_all -o clean_debug -j 2
+          ./build_all -o clean_debug -j 1
       - name: test
         run: |
           python3 -m unittest discover -s BENCHMARKS/tests -v

--- a/.github/workflows/build_use_docker.yml
+++ b/.github/workflows/build_use_docker.yml
@@ -20,4 +20,5 @@ jobs:
           ./build_all -o clean_debug -j 2
       - name: test
         run: |
+          make -C BENCHMARKS test_indexing
           mpiexec ./bin/xstelloptv2 test -h

--- a/BEAMS3D/Sources/beams3d_beam_density.f90
+++ b/BEAMS3D/Sources/beams3d_beam_density.f90
@@ -24,7 +24,7 @@
 !-----------------------------------------------------------------------
       IMPLICIT NONE
       LOGICAL :: lline_in_box
-      INTEGER :: ier, l, nl, i, j, k, m, s
+      INTEGER :: ier, l, nl, i, j, k, m, s, nrm1, nphim1
       DOUBLE PRECISION :: x0, y0, z0, x1, y1, z1, hr2, hz2, hp2, d, &
                           denbeam, dl, dV
       DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: xl,yl,zl,rl,sl,pl
@@ -94,12 +94,13 @@
       CALL MPI_BARRIER(MPI_COMM_SHARMEM,ierr_mpi)
 #endif
       ! Now Divide by the grid volumes
-      CALL MPI_CALC_MYRANGE(MPI_COMM_SHARMEM, 1, (nr-1)*(nphi-1)*(nz-1), mystart, myend)
+      nrm1 = nr - 1
+      nphim1 = nphi - 1
+      CALL MPI_CALC_MYRANGE(MPI_COMM_SHARMEM, 1, nrm1*nphim1*(nz-1), mystart, myend)
       DO s = mystart,myend
-         i = MOD(s-1,nr-1)+1
-         j = MOD(s-1,(nr-1)*(nphi-1))
-         j = FLOOR(REAL(j) / REAL(nr-1))+1
-         k = CEILING(REAL(s) / REAL((nr-1)*(nphi-1)))
+         i = MOD(s-1,nrm1)+1
+         j = MOD(s-1,nrm1*nphim1)/nrm1+1
+         k = (s-1)/(nrm1*nphim1)+1
          dV = raxis(i)*hr(i)*hp(j)*hz(k)
          BEAM_DENSITY(:,i,j,k) = BEAM_DENSITY(:,i,j,k) / dV
       END DO

--- a/BEAMS3D/Sources/beams3d_distnorm.f90
+++ b/BEAMS3D/Sources/beams3d_distnorm.f90
@@ -80,10 +80,9 @@
       ! Iterate over volumes
       DO s = mystart, myend
          ! Distribution grid index
-         i = MOD(s-1,(ns_prof1))+1
-         j = MOD(s-1,(ns_prof1)*(ns_prof2))
-         j = FLOOR(REAL(j) / REAL(ns_prof1))+1
-         k = CEILING(REAL(s) / REAL(ns_prof1*ns_prof2))
+         i = MOD(s-1,ns_prof1)+1
+         j = MOD(s-1,ns_prof1*ns_prof2)/ns_prof1+1
+         k = (s-1)/(ns_prof1*ns_prof2)+1
 
          ! Bounding values of rho and u, p is centered in voxel
          rho1 = (i-1)*ds

--- a/BEAMS3D/Sources/beams3d_init_coil.f90
+++ b/BEAMS3D/Sources/beams3d_init_coil.f90
@@ -118,9 +118,8 @@
       ! Get the fields
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          br = 0; bphi = 0; bz = 0
          br_temp   = 0
          bphi_temp = 0

--- a/BEAMS3D/Sources/beams3d_init_continuegrid.f90
+++ b/BEAMS3D/Sources/beams3d_init_continuegrid.f90
@@ -94,9 +94,8 @@ SUBROUTINE beams3d_init_continuegrid
 #endif
    DO s = mystart, myend
       i = MOD(s-1,nr)+1
-      j = MOD(s-1,nr*nphi)
-      j = FLOOR(REAL(j) / REAL(nr))+1
-      k = CEILING(REAL(s) / REAL(nr*nphi))
+      j = MOD(s-1,nr*nphi)/nr+1
+      k = (s-1)/(nr*nphi)+1
       sflx = 0.0
 
       ! Bfield

--- a/BEAMS3D/Sources/beams3d_init_eqdsk.f90
+++ b/BEAMS3D/Sources/beams3d_init_eqdsk.f90
@@ -160,8 +160,7 @@
 #endif
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         k = MOD(s-1,nr*nz)
-         k = FLOOR(REAL(k) / REAL(nr))+1
+         k = MOD(s-1,nr*nz)/nr+1
          sflx = 0.0
 
          ! Bfield

--- a/BEAMS3D/Sources/beams3d_init_fieldlines.f90
+++ b/BEAMS3D/Sources/beams3d_init_fieldlines.f90
@@ -95,9 +95,8 @@
 #endif
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          sflx = 0.0
 
          ! Bfield

--- a/BEAMS3D/Sources/beams3d_init_fusion.f90
+++ b/BEAMS3D/Sources/beams3d_init_fusion.f90
@@ -122,9 +122,8 @@
       IF (lfusion_alpha) THEN
          DO s = mystart, myend
             i = MOD(s-1,nr1)+1
-            j = MOD(s-1,nr1*nphi1)
-            j = FLOOR(REAL(j) / REAL(nr1))+1
-            k = CEILING(REAL(s) / REAL(nr1*nphi1))
+            j = MOD(s-1,nr1*nphi1)/nr1+1
+            k = (s-1)/(nr1*nphi1)+1
             q = (/raxis(i), phiaxis(j), zaxis(k)/)+0.5*(/hr(i),hp(j),hz(k)/) ! Half grid
             CALL beams3d_DTRATE(q,rateDT(i,j,k))
             maxrateDT = MAX(rateDT(i,j,k),maxrateDT)
@@ -135,9 +134,8 @@
       IF (lfusion_tritium .or. lfusion_proton) THEN
          DO s = mystart, myend
             i = MOD(s-1,nr1)+1
-            j = MOD(s-1,nr1*nphi1)
-            j = FLOOR(REAL(j) / REAL(nr1))+1
-            k = CEILING(REAL(s) / REAL(nr1*nphi1))
+            j = MOD(s-1,nr1*nphi1)/nr1+1
+            k = (s-1)/(nr1*nphi1)+1
             q = (/raxis(i), phiaxis(j), zaxis(k)/)+0.5*(/hr(i),hp(j),hz(k)/) ! Half grid
             CALL beams3d_DDTRATE(q,rateDDT(i,j,k))
             maxrateDDT = MAX(rateDDT(i,j,k),maxrateDDT)
@@ -148,9 +146,8 @@
       IF (lfusion_He3) THEN
          DO s = mystart, myend
             i = MOD(s-1,nr1)+1
-            j = MOD(s-1,nr1*nphi1)
-            j = FLOOR(REAL(j) / REAL(nr1))+1
-            k = CEILING(REAL(s) / REAL(nr1*nphi1))
+            j = MOD(s-1,nr1*nphi1)/nr1+1
+            k = (s-1)/(nr1*nphi1)+1
             q = (/raxis(i), phiaxis(j), zaxis(k)/)+0.5*(/hr(i),hp(j),hz(k)/) ! Half grid
             CALL beams3d_DDHe3RATE(q,rateDDHe(i,j,k))
             maxrateDDHe = MAX(rateDDHe(i,j,k),maxrateDDHe)
@@ -161,9 +158,8 @@
       IF (lfusion_DHe3) THEN ! should probably be it's own thing
          DO s = mystart, myend
             i = MOD(s-1,nr1)+1
-            j = MOD(s-1,nr1*nphi1)
-            j = FLOOR(REAL(j) / REAL(nr1))+1
-            k = CEILING(REAL(s) / REAL(nr1*nphi1))
+            j = MOD(s-1,nr1*nphi1)/nr1+1
+            k = (s-1)/(nr1*nphi1)+1
             q = (/raxis(i), phiaxis(j), zaxis(k)/)+0.5*(/hr(i),hp(j),hz(k)/) ! Half grid
             CALL beams3d_DHe3RATE(q,rateDHe3(i,j,k))
             maxrateDHe3 = MAX(rateDHe3(i,j,k),maxrateDHe3)
@@ -173,9 +169,8 @@
       ! l3d array and volume normalization
       DO s = mystart, myend
          i = MOD(s-1,nr1)+1
-         j = MOD(s-1,nr1*nphi1)
-         j = FLOOR(REAL(j) / REAL(nr1))+1
-         k = CEILING(REAL(s) / REAL(nr1*nphi1))
+         j = MOD(s-1,nr1*nphi1)/nr1+1
+         k = (s-1)/(nr1*nphi1)+1
          q = (/raxis(i), phiaxis(j), zaxis(k)/)+0.5*(/hr(i),hp(j),hz(k)/) ! Half grid
          CALL beams3d_SFLX(q,sval)
          IF (sval < sfactor) l3d(i,j,k) = .true.
@@ -236,9 +231,8 @@
       ! Add volume back into neutrons
       DO s = mystart, myend
          i = MOD(s-1,nr1)+1
-         j = MOD(s-1,nr1*nphi1)
-         j = FLOOR(REAL(j) / REAL(nr1))+1
-         k = CEILING(REAL(s) / REAL(nr1*nphi1))
+         j = MOD(s-1,nr1*nphi1)/nr1+1
+         k = (s-1)/(nr1*nphi1)+1
          ! We have the n/s but we need to add the volume back in (dV=rdrdpdz)
          dV = (raxis(i)+0.5*hr(i))*hr(i)*hp(j)*hz(k)
          NEUTRONS_ARR(:,i,j,k) = NEUTRONS_ARR(:,i,j,k)/dV
@@ -349,9 +343,8 @@
             vpart = sqrt(2*E_BEAMS(l)/mHe4)
             DO s = 1,nr1*nphi1*nz1
                i = MOD(s-1,nr1)+1
-               j = MOD(s-1,nr1*nphi1)
-               j = FLOOR(REAL(j) / REAL(nr1))+1
-               k = CEILING(REAL(s) / REAL(nr1*nphi1))
+               j = MOD(s-1,nr1*nphi1)/nr1+1
+               k = (s-1)/(nr1*nphi1)+1
                IF (n3d(i,j,k)==0) CYCLE
                k2 = n3d(i,j,k)+k1-1
                R_start(k1:k2)   =   raxis(i) + X_rand(k1:k2)*hr(i)
@@ -375,9 +368,8 @@
             !E_NEUTRONS(l) = 3.02E6
             DO s = 1,nr1*nphi1*nz1
                i = MOD(s-1,nr1)+1
-               j = MOD(s-1,nr1*nphi1)
-               j = FLOOR(REAL(j) / REAL(nr1))+1
-               k = CEILING(REAL(s) / REAL(nr1*nphi1))
+               j = MOD(s-1,nr1*nphi1)/nr1+1
+               k = (s-1)/(nr1*nphi1)+1
                IF (n3d(i,j,k)==0) CYCLE
                k2 = n3d(i,j,k)+k1-1
                R_start(k1:k2)   =   raxis(i) + X_rand(k1:k2)*hr(i)
@@ -401,9 +393,8 @@
             !E_NEUTRONS(l) = 2.45E6
             DO s = 1,nr1*nphi1*nz1
                i = MOD(s-1,nr1)+1
-               j = MOD(s-1,nr1*nphi1)
-               j = FLOOR(REAL(j) / REAL(nr1))+1
-               k = CEILING(REAL(s) / REAL(nr1*nphi1))
+               j = MOD(s-1,nr1*nphi1)/nr1+1
+               k = (s-1)/(nr1*nphi1)+1
                IF (n3d(i,j,k)==0) CYCLE
                k2 = n3d(i,j,k)+k1-1
                R_start(k1:k2)   =   raxis(i) + X_rand(k1:k2)*hr(i)
@@ -426,9 +417,8 @@
             vpart = sqrt(2*E_BEAMS(l)/mHe3)
             DO s = 1,nr1*nphi1*nz1
                i = MOD(s-1,nr1)+1
-               j = MOD(s-1,nr1*nphi1)
-               j = FLOOR(REAL(j) / REAL(nr1))+1
-               k = CEILING(REAL(s) / REAL(nr1*nphi1))
+               j = MOD(s-1,nr1*nphi1)/nr1+1
+               k = (s-1)/(nr1*nphi1)+1
                IF (n3d(i,j,k)==0) CYCLE
                k2 = n3d(i,j,k)+k1-1
                R_start(k1:k2)   =   raxis(i) + X_rand(k1:k2)*hr(i)
@@ -452,9 +442,8 @@
             !E_NEUTRONS(l) = 2.45E6
             DO s = 1,nr1*nphi1*nz1
                i = MOD(s-1,nr1)+1
-               j = MOD(s-1,nr1*nphi1)
-               j = FLOOR(REAL(j) / REAL(nr1))+1
-               k = CEILING(REAL(s) / REAL(nr1*nphi1))
+               j = MOD(s-1,nr1*nphi1)/nr1+1
+               k = (s-1)/(nr1*nphi1)+1
                IF (n3d(i,j,k)==0) CYCLE
                k2 = n3d(i,j,k)+k1-1
                R_start(k1:k2)   =   raxis(i) + X_rand(k1:k2)*hr(i)
@@ -476,9 +465,8 @@
             !E_NEUTRONS(l) = 2.45E6
             DO s = 1,nr1*nphi1*nz1
                i = MOD(s-1,nr1)+1
-               j = MOD(s-1,nr1*nphi1)
-               j = FLOOR(REAL(j) / REAL(nr1))+1
-               k = CEILING(REAL(s) / REAL(nr1*nphi1))
+               j = MOD(s-1,nr1*nphi1)/nr1+1
+               k = (s-1)/(nr1*nphi1)+1
                IF (n3d(i,j,k)==0) CYCLE
                k2 = n3d(i,j,k)+k1-1
                R_start(k1:k2)   =   raxis(i) + X_rand(k1:k2)*hr(i)

--- a/BEAMS3D/Sources/beams3d_init_hint.f90
+++ b/BEAMS3D/Sources/beams3d_init_hint.f90
@@ -97,9 +97,8 @@
 #endif
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          sflx = 0.0
 
          ! Bfield

--- a/BEAMS3D/Sources/beams3d_init_mgrid.f90
+++ b/BEAMS3D/Sources/beams3d_init_mgrid.f90
@@ -110,9 +110,8 @@
       ! Get the fields
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          CALL mgrid_bcyl(raxis(i), phiaxis(j), zaxis(k), &
                                        br, bphi, bz, ier)
          IF (ier /= 0) stop 'mgrid_bcyl error!'

--- a/BEAMS3D/Sources/beams3d_init_mumat.f90
+++ b/BEAMS3D/Sources/beams3d_init_mumat.f90
@@ -162,18 +162,16 @@
       IF (lissubmaster) THEN
          DO s = 1, ourstart-1
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             B_R(i,j,k)   = 0.0
             B_PHI(i,j,k) = 0.0
             B_Z(i,j,k)   = 0.0
          END DO
          DO s = ourend+1, nr*nphi*nz
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             B_R(i,j,k)   = 0.0
             B_PHI(i,j,k) = 0.0
             B_Z(i,j,k)   = 0.0
@@ -194,9 +192,8 @@
       ! Get the fields
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          br_temp   = 0
          bphi_temp = 0
          bz_temp   = 0

--- a/BEAMS3D/Sources/beams3d_init_user.f90
+++ b/BEAMS3D/Sources/beams3d_init_user.f90
@@ -55,9 +55,8 @@
       ! Here is where you can set the mangetic field.
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          ! Pure vertical field
          B_R(i,j,k)   = 0.0
          B_PHI(i,j,k) = 0.0

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -323,9 +323,8 @@
       CALL FLUSH(6)
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          sflx = MAX(0.001,MIN(0.999,sflx))
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                       br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
@@ -376,9 +375,8 @@
       CALL FLUSH(6)
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          ! First update progress
          IF (MOD(s,nr) == 0) THEN
             IF (lverb) THEN
@@ -453,9 +451,8 @@
       CALL FLUSH(6)
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          sflx = S_ARR(i,j,k)
          sflx = MAX(sflx,0.0)
          ! Do the potential everwhere
@@ -495,9 +492,8 @@
          CALL FLUSH(6)
          DO s = mystart, myend
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             sflx = S_ARR(i,j,k)
             sflx = MAX(sflx,0.0)
             IF (sflx <= 1.0) CYCLE

--- a/BENCHMARKS/makefile
+++ b/BENCHMARKS/makefile
@@ -19,7 +19,10 @@
   MPI_RUN_OPTS_MD ?= $(MPI_RUN_OPTS)
   MPI_RUN_OPTS_LG ?= $(MPI_RUN_OPTS)
 
-.PHONY: test_vmec
+.PHONY: test_indexing test_vmec
+
+test_indexing:
+	python3 -m unittest discover -s tests -v
 
 test_beams3d:
 	@echo "Beginning testing of BEAMS3D"
@@ -471,6 +474,7 @@ help:
 	@echo "      LTRAVIS:         " $(LTRAVIS)
 	@echo ""
 	@echo "   COMMANDS"
+	@echo "      test_indexing   Testing of linear to 3D indexing"
 	@echo "      test_beams3d    Tesing of BEAMS3D"
 	@echo "      test_diagno     Tesing of DIAGNO"
 	@echo "      test_fieldlines Tesing of FIELDLINES"

--- a/BENCHMARKS/tests/test_linear_to_3d_indexing.py
+++ b/BENCHMARKS/tests/test_linear_to_3d_indexing.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Regression tests for converting a linear index to three dimensions."""
+
+import math
+import struct
+import unittest
+
+
+FLOAT32_LIMIT = 2**24
+
+
+def decode_integer(index, nr, nphi):
+    """Decode a one-based linear index using integer arithmetic."""
+    i = (index - 1) % nr + 1
+    j = (index - 1) % (nr * nphi) // nr + 1
+    k = (index - 1) // (nr * nphi) + 1
+    return i, j, k
+
+
+def encode(i, j, k, nr, nphi):
+    """Encode one-based three-dimensional indices as a linear index."""
+    return i + (j - 1) * nr + (k - 1) * nr * nphi
+
+
+def float32(value):
+    """Round a Python number to the default Fortran REAL representation."""
+    return struct.unpack("f", struct.pack("f", value))[0]
+
+
+def decode_k_with_real(index, nr, nphi):
+    """Reproduce the former CEILING(REAL(...)/REAL(...)) expression."""
+    quotient = float32(float32(index) / float32(nr * nphi))
+    return math.ceil(quotient)
+
+
+class TestLinearTo3DIndexing(unittest.TestCase):
+    def test_integer_decode_round_trips_across_float32_limit(self):
+        nr = 384
+        nphi = 192
+        first = FLOAT32_LIMIT - 4096
+        last = FLOAT32_LIMIT + 65536
+
+        for index in range(first, last + 1):
+            decoded = decode_integer(index, nr, nphi)
+            self.assertEqual(encode(*decoded, nr, nphi), index)
+
+    def test_previous_real_decode_loses_an_index(self):
+        nr = 384
+        nphi = 192
+        index = 16809985
+
+        integer_k = decode_integer(index, nr, nphi)[2]
+        self.assertEqual(integer_k, 229)
+        self.assertEqual(decode_k_with_real(index, nr, nphi), 228)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/FIELDLINES/Sources/fieldlines_gridgen.f90
+++ b/FIELDLINES/Sources/fieldlines_gridgen.f90
@@ -220,8 +220,7 @@
          ! Now find missing points
          DO l = 1, nr*nz
             i = MOD(l-1,nr)+1
-            k = MOD(l-1,nr*nz)
-            k = FLOOR(REAL(k) / REAL(nr))+1
+            k = MOD(l-1,nr*nz)/nr+1
             i = MAX(MIN(i,nr-1),2)
             k = MAX(MIN(k,nz-1),2)
             j = 1

--- a/FIELDLINES/Sources/fieldlines_init_I.f90
+++ b/FIELDLINES/Sources/fieldlines_init_I.f90
@@ -137,9 +137,8 @@
       ! Put the field on the grid
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          xp  = raxis_g(i)*cos(phiaxis(j))
          yp  = raxis_g(i)*sin(phiaxis(j))
          zp  = zaxis_g(k)

--- a/FIELDLINES/Sources/fieldlines_init_coil.f90
+++ b/FIELDLINES/Sources/fieldlines_init_coil.f90
@@ -108,9 +108,8 @@
       IF (lafield_only) THEN
          DO s = mystart, myend
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             br = 0.; bphi = 0.; bz = 0.
             br_temp   = 0.0;
             bphi_temp = 0.0;
@@ -134,9 +133,8 @@
       ELSE
          DO s = mystart, myend
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             br = 0.; bphi = 0.; bz = 0.
             br_temp   = 0.0;
             bphi_temp = 0.0;

--- a/FIELDLINES/Sources/fieldlines_init_eqdsk.f90
+++ b/FIELDLINES/Sources/fieldlines_init_eqdsk.f90
@@ -152,8 +152,7 @@
 #endif
         DO s = mystart, myend
             i = MOD(s-1,nr)+1
-            k = MOD(s-1,nr*nz)
-            k = FLOOR(REAL(k) / REAL(nr))+1
+            k = MOD(s-1,nr*nz)/nr+1
             sflx = 0.0
 
             ! Bfield

--- a/FIELDLINES/Sources/fieldlines_init_errorfield.f90
+++ b/FIELDLINES/Sources/fieldlines_init_errorfield.f90
@@ -62,9 +62,8 @@
       ! Here's the logic the index defines n
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          DO ig = 1, 20
             B_R(i,j,k) = B_R(i,j,k) + errorfield_amp(ig)*COS(ig*phiaxis(j)-errorfield_phase(ig))
             B_PHI(i,j,k) = B_PHI(i,j,k) - errorfield_amp(ig)*SIN(ig*phiaxis(j)-errorfield_phase(ig))/ig

--- a/FIELDLINES/Sources/fieldlines_init_hint.f90
+++ b/FIELDLINES/Sources/fieldlines_init_hint.f90
@@ -78,9 +78,8 @@
       ELSE
          DO s = mystart, myend
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
 
             ! Bfield
             CALL get_hint_gridB(i,j,k,br,bphi,bz)

--- a/FIELDLINES/Sources/fieldlines_init_mgrid.f90
+++ b/FIELDLINES/Sources/fieldlines_init_mgrid.f90
@@ -107,9 +107,8 @@
       ELSE
          DO s = mystart, myend
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j, rprec) / REAL(nr, rprec)) + 1
-            k = CEILING(REAL(s, rprec) / REAL(nr*nphi, rprec))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             CALL mgrid_bcyl(raxis(i), phiaxis(j), zaxis(k), &
                             br, bphi, bz, ier)
             IF (ier /= 0) stop 'mgrid_bcyl error!'

--- a/FIELDLINES/Sources/fieldlines_init_mumat.f90
+++ b/FIELDLINES/Sources/fieldlines_init_mumat.f90
@@ -166,18 +166,16 @@
       IF (lissubmaster) THEN
          DO s = 1, ourstart-1
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             B_R(i,j,k)   = 0.0
             B_PHI(i,j,k) = 0.0
             B_Z(i,j,k)   = 0.0
          END DO
          DO s = ourend+1, nr*nphi*nz
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             B_R(i,j,k)   = 0.0
             B_PHI(i,j,k) = 0.0
             B_Z(i,j,k)   = 0.0
@@ -198,9 +196,8 @@
       ! Get the fields
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
-         j = MOD(s-1,nr*nphi)
-         j = FLOOR(REAL(j) / REAL(nr))+1
-         k = CEILING(REAL(s) / REAL(nr*nphi))
+         j = MOD(s-1,nr*nphi)/nr+1
+         k = (s-1)/(nr*nphi)+1
          br_temp   = 0
          bphi_temp = 0
          bz_temp   = 0

--- a/FIELDLINES/Sources/fieldlines_init_nescoil.f90
+++ b/FIELDLINES/Sources/fieldlines_init_nescoil.f90
@@ -66,9 +66,8 @@
       ELSE
          DO s = mystart, myend
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             x = raxis_g(i)*COS(phiaxis(j))
             y = raxis_g(i)*SIN(phiaxis(j))
             z = zaxis_g(k)

--- a/FIELDLINES/Sources/fieldlines_init_vmec.f90
+++ b/FIELDLINES/Sources/fieldlines_init_vmec.f90
@@ -260,9 +260,8 @@
       IF (lafield_only) THEN
          DO s = mystart, myend
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             sflx = 0.0
             CALL GetAcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                          br, bphi, bz, SFLX=sflx,info=ier)
@@ -303,9 +302,8 @@
       ELSE
          DO s = mystart, myend
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             sflx = 0.0
             ! The GetBcyl Routine returns -3 if cyl2flx thinks s>1
             ! however, if cyl2flx fails to converge then s may be

--- a/LIBSTELL/Sources/Modules/wall_mod.f90
+++ b/LIBSTELL/Sources/Modules/wall_mod.f90
@@ -1535,9 +1535,8 @@
 
          DO i = 1, wall%nblocks
             zi = MOD(i-1,nblocks(3))+1
-            yi = MOD(i-1,nblocks(2)*nblocks(3))
-            yi = FLOOR(REAL(yi) / REAL(nblocks(3)))+1
-            xi = CEILING(REAL(i) / REAL(nblocks(2)*nblocks(3)))
+            yi = MOD(i-1,nblocks(2)*nblocks(3))/nblocks(3)+1
+            xi = (i-1)/(nblocks(2)*nblocks(3))+1
             wall%blocks(i)%rmin(1) = xs(xi)
             wall%blocks(i)%rmin(2) = ys(yi)
             wall%blocks(i)%rmin(3) = zs(zi)

--- a/STELLOPTV2/Sources/General/stellopt_compute_bnormal.f90
+++ b/STELLOPTV2/Sources/General/stellopt_compute_bnormal.f90
@@ -142,8 +142,7 @@
       CALL MPI_CALC_MYRANGE(MPI_COMM_MYWORLD, 1, nuv, mystart, myend)
       DO uv = mystart, myend
          u = MOD(uv-1,nu)+1
-         v = MOD(uv-1,nuv)
-         v = FLOOR(REAL(v) / REAL(nu))+1
+         v = MOD(uv-1,nuv)/nu+1
          theta = pi2*DBLE(u-1)/DBLE(nu)
          phi = zeta(v)/nfp
          RU = 0.0; ZU = 0.0; RV = 0.0; ZV = 0.0
@@ -281,8 +280,7 @@
          WRITE(iunit,'(I8)') nuv
          DO uv = 1, nuv
             u = MOD(uv-1,nu)+1
-            v = MOD(uv-1,nuv)
-            v = FLOOR(REAL(v) / REAL(nu))+1
+            v = MOD(uv-1,nuv)/nu+1
             theta = pi2*DBLE(u-1)/DBLE(nu)
             phi = zeta(v)/nfp
             WRITE(iunit, '(3(1X,I6),11(1pe24.16))') &

--- a/STELLOPTV2/Sources/General/stellopt_write_mgrid.f90
+++ b/STELLOPTV2/Sources/General/stellopt_write_mgrid.f90
@@ -201,15 +201,10 @@
       ! Now loop over coil Groups
       DO ig = 1, nextcur
          DO s = mystart, myend
-            !i = MOD(s-1,nr)+1
-            !j = MOD(s-1,nr*nphi)
-            !j = FLOOR(REAL(j) / REAL(nr))+1
-            !k = CEILING(REAL(s) / REAL(nr*nphi))
-            ! Changed from nr,nphi,nz to nr,nz,nphi ordering
+            ! Ordering nr,nz,nphi
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nz)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nz))
+            j = MOD(s-1,nr*nz)/nr+1
+            k = (s-1)/(nr*nz)+1
             r = rmin + dr*(i-1)
             z = zmin + dz*(j-1)
             phi = dphi*(k-1)

--- a/TORLINES/Sources/torlines_init_external.f90
+++ b/TORLINES/Sources/torlines_init_external.f90
@@ -131,10 +131,9 @@
       IF (ierr_mpi /=0) CALL handle_err(MPI_BARRIER_ERR,'fieldlines_init',ierr_mpi)
 #endif
          DO i = mystart, myend
-            s = MOD(i-1,nrho) + 1
-            u = MOD(i-1,nrho*nu)
-            u = FLOOR(REAL(u) / REAL(nrho))+1
-            v = CEILING(REAL(i) / REAL(nrho*nu))
+            s = MOD(i-1,nrho)+1
+            u = MOD(i-1,nrho*nu)/nrho+1
+            v = (i-1)/(nrrho*nu)+1
             IF (s < s1) CYCLE
             !u = MOD(s,k)
             !IF (u < s1 .and. u /= 0) CYCLE
@@ -188,10 +187,9 @@
             CALL FLUSH(6)
          END IF
          DO i = mystart, myend
-            s = MOD(i-1,nrho) + 1
-            u = MOD(i-1,nrho*nu)
-            u = FLOOR(REAL(u) / REAL(nrho))+1
-            v = CEILING(REAL(i) / REAL(nrho*nu))
+            s = MOD(i-1,nrho)+1
+            u = MOD(i-1,nrho*nu)/nrho+1
+            v = (i-1)/(nrrho*nu)+1
             IF (s < s1) CYCLE
             br = 0; bphi = 0; bz = 0
             r = rreal(s,u,v)
@@ -222,10 +220,9 @@
             CALL FLUSH(6)
          END IF
          DO i = mystart, myend
-            s = MOD(i-1,nrho) + 1
-            u = MOD(i-1,nrho*nu)
-            u = FLOOR(REAL(u) / REAL(nrho))+1
-            v = CEILING(REAL(i) / REAL(nrho*nu))
+            s = MOD(i-1,nrho)+1
+            u = MOD(i-1,nrho*nu)/nrho+1
+            v = (i-1)/(nrrho*nu)+1
             IF (s < s1) CYCLE
             phi = pi2*xv(v)/nfp
             x_vc = rreal(s,u,v)*cos(phi)

--- a/TORLINES/Sources/torlines_init_external.f90
+++ b/TORLINES/Sources/torlines_init_external.f90
@@ -133,7 +133,7 @@
          DO i = mystart, myend
             s = MOD(i-1,nrho)+1
             u = MOD(i-1,nrho*nu)/nrho+1
-            v = (i-1)/(nrrho*nu)+1
+            v = (i-1)/(nrho*nu)+1
             IF (s < s1) CYCLE
             !u = MOD(s,k)
             !IF (u < s1 .and. u /= 0) CYCLE
@@ -189,7 +189,7 @@
          DO i = mystart, myend
             s = MOD(i-1,nrho)+1
             u = MOD(i-1,nrho*nu)/nrho+1
-            v = (i-1)/(nrrho*nu)+1
+            v = (i-1)/(nrho*nu)+1
             IF (s < s1) CYCLE
             br = 0; bphi = 0; bz = 0
             r = rreal(s,u,v)
@@ -222,7 +222,7 @@
          DO i = mystart, myend
             s = MOD(i-1,nrho)+1
             u = MOD(i-1,nrho*nu)/nrho+1
-            v = (i-1)/(nrrho*nu)+1
+            v = (i-1)/(nrho*nu)+1
             IF (s < s1) CYCLE
             phi = pi2*xv(v)/nfp
             x_vc = rreal(s,u,v)*cos(phi)


### PR DESCRIPTION
This pull request improve the logic of the linear to 3D indexing we do.  In the previous version we had
```fortran
i = MOD(s-1,nr)+1
j = MOD(s-1,nr*nphi)
j = FLOOR(REAL(j) / REAL(nr))+1
k = CEILING(REAL(s) / REAL(nr*nphi))
```
which is now changed to the following per the testing of @krystophny 
```fortran
i = MOD(s-1,nr)+1
j = MOD(s-1,nr*nphi)/nr+1
k = (s-1)/(nr*nphi)+1
```
Both the regression tests for BEAMS3D and FIELDLINES pass with this change.  There may be similar improvements elsewhere in the code but I did not find them (maybe in STELLOPT somehwere). @krystophny has exenstively tested this and shown that the change fixes issues with large grids. @luisahuebner and @lvanham can you confirm that this change does not affect the current status of your results?
