### PR TITLE
THRIFT: Fixed missing MPI_COMM_MYWORLD to allow free boundary in THRIFT.

### DIFF
--- a/THRIFT/Sources/thrift_reinit_vmec.f90
+++ b/THRIFT/Sources/thrift_reinit_vmec.f90
@@ -51,7 +51,7 @@
       ier_flag_init = 0
 !     Adjust vaccum grid file
       IF (lfreeb) THEN
-         CALL free_mgrid(iflag)
+         CALL free_mgrid(iflag,MPI_COMM_MYWORLD)
          mgrid_path_old = " "
          CALL read_mgrid(mgrid_file,extcur,nzeta,nfp,.false.,iflag,MPI_COMM_MYWORLD)
       END IF


### PR DESCRIPTION
This small changes allows free boundary VMEC equilibria to sucesssfully run in THRIFT. It does not however, guaruntee that the model is fully correct. Specifically, THRIFT does not evolve the toroidal flux self-consistently yet.