### PR TITLE
BEAMS3D: restore #478's deterministic seed and #482's integer indexing

### DIFF
--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -330,7 +330,8 @@
          i = MOD(s-1,nr)+1
          j = MOD(s-1,nr*nphi)/nr+1
          k = (s-1)/(nr*nphi)+1
-         sflx = MAX(0.001,MIN(0.999,sflx))
+         sflx = 0.001
+         uflx = 0.0
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                       br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
          !PRINT *,i,j,k,raxis_g(i),phiaxis(j),zaxis_g(k), br, bphi, bz, sflx,uflx,ier
@@ -399,9 +400,8 @@
          ifailed = 0
          DO s = mystart, myend
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             IF ((i==1) .or. (i==nr) .or. (k==1) .or. (k==nz)) CYCLE
             IF (S_ARR(i,j,k) >= 0.0) CYCLE
             ifailed = ifailed + 1
@@ -441,9 +441,8 @@
             IF (.not. retry_success(ifailed)) CYCLE
             s = failed_index(ifailed)
             i = MOD(s-1,nr)+1
-            j = MOD(s-1,nr*nphi)
-            j = FLOOR(REAL(j) / REAL(nr))+1
-            k = CEILING(REAL(s) / REAL(nr*nphi))
+            j = MOD(s-1,nr*nphi)/nr+1
+            k = (s-1)/(nr*nphi)+1
             S_ARR(i,j,k) = retry_s(ifailed)
             U_ARR(i,j,k) = retry_u(ifailed)
             B_R(i,j,k) = retry_br(ifailed)

--- a/BEAMS3D/Sources/beams3d_init_vmec.f90
+++ b/BEAMS3D/Sources/beams3d_init_vmec.f90
@@ -326,12 +326,12 @@
          WRITE(6,'(5X,A,I3.3,A)',ADVANCE='no') 'Plasma Field Lookup [',0,']%'
       END IF
       CALL FLUSH(6)
+      sflx = 0.001
+      uflx = 0.0
       DO s = mystart, myend
          i = MOD(s-1,nr)+1
          j = MOD(s-1,nr*nphi)/nr+1
          k = (s-1)/(nr*nphi)+1
-         sflx = 0.001
-         uflx = 0.0
          CALL GetBcyl(raxis_g(i),phiaxis(j),zaxis_g(k),&
                       br, bphi, bz, SFLX=sflx,UFLX=uflx,info=ier)
          !PRINT *,i,j,k,raxis_g(i),phiaxis(j),zaxis_g(k), br, bphi, bz, sflx,uflx,ier
@@ -357,6 +357,8 @@
             END IF
          ELSE IF (ier == -1) THEN
             S_ARR(i,j,k) = -1
+            sflx = 0.001
+            uflx = 0.0
          END IF
          IF (MOD(s,nr) == 0) THEN
             IF (lverb) THEN


### PR DESCRIPTION
Two changes were lost when #478 was merged. Both are in
`BEAMS3D/Sources/beams3d_init_vmec.f90`, and neither is a revert of anything
that was reviewed — they are merge fallout. This restores them.

I introduced the first one myself, in `98d9b1dc` (`Merge branch 'develop' into
fix/beams3d-deterministic-vmec-grid`), so this is my mistake to fix.

### 1. The deterministic seed is gone (uninitialised read)

#478's description says "each inverse lookup now starts from an explicit axis
seed", and the reviewed branch did exactly that:

```fortran
sflx = 0.001
uflx = 0.0
```

`develop` today reads:

```fortran
sflx = MAX(0.001,MIN(0.999,sflx))
```

That is the pre-#478 line, restored by the merge. `75620ccd` ("Improved linear
to 3D indexing math") had rewritten the three index lines directly above it, so
the hunks overlapped and the conflict resolution took `develop`'s side.

Two consequences:

* `sflx` and `uflx` are carried over from the previous grid point, so the seed
  each lookup starts from depends on where the rank's `mystart..myend` range
  begins. That is precisely the MPI-decomposition dependence #478 set out to
  remove.
* On the first iteration of the loop, `sflx` is read **uninitialised**. It is a
  plain local declared at line 51 and never assigned before line 333 — the
  `MAX`/`MIN` clamp bounds it into `[0.001, 0.999]` but does not define it.

`FIELDLINES/Sources/fieldlines_init_vmec.f90` kept the cold start (lines
268/269 and 312/313); only BEAMS3D lost it.

### 2. #482's integer indexing is undone in the two retry loops

#478's retry block was written before #482 landed, and the merge kept it
verbatim, so `develop` has the floating-point form back at lines 403-404 and
445-446:

```fortran
j = MOD(s-1,nr*nphi)
j = FLOOR(REAL(j) / REAL(nr))+1
k = CEILING(REAL(s) / REAL(nr*nphi))
```

Per the review on #482, this loses integer resolution just above
2^24 = 16777216, and for large grids `nr*nphi` alone crosses the threshold and
corrupts `j`. #482 fixed four sites; #478 reintroduced two of them. 256x256x256
sits exactly on the threshold, so this is reachable rather than theoretical.

The second site is the commit loop, where a corrupted `j`/`k` writes
`retry_s`/`retry_u`/`retry_br`/`retry_bphi`/`retry_bz` into the wrong cell —
a silent wrong answer, not a crash.

Both sites are converted to the integer form #482 settled on, which satisfies
`i + (j-1)*nr + (k-1)*nr*nphi == s` at every point.

### Measured

`BENCHMARKS/BEAMS3D_TEST` ORBITS, `-vmec ORBITS -plasma`, same binary and same
inputs, only the rank count changed. Comparison is
`BENCHMARKS/compare_beams3d_mpi_grid.py`, which shipped with #478.

Before (29ddc799), `-np 2` against `-np 3`:

```
default-mask changes: 0
S_ARR:   changed=70    max_abs=2.06403927283105304e-09
U_ARR:   changed=57    max_abs=3.55339069280091735e-09
B_R:     changed=69    max_abs=4.47757053656516746e-10
B_PHI:   changed=50    max_abs=2.71745381752452886e-09
B_Z:     changed=70    max_abs=1.02673206048287113e-09
S_lines: changed=8468  max_abs=1.67910373469470908e-05
B_lines: changed=8467  max_abs=1.96315073020869590e-04
```

After, same two rank counts: `changed=0` and `max_abs=0.0` on all seven
datasets, mask unchanged.

The 1e-9 seeding differences on the background grid amplify into 1.7e-5 in
`S_lines` and 2.0e-4 in `B_lines` along the followed orbits, so this is visible
in results, not only in the grid.

Two honest caveats. The default mask is unaffected in both cases — no cell
changes its inside/outside classification, so the failure mode is a small
perturbation rather than a lost region. And repeating `-np 2` twice on the
unpatched build gives bit-identical output, so on this compiler the
uninitialised first-iteration read happens to be reproducible; what the test
above demonstrates is the carry-over dependence on the decomposition, which is
the part that actually varies in practice.

### Scope

Four lines. No change to the VMEC mapping, the retry selection order, the
shared-memory barrier, the outside/default treatment of failed cells, units or
conventions. `FIELDLINES` is untouched — it is already correct on both counts.