### PR TITLE
Fix the mode index of bmns in the NEO boozmn reader

### DIFF
--- a/NEO/Sources/read_booz_in.f90
+++ b/NEO/Sources/read_booz_in.f90
@@ -140,7 +140,7 @@ subroutine read_booz_in
               rmns(i,k) = rmns_b(j,i_surf)
               zmnc(i,k) = zmnc_b(j,i_surf)
               lmnc(i,k) = -pmnc_b(j,i_surf)*nfp_b/twopi
-              bmns(i,i) = bmns_b(j,i_surf)
+              bmns(i,k) = bmns_b(j,i_surf)
               if (ixm_b(j).eq.0 .and. ixn_b(j).eq.0)            &
                sqrtg00(i) = gmnc_b(j,i_surf) + gmns_b(j,i_surf)
            end if


### PR DESCRIPTION
In `READ_BOOZ_IN` (`NEO/Sources/read_booz_in.f90`), `i` indexes the flux surface and `k` counts the retained Boozer modes:

```fortran
rmns(i,k) = rmns_b(j,i_surf)
zmnc(i,k) = zmnc_b(j,i_surf)
lmnc(i,k) = -pmnc_b(j,i_surf)*nfp_b/twopi
bmns(i,i) = bmns_b(j,i_surf)   ! should be bmns(i,k)
```

So `bmns` keeps only one element per surface instead of the mode row, and writes out of bounds whenever the number of surfaces exceeds the number of retained modes. A LASYM run therefore loses the asymmetric |B| spectrum, which is what sets the ripple, and standalone `xneo` gives an effective ripple computed on an essentially symmetrized field.

The three neighbouring assignments in the same block use `(i,k)`, and so does the equivalent line in `STELLOPTV2/Sources/General/stellopt_neo.f90`, which reads the same arrays in memory and is unaffected — only the standalone reader has the typo.

Found while validating a JAX reimplementation of NEO against `xneo` on asymmetric equilibria.